### PR TITLE
Fix for SegFault error in -out=raw/bin output format

### DIFF
--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -268,6 +268,7 @@ int main(int argc, char *argv[])
 				switch (ccx_options.write_format)
 				{
 				case CCX_OF_RAW:
+					init_encoder(enc_ctx, &ctx->wbout1);
 					writeraw(BROADCAST_HEADER, sizeof(BROADCAST_HEADER), &ctx->wbout1);
 					break;
 				case CCX_OF_DVDRAW:

--- a/src/lib_ccx/ccx_decoders_structs.h
+++ b/src/lib_ccx/ccx_decoders_structs.h
@@ -99,6 +99,7 @@ struct lib_cc_decode
 	enum ccx_output_format write_format; // 0=Raw, 1=srt, 2=SMI
 	struct ccx_boundary_time extraction_start, extraction_end; // Segment we actually process
 	void *wbout1;
+	void *wbout2;
 	LLONG subs_delay; // ms to delay (or advance) subs
 };
 

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -538,6 +538,7 @@ void general_loop(struct lib_ccx_ctx *ctx, void *enc_ctx)
 	struct cc_subtitle dec_sub;
 	struct lib_cc_decode *dec_ctx = NULL;
 	dec_ctx = ctx->dec_ctx;
+    dec_ctx->wbout1 = (struct ccx_s_write*)&ctx->wbout1 ; 
     inbuf = 0; // No data yet
 
     end_of_file = 0;

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -538,7 +538,8 @@ void general_loop(struct lib_ccx_ctx *ctx, void *enc_ctx)
 	struct cc_subtitle dec_sub;
 	struct lib_cc_decode *dec_ctx = NULL;
 	dec_ctx = ctx->dec_ctx;
-    dec_ctx->wbout1 = (struct ccx_s_write*)&ctx->wbout1 ; 
+    	dec_ctx->wbout1 = (struct ccx_s_write*)&ctx->wbout1 ; 
+	dec_ctx->wbout2 = (struct ccx_s_write*)&ctx->wbout2 ;
     inbuf = 0; // No data yet
 
     end_of_file = 0;

--- a/src/lib_ccx/output.c
+++ b/src/lib_ccx/output.c
@@ -110,6 +110,8 @@ void printdata (struct lib_cc_decode *ctx, const unsigned char *data1, int lengt
 	struct ccx_decoder_608_context *field_1 = ctx->context_cc608_field_1;
 	struct ccx_decoder_608_context *field_2 = ctx->context_cc608_field_2;
 	struct ccx_s_write *wbout1 = ctx->wbout1;
+    field_1->out = ctx->wbout1 ;
+    field_2->out = ctx->wbout1 ;
 	if (ctx->write_format==CCX_OF_DVDRAW)
 		writeDVDraw (data1, length1, data2, length2, wbout1);
 	else /* Broadcast raw or any non-raw */

--- a/src/lib_ccx/output.c
+++ b/src/lib_ccx/output.c
@@ -111,7 +111,7 @@ void printdata (struct lib_cc_decode *ctx, const unsigned char *data1, int lengt
 	struct ccx_decoder_608_context *field_2 = ctx->context_cc608_field_2;
 	struct ccx_s_write *wbout1 = ctx->wbout1;
     field_1->out = ctx->wbout1 ;
-    field_2->out = ctx->wbout1 ;
+    field_2->out = ctx->wbout2 ;
 	if (ctx->write_format==CCX_OF_DVDRAW)
 		writeDVDraw (data1, length1, data2, length2, wbout1);
 	else /* Broadcast raw or any non-raw */


### PR DESCRIPTION
This is the fix for SegFault errors occurring while the output format was set to .bin/.raw format

Issue Link:https://github.com/CCExtractor/ccextractor/issues/102