### PR TITLE
handling 7-byte PES packets for dvb-subs stream

### DIFF
--- a/src/lib_ccx/dvb_subtitle_decoder.c
+++ b/src/lib_ccx/dvb_subtitle_decoder.c
@@ -1551,7 +1551,7 @@ int dvbsub_decode(void *dvb_ctx, const unsigned char *buf, int buf_size, struct 
 
 	if (buf_size <= 6 || *buf != 0x0f)
 	{
-		mprint("incomplete or broken packet\n");
+		mprint("dvbsub_decode: incomplete, broken or empty packet\n");
 		return -1;
 	}
 
@@ -1570,7 +1570,7 @@ int dvbsub_decode(void *dvb_ctx, const unsigned char *buf, int buf_size, struct 
 
 		if (p_end - p < segment_length)
 		{
-			mprint("incomplete or broken packet\n");
+			mprint("dvbsub_decode: incomplete, broken or empty packet\n");
 			return -1;
 		}
 

--- a/src/lib_ccx/stream_functions.c
+++ b/src/lib_ccx/stream_functions.c
@@ -257,9 +257,17 @@ int read_video_pes_header (struct lib_ccx_ctx *ctx, unsigned char *nextheader, i
     }
     else
     {
-	// We need at least 9 bytes to continue
-	if( sbuflen < 9 )
-	    return -1;
+        if (ccx_bufferdatatype == CCX_DVB_SUBTITLE
+            && peslen == 1 && nextheader[6] == 0xFF)
+        {
+            *headerlength = sbuflen;
+            return 0;
+        }
+
+        if (sbuflen < 9) // We need at least 9 bytes to continue
+        {
+            return -1;
+        }
     }
     *headerlength = 6+3;
 

--- a/src/lib_ccx/ts_functions.c
+++ b/src/lib_ccx/ts_functions.c
@@ -619,9 +619,18 @@ LLONG ts_getmoredata(struct lib_ccx_ctx *ctx)
 		int pesheaderlen;
 		int vpesdatalen = read_video_pes_header(ctx, ctx->capbuf, &pesheaderlen, ctx->capbuflen);
 
+		if (ccx_bufferdatatype == CCX_DVB_SUBTITLE && !vpesdatalen)
+		{
+			dbg_print(CCX_DMT_VERBOSE, "TS payload is a DVB Subtitle\n");
+			payload_read = ctx->capbuflen;
+			inbuf += payload_read;
+			break;
+		}
+
 		if (vpesdatalen < 0)
-		{   // Seems to be a broken PES
-			end_of_file=1;
+		{
+			dbg_print(CCX_DMT_VERBOSE, "Seems to be a broken PES. Terminating file handling.\n");
+			end_of_file = 1;
 			break;
 		}
 


### PR DESCRIPTION
This handling is be better, because broken PES packets could happen too.