### PR TITLE
moved up enum mode in 608.h

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -5,7 +5,7 @@ CXX = g++
 
 CFLAGS = -O3 -std=gnu99
 INCLUDE = -I../src/gpacmp4/ -I../src/libpng -I../src/zlib
-ALL_FLAGS = -Wno-write-strings -DGPAC_CONFIG_LINUX -D_FILE_OFFSET_BITS=64 
+ALL_FLAGS =-Wall -Wno-write-strings -DGPAC_CONFIG_LINUX -D_FILE_OFFSET_BITS=64 
 LDFLAGS = -lm -zmuldefs
 
 TARGET = ccextractor

--- a/src/platform.h
+++ b/src/platform.h
@@ -66,17 +66,11 @@ extern "C" __int64 __cdecl _ftelli64(FILE *);
 #define LSEEK _lseeki64
 typedef struct _stati64 FSTATSTRUCT;
 #else
-#ifdef __CYGWIN__
-// Cygwin internally maps these functions to 64bit usage, but there are
-// no explicit xxxx64 functions.
+// Linux internally maps these functions to 64bit usage, 
+// if _FILE_OFFSET_BITS macro is set to 64 
 #define FOPEN64 fopen
 #define OPEN open
 #define LSEEK lseek
-#else
-#define FOPEN64 fopen64
-#define OPEN open64
-#define LSEEK lseek64
-#endif
 #define FSEEK fseek
 #define FTELL ftell
 #define FSTAT fstat


### PR DESCRIPTION
since struct s_context_cc608 using enum cc_mode, code was not able to compile on gnu linux.
so moved up enum cc_mode, so that compiler know what cc_mode is.

also added macro according lseek64 manual, this was required
