### PR TITLE
Attempt to improve mp4 detection

### DIFF
--- a/src/lib_ccx/stream_functions.c
+++ b/src/lib_ccx/stream_functions.c
@@ -141,7 +141,7 @@ void detect_stream_type (struct lib_ccx_ctx *ctx)
 			   (ctx->startbytes[i]=='m' && ctx->startbytes[i+1]=='d' &&
                ctx->startbytes[i+2]=='a' && ctx->startbytes[i+3]=='t')
 			   ||
-			   (ctx->startbytes[i]=='f' && ctx->startbytes[i+1]=='e' &&
+			   (ctx->startbytes[i]=='f' && ctx->startbytes[i+1]=='r' &&
                ctx->startbytes[i+2]=='e' && ctx->startbytes[i+3]=='e')
 			   ||
 			   (ctx->startbytes[i]=='s' && ctx->startbytes[i+1]=='k' &&
@@ -155,6 +155,9 @@ void detect_stream_type (struct lib_ccx_ctx *ctx)
 			   ||
 			   (ctx->startbytes[i]=='v' && ctx->startbytes[i+1]=='o' &&
                ctx->startbytes[i+2]=='i' && ctx->startbytes[i+3]=='d')
+               ||
+               (ctx->startbytes[i]=='w' && ctx->startbytes[i+1]=='i' &&
+                ctx->startbytes[i+2]=='d' && ctx->startbytes[i+3]=='e')
 			   )
 			{
 				ctx->stream_mode=CCX_SM_MP4;


### PR DESCRIPTION
This fix is based on gpacs' mp4 detecition "gf_isom_probe_file" function
there was a typo in mp4 detection algorithm 'feee'->'free'
I had also added 'wide' box to mp4 detection algorithm, because it could also appear in the beginning of the file
I haven't found any description of 'jP  ' box, so it was not included in this fix
Hope this fix will slightly increase true positive rate of mp4 detection.