### PR TITLE
Prevent overwriting files

### DIFF
--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -228,6 +228,10 @@ int main(int argc, char *argv[])
 			else
 			{
 				mprint ("Creating %s\n", ctx->wbout1.filename);
+				if (detect_input_file_overwrite(ctx, ctx->wbout1.filename)) {
+					fatal(CCX_COMMON_EXIT_FILE_CREATION_FAILED,
+						  "Output filename is same as one of input filenames. Check output parameters.\n");
+				}
 				ctx->wbout1.fh=open (ctx->wbout1.filename, O_RDWR | O_CREAT | O_TRUNC | O_BINARY, S_IREAD | S_IWRITE);
 				if (ctx->wbout1.fh==-1)
 				{
@@ -260,6 +264,10 @@ int main(int argc, char *argv[])
 						strcat (ctx->wbout1.filename,(const char *) ctx->extension);
 					}
 					mprint ("Creating %s\n", ctx->wbout1.filename);
+					if (detect_input_file_overwrite(ctx, ctx->wbout1.filename)) {
+						fatal(CCX_COMMON_EXIT_FILE_CREATION_FAILED,
+							  "Output filename is same as one of input filenames. Check output parameters.\n");
+					}
 					ctx->wbout1.fh=open (ctx->wbout1.filename, O_RDWR | O_CREAT | O_TRUNC | O_BINARY, S_IREAD | S_IWRITE);
 					if (ctx->wbout1.fh==-1)
 					{
@@ -322,6 +330,10 @@ int main(int argc, char *argv[])
 						strcat (ctx->wbout2.filename,(const char *) ctx->extension);
 					}
 					mprint ("Creating %s\n", ctx->wbout2.filename);
+					if (detect_input_file_overwrite(ctx, ctx->wbout2.filename)) {
+						fatal(CCX_COMMON_EXIT_FILE_CREATION_FAILED,
+							  "Output filename is same as one of input filenames. Check output parameters.\n");
+					}
 					ctx->wbout2.fh=open (ctx->wbout2.filename, O_RDWR | O_CREAT | O_TRUNC | O_BINARY, S_IREAD | S_IWRITE);
 					if (ctx->wbout2.fh==-1)
 					{

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -268,6 +268,7 @@ void dinit_libraries( struct lib_ccx_ctx **ctx);
 //params.c
 void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[]);
 void usage (void);
+int detect_input_file_overwrite(struct lib_ccx_ctx *ctx, const char *output_filename);
 int atoi_hex (char *s);
 int stringztoms (const char *s, struct ccx_boundary_time *bt);
 

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -1673,3 +1673,14 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		// Unrecognized switches are silently ignored
 	}
 }
+
+int detect_input_file_overwrite(struct lib_ccx_ctx *ctx, const char *output_filename)
+{
+	for (int i = 0; i < ctx->num_input_files; i++)
+	{
+		if (!strcmp(ctx->inputfile[i], output_filename)) {
+			return 1;
+		}
+	}
+	return 0;
+}


### PR DESCRIPTION
Terminating application if one of output filenames is same as one of input filenames. Since it looks like user has mistaken with input or output parameters, I decided that this error is fatal and there is no need to try to handle this situation in ccextractor (e.g. add something to the output name).