### PR TITLE
Fixing GCC warnings

### DIFF
--- a/src/lib_ccx/608_spupng.c
+++ b/src/lib_ccx/608_spupng.c
@@ -259,8 +259,8 @@ spupng_write_ccbuffer(struct spupng_t *sp, struct eia608_screen* data,
                         break;
                 }
             }
-                        strncat(str,(const char*)subline,256);
-                        strncat(str,"\n",256);
+                        strncat(str,(const char*)subline,256 - strlen(str) - 1); // 256 - (Size of buffer already filled)
+                        strncat(str,"\n",256 - strlen(str) - 1);                 // -1 for the terminating null character
         }
     }
 

--- a/src/lib_ccx/ts_tables_epg.c
+++ b/src/lib_ccx/ts_tables_epg.c
@@ -39,7 +39,7 @@ void EPG_DVB_calc_start_time(struct EPG_event *event, uint64_t time) {
 		y = y + k + 1900;
 		m = m - 1 - k*12;
 
-		sprintf(event->start_time_string, "%02d%02d%02d%06x +0000",y,m,d,time&0xffffff);
+		sprintf(event->start_time_string, "%02d%02d%02d%06x +0000",(int)y, (int)m, (int)d, (unsigned int)time&0xffffff);
 	}
 }
 


### PR DESCRIPTION
Typecasting arguments to sprintf() in ts_tables_epg.c
Avoiding buffer overflow in strncat() in 608_spupng.c