### PR TITLE
Fixing possible buffer overflow

### DIFF
--- a/src/lib_ccx/608_sami.c
+++ b/src/lib_ccx/608_sami.c
@@ -23,24 +23,17 @@ void write_stringz_as_sami(char *string, struct encoder_ctx *context, LLONG ms_s
 	unsigned char *el = (unsigned char *) malloc (len*3+1); // Be generous
 	if (el==NULL || unescaped==NULL)
 		fatal (EXIT_NOT_ENOUGH_MEMORY, "In write_stringz_as_sami() - not enough memory.\n");
-	int pos_r=0;
-	int pos_w=0;
+	int pos=0;
 	// Scan for \n in the string and replace it with a 0
-	while (pos_r<len)
+	while (pos<len)
 	{
-		if (string[pos_r]=='\\' && string[pos_r+1]=='n')
-		{
-			unescaped[pos_w]=0;
-			pos_r+=2;
-		}
+		if (string[pos]=='\n')
+			unescaped[pos]=0;
 		else
-		{
-			unescaped[pos_w]=string[pos_r];
-			pos_r++;
-		}
-		pos_w++;
+			unescaped[pos]=string[pos];
+		pos++;
 	}
-	unescaped[pos_w]=0;
+	unescaped[pos]=0;
 	// Now read the unescaped string (now several string'z and write them)
 	unsigned char *begin=unescaped;
 	while (begin<unescaped+len)
@@ -121,7 +114,6 @@ int write_cc_bitmap_as_sami(struct cc_subtitle *sub, struct encoder_ctx *context
 			token = strtok(rect[0].ocr_text,"\r\n");
 			while (token)
 			{
-
 				sprintf(buf, "%s", token);
 				token = strtok(NULL,"\r\n");
 				if(token)

--- a/src/lib_ccx/608_smptett.c
+++ b/src/lib_ccx/608_smptett.c
@@ -48,25 +48,18 @@ void write_stringz_as_smptett(char *string, struct encoder_ctx *context, LLONG m
     unsigned char *unescaped= (unsigned char *) malloc (len+1);
     unsigned char *el = (unsigned char *) malloc (len*3+1); // Be generous
     if (el==NULL || unescaped==NULL)
-        fatal (EXIT_NOT_ENOUGH_MEMORY, "In write_stringz_as_sami() - not enough memory.\n");
-    int pos_r=0;
-    int pos_w=0;
-    // Scan for \n in the string and replace it with a 0
-    while (pos_r<len)
-    {
-        if (string[pos_r]=='\\' && string[pos_r+1]=='n')
-        {
-            unescaped[pos_w]=0;
-            pos_r+=2;
-        }
-        else
-        {
-            unescaped[pos_w]=string[pos_r];
-            pos_r++;
-        }
-        pos_w++;
-    }
-    unescaped[pos_w]=0;
+        fatal (EXIT_NOT_ENOUGH_MEMORY, "In write_stringz_as_smptett() - not enough memory.\n");
+    int pos=0;
+	// Scan for \n in the string and replace it with a 0
+	while (pos<len)
+	{
+		if (string[pos]=='\n')
+			unescaped[pos]=0;
+		else
+			unescaped[pos]=string[pos];
+		pos++;
+	}
+	unescaped[pos]=0;
     // Now read the unescaped string (now several string'z and write them)
     unsigned char *begin=unescaped;
     while (begin<unescaped+len)
@@ -83,7 +76,6 @@ void write_stringz_as_smptett(char *string, struct encoder_ctx *context, LLONG m
 		write(context->out->fh, encoded_crlf, encoded_crlf_length);
         begin+= strlen ((const char *) begin)+1;
     }
-
     sprintf ((char *) str,"</p>\n");
     if (ccx_options.encoding!=CCX_ENC_UNICODE)
     {

--- a/src/lib_ccx/608_spupng.c
+++ b/src/lib_ccx/608_spupng.c
@@ -259,8 +259,8 @@ spupng_write_ccbuffer(struct spupng_t *sp, struct eia608_screen* data,
                         break;
                 }
             }
-                        strncat(str,(const char*)subline,256);
-                        strncat(str,"\n",256);
+                        strncat(str,(const char*)subline,256 - strlen(str) - 1); // 256 - (Size of buffer already filled)
+                        strncat(str,"\n",256 - strlen(str) - 1);                 // -1 for the terminating null character
         }
     }
 

--- a/src/lib_ccx/608_spupng.c
+++ b/src/lib_ccx/608_spupng.c
@@ -259,8 +259,8 @@ spupng_write_ccbuffer(struct spupng_t *sp, struct eia608_screen* data,
                         break;
                 }
             }
-                        strncat(str,(const char*)subline,256 - strlen(str) - 1); // 256 - (Size of buffer already filled)
-                        strncat(str,"\n",256 - strlen(str) - 1);                 // -1 for the terminating null character
+                        strncat(str,(const char*)subline,(sizeof(str)/sizeof(char)) - strlen(str) - 1); // (Size of entire buffer) - (Size of buffer already filled)
+                        strncat(str,"\n",(sizeof(str)/sizeof(char)) - strlen(str) - 1); // -1 for the terminating null character
         }
     }
 

--- a/src/lib_ccx/608_srt.c
+++ b/src/lib_ccx/608_srt.c
@@ -30,24 +30,17 @@ void write_stringz_as_srt(char *string, struct encoder_ctx *context, LLONG ms_st
 	unsigned char *el = (unsigned char *) malloc (len*3+1); // Be generous
 	if (el==NULL || unescaped==NULL)
 		fatal (EXIT_NOT_ENOUGH_MEMORY, "In write_stringz_as_srt() - not enough memory.\n");
-	int pos_r=0;
-	int pos_w=0;
+	int pos=0;
 	// Scan for \n in the string and replace it with a 0
-	while (pos_r<len)
+	while (pos<len)
 	{
-		if (string[pos_r]=='\\' && string[pos_r+1]=='n')
-		{
-			unescaped[pos_w]=0;
-			pos_r+=2;
-		}
+		if (string[pos]=='\n')
+			unescaped[pos]=0;
 		else
-		{
-			unescaped[pos_w]=string[pos_r];
-			pos_r++;
-		}
-		pos_w++;
+			unescaped[pos]=string[pos];
+		pos++;
 	}
-	unescaped[pos_w]=0;
+	unescaped[pos]=0;
 	// Now read the unescaped string (now several string'z and write them)
 	unsigned char *begin=unescaped;
 	while (begin<unescaped+len)

--- a/src/lib_ccx/ts_tables_epg.c
+++ b/src/lib_ccx/ts_tables_epg.c
@@ -39,7 +39,7 @@ void EPG_DVB_calc_start_time(struct EPG_event *event, uint64_t time) {
 		y = y + k + 1900;
 		m = m - 1 - k*12;
 
-		sprintf(event->start_time_string, "%02d%02d%02d%06x +0000",(int)y, (int)m, (int)d, (unsigned int)time&0xffffff);
+		sprintf(event->start_time_string, "%02d%02d%02d%06x +0000",y,m,d,time&0xffffff);
 	}
 }
 

--- a/src/lib_ccx/ts_tables_epg.c
+++ b/src/lib_ccx/ts_tables_epg.c
@@ -39,7 +39,7 @@ void EPG_DVB_calc_start_time(struct EPG_event *event, uint64_t time) {
 		y = y + k + 1900;
 		m = m - 1 - k*12;
 
-		sprintf(event->start_time_string, "%02d%02d%02d%06x +0000",y,m,d,time&0xffffff);
+		sprintf(event->start_time_string, "%02d%02d%02d%06x +0000",(int)y, (int)m, (int)d, (unsigned int)time&0xffffff);
 	}
 }
 


### PR DESCRIPTION
Modifying 3rd argument of strncat()
Refactoring 256 (magic number) to sizeof(str)/sizeof(char)