### PR TITLE
lseek64 is not required by linux

### DIFF
--- a/src/platform.h
+++ b/src/platform.h
@@ -66,17 +66,11 @@ extern "C" __int64 __cdecl _ftelli64(FILE *);
 #define LSEEK _lseeki64
 typedef struct _stati64 FSTATSTRUCT;
 #else
-#ifdef __CYGWIN__
-// Cygwin internally maps these functions to 64bit usage, but there are
-// no explicit xxxx64 functions.
+// Linux internally maps these functions to 64bit usage, 
+// if _FILE_OFFSET_BITS macro is set to 64 
 #define FOPEN64 fopen
 #define OPEN open
 #define LSEEK lseek
-#else
-#define FOPEN64 fopen64
-#define OPEN open64
-#define LSEEK lseek64
-#endif
 #define FSEEK fseek
 #define FTELL ftell
 #define FSTAT fstat


### PR DESCRIPTION
I have tested this on 64 bit linux system with following uname info
 3.2.0-29-generic Ubuntu SMP Fri Jul 27 17:03:23 UTC 2012 x86_64 x86_64 x86_64 GNU/Linux

32 bit system have following uname - a info
Linux daku_daddy 3.7.10-1.32-pae SMP Thu May 8 00:09:34 UTC 2014 (5978d00) i686 i686 i386 GNU/Linux

I have not tested on windows since i have not touched the windows macro part. so i assume my commit  should not interfere with windows.

this patch compel code to use lseek instead of lseek64, since according to manual its done internally.
