### PR TITLE
Binary search for dictionary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ CVS
 linux/ccextractor
 linux/depend
 windows/debug/*
+*.sdf
+*.suo

--- a/src/params.c
+++ b/src/params.c
@@ -1,4 +1,5 @@
 #include "ccextractor.h"
+#include "utility.h"
 
 static int inputfile_capacity=0; 
 static int spell_builtin_added=0; // so we don't do it twice
@@ -158,7 +159,6 @@ int process_cap_file (char *filename)
     fclose (fi);
     return 0;
 }
-
 int isanumber (char *s)
 {
     while (*s)
@@ -1058,6 +1058,8 @@ void parse_parameters (int argc, char *argv[])
             if (add_built_in_words())
                 fatal (EXIT_NOT_ENOUGH_MEMORY, "Not enough memory for word list");
             ccx_options.sentence_cap=1;
+			shell_sort(spell_lower,spell_words,sizeof(*spell_lower),string_cmp2,NULL);
+			shell_sort(spell_correct,spell_words,sizeof(*spell_correct),string_cmp2,NULL);
 			continue;
         }
         if ((strcmp (argv[i],"--capfile")==0 ||
@@ -1071,6 +1073,8 @@ void parse_parameters (int argc, char *argv[])
             ccx_options.sentence_cap=1;
             ccx_options.sentence_cap_file=argv[i+1];
             i++;
+			shell_sort(spell_lower,spell_words,sizeof(*spell_lower),string_cmp2,NULL);
+			shell_sort(spell_correct,spell_words,sizeof(*spell_correct),string_cmp2,NULL);
 			continue;
         }
         if (strcmp (argv[i],"--program-number")==0 ||

--- a/src/utility.c
+++ b/src/utility.c
@@ -1,5 +1,9 @@
 #include "ccextractor.h"
 
+#ifdef _MSC_VER
+#define strcasecmp stricmp
+#endif
+
 static char *text;
 static int text_size=0;
 
@@ -295,4 +299,40 @@ int hex2int (char high, char low)
 	else 
 		return -1;
 	return h*16+l;
+}
+/**
+ * @param base points to the start of the array
+ * @param nb   number of element in array
+ * @param size size of each element
+ * @param compar Comparison function, which is called with three argument
+ *               that point to the objects being compared and arg.
+ * @param arg argument passed as it is to compare function
+ */
+void shell_sort(void *base, int nb,size_t size,int (*compar)(const void*p1,const void *p2,void*arg),void *arg)
+{
+	unsigned char *lbase = (unsigned char*)base;
+	unsigned char *tmp = (unsigned char*)malloc(size);
+	for (int gap = nb / 2; gap > 0; gap = gap / 2)
+	{
+		int p, j;
+		for (p = gap; p < nb; p++)
+		{
+			memcpy(tmp, lbase + (p *size), size);
+			for (j = p; j >= gap && ( compar(tmp,lbase + ( (j - gap) * size),arg) < 0); j -= gap)
+			{
+				memcpy(lbase + (j*size),lbase + ( (j - gap) * size),size);
+			}
+			memcpy(lbase + (j *size),tmp, size);
+		}
+	}
+    free(tmp);
+}
+
+int string_cmp2(const void *p1,const void *p2,void *arg)
+{
+	return strcasecmp(*(char**)p1,*(char**)p2);
+}
+int string_cmp(const void *p1,const void *p2)
+{
+	return string_cmp2(p1, p2, NULL);
 }

--- a/src/utility.h
+++ b/src/utility.h
@@ -10,5 +10,8 @@
 #define RL16(x) (*(unsigned short int*)(x))
 #define RB16(x) (ntohs(*(unsigned short int*)(x)))
 
+void shell_sort(void *base, int nb,size_t size,int (*compar)(const void*p1,const void *p2,void*arg),void *arg);
+int string_cmp(const void *p1,const void *p2);
+int string_cmp2(const void *p1,const void *p2,void *arg);
 
 #endif


### PR DESCRIPTION
1) Ignored Binary file *.sdf *.suo, since they are automatically created by visual studio.
2) had to rewrite correct_case function minor tweaks were not possible.
3) Using Shell short since I found it to be least time complexity O(n ^ 4/3) for our case and it has better performance then quick sort in terms of time complexity. for detail http://www.sorting-algorithms.com/

4)I have reused shell_sort from quantization logic in dvb_subtile so had to remove some dependency in dvb_subtitle
5) removed ISSEPARATOR, since it was used nowhere other then correct_case
6) tested on windows and linux using the.tudors.208-ALANiS.ts
