### PR TITLE
remove cursor reset

### DIFF
--- a/src/608.h
+++ b/src/608.h
@@ -43,6 +43,7 @@ struct s_context_cc608
 	int my_field; // Used for sanity checks
 	long bytes_processed_608; // To be written ONLY by process_608
 	struct ccx_s_write *out;
+	int is_pac_received;
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
Leaving just "context->cursor_row = context->rollup_base_row;" at 830 makes no sense. Suppose there was PAC before the RU. Then cursor_row wouldn't change after this line. If there wasn't PAC, then line 838 would set cursor_row.
