### PR TITLE
removed problem for compiling c file in visual studio

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -42,7 +42,7 @@ src_SRC = \
 	../src/output.cpp ../src/params.cpp ../src/params_dump.cpp \
 	../src/sequencing.cpp ../src/stream_functions.cpp ../src/telxcc.cpp \
 	../src/timing.cpp ../src/ts_functions.cpp ../src/utility.cpp \
-	../src/wtv_functions.cpp ../src/xds.cpp ../src/dvb_subtitle_decoder.cpp \
+	../src/wtv_functions.cpp ../src/xds.cpp ../src/dvb_subtitle_decoder.c \
 	../src/ts_tables.cpp
 
 gpacmp4_SRC = \

--- a/src/dvb_subtitle_decoder.c
+++ b/src/dvb_subtitle_decoder.c
@@ -23,15 +23,14 @@
 #include <errno.h>
 /* convert values between host and network byte order(big endian) */
 #ifdef _WIN32
-#include <winsock2.h> 
+#include <winsock2.h>
 #else
-#include <arpa/inet.h> 
+#include <arpa/inet.h>
 #endif
 
 #ifdef _MSC_VER
 #define snprintf(str,size,format,...) _snprintf(str,size-1,format,__VA_ARGS__)
 #endif
-
 
 #include "dvb_subtitle_decoder.h"
 #define DEBUG
@@ -1559,7 +1558,7 @@ static int dvbsub_display_end_segment(void *dvb_ctx, const uint8_t *buf,
  */
 int dvbsub_decode(void *dvb_ctx,
                          void *data, int *data_size,
-                         const unsigned char *buf, int buf_size)
+                         const unsigned char *buf,int buf_size)
 {
     DVBSubContext *ctx = (DVBSubContext *)dvb_ctx;
 //    AVSubtitle *sub = data;

--- a/src/dvb_subtitle_decoder.h
+++ b/src/dvb_subtitle_decoder.h
@@ -18,6 +18,10 @@
 
 #define MAX_LANGUAGE_PER_DESC 5
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
 struct dvb_config
 {
@@ -59,7 +63,7 @@ int dvbsub_close_decoder(void *dvb_ctx);
  */
 int dvbsub_decode(void *dvb_ctx,
                          void *data, int *data_size,
-                         const unsigned char *buf,int buf_size);
+                        const unsigned char *buf,int buf_size);
 /**
  * @func parse_dvb_description
  *
@@ -71,4 +75,8 @@ int dvbsub_decode(void *dvb_ctx,
  * errno is set is to EINVAL if invalid data is found
  */
 int  parse_dvb_description (struct dvb_config* cfg,unsigned char*data,unsigned int len);
+
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/src/ts_tables.cpp
+++ b/src/ts_tables.cpp
@@ -200,9 +200,6 @@ int parse_PMT (int pos)
 		unsigned ES_info_length = (((payload_start[i+3] & 0x0F) << 8)
                                    | payload_start[i+4]);
 
-		/* There is no information about elementry stream */
-		/*if(!ES_info_length)
-			continue; */
 
 		if (ccx_options.ts_cappid==0 && ccx_stream_type==ccx_options.ts_datastreamtype) // Found a stream with the type the user wants
 		{
@@ -210,7 +207,10 @@ int parse_PMT (int pos)
 			ccx_options.ts_cappid = newcappid = elementary_PID;
 			cap_stream_type=CCX_STREAM_TYPE_UNKNOWNSTREAM;
 		}
-		if(IS_FEASIBLE(ccx_options.codec,ccx_options.nocodec,CCX_CODEC_DVB) && !ccx_options.ts_cappid && ccx_stream_type == CCX_STREAM_TYPE_PRIVATE_MPEG2)
+		if(IS_FEASIBLE(ccx_options.codec,ccx_options.nocodec,CCX_CODEC_DVB) &&
+			ES_info_length &&
+			!ccx_options.ts_cappid &&
+			ccx_stream_type == CCX_STREAM_TYPE_PRIVATE_MPEG2)
 		{
 			unsigned char *es_info = payload_start + i + 5;
 			for (desc_len = 0;(payload_start + i + 5 + ES_info_length) - es_info ;es_info += desc_len)
@@ -234,7 +234,8 @@ int parse_PMT (int pos)
 		}
 
 
-		if (IS_FEASIBLE(ccx_options.codec,ccx_options.nocodec,CCX_CODEC_TELETEXT) && (ccx_options.teletext_mode==CCX_TXT_AUTO_NOT_YET_FOUND ||
+		if (IS_FEASIBLE(ccx_options.codec,ccx_options.nocodec,CCX_CODEC_TELETEXT) &&
+			ES_info_length	&& (ccx_options.teletext_mode==CCX_TXT_AUTO_NOT_YET_FOUND ||
 			(ccx_options.teletext_mode==CCX_TXT_IN_USE && !ccx_options.ts_cappid)) // Want teletext but don't know the PID yet
 			&& ccx_stream_type == CCX_STREAM_TYPE_PRIVATE_MPEG2) // MPEG-2 Packetized Elementary Stream packets containing private data
 		{
@@ -253,7 +254,7 @@ int parse_PMT (int pos)
 					elementary_PID, elementary_PID, program_number, program_number);
 			}
 		}
-		if (ccx_options.teletext_mode==CCX_TXT_FORBIDDEN && 
+		if (ccx_options.teletext_mode==CCX_TXT_FORBIDDEN && ES_info_length  &&
 			ccx_stream_type == CCX_STREAM_TYPE_PRIVATE_MPEG2) // MPEG-2 Packetized Elementary Stream packets containing private data
 		{
 			unsigned descriptor_tag = payload_start[i + 5];


### PR DESCRIPTION
previously we changed c to cpp extension, since code did not compile using visual studio, i looked why we cant compile c files with cpp, it is because function name are changed before calling in cpp,  if we define in header file that functions are c not cpp. then it work.
