### PR TITLE
increased 1 byte of cc_data according to spec

### DIFF
--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -394,7 +394,6 @@ int main(int argc, char *argv[])
 		}
 	}	
 
-	build_parity_table();
 
 	// Initialize HDTV caption buffer
 	init_hdcc();
@@ -442,8 +441,9 @@ int main(int argc, char *argv[])
 			{
 				int ret = 0;
 				char *bptr = ctx->buffer;
-				memset(bptr,0,1024);
 				int len = ff_get_ccframe(ffmpeg_ctx, bptr, 1024);
+                                int cc_count = 0;
+				memset(bptr,0,1024);
 				if(len == AVERROR(EAGAIN))
 				{
 					continue;
@@ -458,7 +458,9 @@ int main(int argc, char *argv[])
 					break;
 
 				}
-				store_hdcc(ctx, bptr,len, i++,fts_now,&dec_sub);
+                                else
+                                    cc_count = (len-2)/3;
+				store_hdcc(ctx, bptr, cc_count, i++,fts_now,&dec_sub);
 				if(dec_sub.got_output)
 				{
 					encode_sub(enc_ctx, &dec_sub);

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -533,7 +533,7 @@ void dinit_encoder(struct encoder_ctx *ctx)
 
 int encode_sub(struct encoder_ctx *context, struct cc_subtitle *sub)
 {
-	int wrote_something = 0 ;
+	int wrote_something = 0;
 
 	if (sub->type == CC_608)
 	{

--- a/src/lib_ccx/es_userdata.c
+++ b/src/lib_ccx/es_userdata.c
@@ -142,7 +142,7 @@ int user_data(struct lib_ccx_ctx *ctx, struct bitstream *ustream, int udtype, st
     {
         if ((ud_header[1]&0x7F) == 0x01)
         {
-            unsigned char cc_data[3*31+1]; // Maximum cc_count is 31
+            unsigned char cc_data[3*31+2]; // Maximum cc_count is 31
 
             ctx->stat_scte20ccheaders++;
             read_bytes(ustream, 2); // "03 01"

--- a/src/lib_ccx/lib_ccx.c
+++ b/src/lib_ccx/lib_ccx.c
@@ -84,5 +84,6 @@ struct lib_ccx_ctx* init_libraries(struct ccx_s_options *opt)
 	ctx->wbout2.filename = opt->wbout2.filename;
 
 
+	build_parity_table();
 	return ctx;
 }

--- a/src/lib_ccx/sequencing.c
+++ b/src/lib_ccx/sequencing.c
@@ -11,7 +11,7 @@ int cc_data_count[SORTBUF];
 // Store fts;
 static LLONG cc_fts[SORTBUF];
 // Store HD CC packets
-unsigned char cc_data_pkts[SORTBUF][10*31*3+1]; // *10, because MP4 seems to have different limits
+unsigned char cc_data_pkts[SORTBUF][10*31*3+2]; // *10, because MP4 seems to have different limits
 
 // Set to true if data is buffered
 int has_ccdata_buffered = 0;
@@ -29,7 +29,7 @@ void init_hdcc (void)
         cc_data_count[j] = 0;
         cc_fts[j] = 0;
     }
-    memset(cc_data_pkts, 0, SORTBUF*(31*3+1));
+    memset(cc_data_pkts, 0, SORTBUF*(31*3+2));
     has_ccdata_buffered = 0;
 }
 


### PR DESCRIPTION
According to CEA-708-D August 2008
cc_data() {
    reserved                   1 bit
    proccess_cc_data_flag      1 bit
    zero bit                   1 bit
    cc_count                   5 bit
    reserved                   8 bit
    for( i = 0; i < cc_count; i++) {
        one_bit_4_compatibility      1 bit
        reserved                     4 bit
        cc_valid                     1 bit
        cc_type                      2 bit
        cc_data_1                    8 bit
        cc_data_2                    8 bit
    }
}
