### PR TITLE
Output filename fix

### DIFF
--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -52,8 +52,8 @@ int main(int argc, char *argv[])
 	ccx_common_timing_init(&ctx->past,ccx_options.nosync);
 
 	// Prepare write structures
-	init_write(&ctx->wbout1);
-	init_write(&ctx->wbout2);
+	init_write(&ctx->wbout1,ccx_options.wbout1.filename);
+	init_write(&ctx->wbout2,ccx_options.wbout2.filename);
 	
 	// Prepare time structures
 	init_boundary_time (&ccx_options.extraction_start);

--- a/src/lib_ccx/output.c
+++ b/src/lib_ccx/output.c
@@ -7,11 +7,11 @@
 #endif
 
 
-void init_write (struct ccx_s_write *wb)
+void init_write (struct ccx_s_write *wb,char *filename)
 {
 	memset(wb, 0, sizeof(struct ccx_s_write));
     wb->fh=-1;
-    wb->filename=NULL;
+    wb->filename=filename;
 }
 
 void writeraw (const unsigned char *data, int length, struct ccx_s_write *wb)


### PR DESCRIPTION
The provided names in -o1 and -o2 were not passed on between argument
passing and initialisation of write structures, resulting in default
names.
