### PR TITLE
Possible MP4 detection fix

### DIFF
--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -350,6 +350,7 @@ void flushbuffer (struct lib_ccx_ctx *ctx, struct ccx_s_write *wb, int closefile
 void writercwtdata (struct lib_cc_decode *ctx, const unsigned char *data);
 
 // stream_functions.c
+int isValidMP4Box(unsigned char *buffer, long position, long *nextBoxLocation, int *boxScore);
 void detect_stream_type (struct lib_ccx_ctx *ctx);
 int detect_myth( struct lib_ccx_ctx *ctx );
 int read_video_pes_header (struct lib_ccx_ctx *ctx, unsigned char *nextheader, int *headerlength, int sbuflen);


### PR DESCRIPTION
Expanded detection for mp4. This fix does not affect any other files (as opposed to the initial "fix").

New detection code requires a couple of valid mp4 boxes after each other instead of just a single string reference. It uses the length parameter of the supposed mp4 boxes to skip the contents of the supposed boxes (as would be the case in mp4).

- [x] Checked with test suite 
- [x] Discussed with Carlos

