### PR TITLE
Removing use ccx_options from decoders and encoders

### DIFF
--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -20,7 +20,7 @@ void sigint_handler()
 	exit(EXIT_SUCCESS);
 }
 
-
+struct ccx_s_options ccx_options;
 int main(int argc, char *argv[])
 {
 	char *c;

--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -10,6 +10,7 @@ License: GPL 2.0
 #include <signal.h>
 #include "ffmpeg_intgr.h"
 #include "ccx_common_option.h"
+#include "ccx_mp4.h"
 
 struct lib_ccx_ctx *signal_ctx;
 void sigint_handler()
@@ -564,6 +565,7 @@ int main(int argc, char *argv[])
 				
 		switch (ctx->stream_mode)
 		{
+			struct ccx_s_mp4Cfg mp4_cfg = {ccx_options.mp4vidtrack};
 			case CCX_SM_ELEMENTARY_OR_NOT_FOUND:
 				if (!ccx_options.use_gop_as_pts) // If !0 then the user selected something
 					ccx_options.use_gop_as_pts = 1; // Force GOP timing for ES
@@ -590,10 +592,12 @@ int main(int argc, char *argv[])
 				show_myth_banner = 1;
 				myth_loop(ctx, &enc_ctx);
 				break;
-			case CCX_SM_MP4:				
+			case CCX_SM_MP4:
 				mprint ("\rAnalyzing data with GPAC (MP4 library)\n");
 				close_input_file(ctx); // No need to have it open. GPAC will do it for us
-				processmp4 (ctx, ctx->inputfile[0],&enc_ctx);
+				processmp4 (ctx, &mp4_cfg, ctx->inputfile[0],&enc_ctx);
+				if (ccx_options.print_file_reports)
+					print_file_report(ctx);
 				break;
 #ifdef WTV_DEBUG
 			case CCX_SM_HEX_DUMP:

--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -276,13 +276,13 @@ int main(int argc, char *argv[])
 				switch (ccx_options.write_format)
 				{
 				case CCX_OF_RAW:
-					init_encoder(enc_ctx, &ctx->wbout1);
-					writeraw(BROADCAST_HEADER, sizeof(BROADCAST_HEADER), &ctx->wbout1);
+					init_encoder(enc_ctx, &ctx->wbout1,&ccx_options);
+					dec_ctx->writedata(BROADCAST_HEADER, sizeof(BROADCAST_HEADER), dec_ctx->context_cc608_field_1, NULL);
 					break;
 				case CCX_OF_DVDRAW:
 					break;
 				case CCX_OF_RCWT:
-					if (init_encoder(enc_ctx, &ctx->wbout1))
+					if (init_encoder(enc_ctx, &ctx->wbout1, &ccx_options))
 						fatal(EXIT_NOT_ENOUGH_MEMORY, "Not enough memory\n");
 					set_encoder_subs_delay(enc_ctx, ctx->subs_delay);
 					set_encoder_last_displayed_subs_ms(enc_ctx, ctx->last_displayed_subs_ms);
@@ -291,13 +291,13 @@ int main(int argc, char *argv[])
 				default:
 					if (!ccx_options.no_bom){
 						if (ccx_options.encoding == CCX_ENC_UTF_8){ // Write BOM
-							writeraw(UTF8_BOM, sizeof(UTF8_BOM), &ctx->wbout1);
+							dec_ctx->writedata(UTF8_BOM, sizeof(UTF8_BOM), dec_ctx->context_cc608_field_1, NULL);
 						}
 						if (ccx_options.encoding == CCX_ENC_UNICODE){ // Write BOM				
-							writeraw(LITTLE_ENDIAN_BOM, sizeof(LITTLE_ENDIAN_BOM), &ctx->wbout1);
+							dec_ctx->writedata(LITTLE_ENDIAN_BOM, sizeof(LITTLE_ENDIAN_BOM), dec_ctx->context_cc608_field_1, NULL);
 						}
 					}
-					if (init_encoder(enc_ctx, &ctx->wbout1)){
+					if (init_encoder(enc_ctx, &ctx->wbout1, &ccx_options)){
 						fatal(EXIT_NOT_ENOUGH_MEMORY, "Not enough memory\n");
 					}
 					set_encoder_subs_delay(enc_ctx, ctx->subs_delay);
@@ -339,7 +339,7 @@ int main(int argc, char *argv[])
 						fatal(CCX_COMMON_EXIT_FILE_CREATION_FAILED, "Failed\n");
 					}
 					if(ccx_options.write_format == CCX_OF_RAW)
-						writeraw (BROADCAST_HEADER,sizeof (BROADCAST_HEADER),&ctx->wbout2);
+						dec_ctx->writedata (BROADCAST_HEADER,sizeof (BROADCAST_HEADER), dec_ctx->context_cc608_field_2, NULL);
 				}
 
 				switch (ccx_options.write_format)
@@ -348,7 +348,7 @@ int main(int argc, char *argv[])
 					case CCX_OF_DVDRAW:
 						break;
 					case CCX_OF_RCWT:
-						if( init_encoder(enc_ctx+1,&ctx->wbout2) )
+						if( init_encoder(enc_ctx+1, &ctx->wbout2, &ccx_options) )
 							fatal (EXIT_NOT_ENOUGH_MEMORY, "Not enough memory\n");
 						set_encoder_subs_delay(enc_ctx+1, ctx->subs_delay);
 						set_encoder_last_displayed_subs_ms(enc_ctx+1, ctx->last_displayed_subs_ms);
@@ -357,13 +357,13 @@ int main(int argc, char *argv[])
 					default:
 						if (!ccx_options.no_bom){
 							if (ccx_options.encoding == CCX_ENC_UTF_8){ // Write BOM
-								writeraw(UTF8_BOM, sizeof(UTF8_BOM), &ctx->wbout2);
+								dec_ctx->writedata(UTF8_BOM, sizeof(UTF8_BOM), dec_ctx->context_cc608_field_2, NULL);
 							}
 							if (ccx_options.encoding == CCX_ENC_UNICODE){ // Write BOM				
-								writeraw(LITTLE_ENDIAN_BOM, sizeof(LITTLE_ENDIAN_BOM), &ctx->wbout2);
+								dec_ctx->writedata(LITTLE_ENDIAN_BOM, sizeof(LITTLE_ENDIAN_BOM), dec_ctx->context_cc608_field_2, NULL);
 							}
 						}
-						if (init_encoder(enc_ctx + 1, &ctx->wbout2)){
+						if (init_encoder(enc_ctx + 1, &ctx->wbout2, &ccx_options)){
 							fatal(EXIT_NOT_ENOUGH_MEMORY, "Not enough memory\n");
 						}
 						set_encoder_subs_delay(enc_ctx+1, ctx->subs_delay);

--- a/src/gpacmp4/mp4.c
+++ b/src/gpacmp4/mp4.c
@@ -7,6 +7,7 @@
 #include "utility.h"
 #include "ccx_encoders_common.h"
 #include "ccx_common_option.h"
+#include "ccx_mp4.h"
 
 void do_NAL (struct lib_ccx_ctx *ctx, unsigned char *NALstart, LLONG NAL_length, struct cc_subtitle *sub);
 void set_fts(void); // From timing.c
@@ -279,7 +280,7 @@ unsigned char * ccdp_find_data(unsigned char * ccdp_atom_content, unsigned int l
 		}
 
 */
-int processmp4 (struct lib_ccx_ctx *ctx, char *file,void *enc_ctx)
+int processmp4 (struct lib_ccx_ctx *ctx,struct ccx_s_mp4Cfg *cfg, char *file,void *enc_ctx)
 {	
 	GF_ISOFile* f;
 	u32 i, j, track_count, avc_track_count, cc_track_count;
@@ -328,7 +329,7 @@ int processmp4 (struct lib_ccx_ctx *ctx, char *file,void *enc_ctx)
 
 		if ( type == GF_ISOM_MEDIA_VISUAL && subtype == GF_ISOM_SUBTYPE_XDVB)
 		{
-			if (cc_track_count && !ccx_options.mp4vidtrack)
+			if (cc_track_count && !cfg->mp4vidtrack)
 				continue;
 			if(process_xdvb_track(ctx, file, f, i + 1, &dec_sub) != 0)
 			{
@@ -344,7 +345,7 @@ int processmp4 (struct lib_ccx_ctx *ctx, char *file,void *enc_ctx)
 
 		if( type == GF_ISOM_MEDIA_VISUAL && subtype == GF_ISOM_SUBTYPE_AVC_H264)
 		{			
-			if (cc_track_count && !ccx_options.mp4vidtrack)
+			if (cc_track_count && !cfg->mp4vidtrack)
 				continue;
 			GF_AVCConfig *cnf = gf_isom_avc_config_get(f,i+1,1);
 			if (cnf!=NULL)
@@ -372,7 +373,7 @@ int processmp4 (struct lib_ccx_ctx *ctx, char *file,void *enc_ctx)
 		if (type == GF_ISOM_MEDIA_CAPTIONS &&
 				(subtype == GF_ISOM_SUBTYPE_C608 || subtype == GF_ISOM_SUBTYPE_C708))
 		{
-			if (avc_track_count && ccx_options.mp4vidtrack)
+			if (avc_track_count && cfg->mp4vidtrack)
 				continue;
 
 #ifdef MP4_DEBUG
@@ -550,8 +551,6 @@ int processmp4 (struct lib_ccx_ctx *ctx, char *file,void *enc_ctx)
 		mprint ("found no dedicated CC track(s).\n");
 
 	ctx->freport.mp4_cc_track_cnt = cc_track_count;
-	if (ccx_options.print_file_reports)
-		print_file_report(ctx);
 
 	return 0;
 }

--- a/src/lib_ccx/608_sami.c
+++ b/src/lib_ccx/608_sami.c
@@ -11,7 +11,7 @@ void write_stringz_as_sami(char *string, struct encoder_ctx *context, LLONG ms_s
 	int used;
 	sprintf ((char *) str,
 	"<SYNC start=%llu><P class=\"UNKNOWNCC\">\r\n",(unsigned long long)ms_start);
-	if (ccx_options.encoding!=CCX_ENC_UNICODE)
+	if (context->encoding!=CCX_ENC_UNICODE)
 	{
 		dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
 	}
@@ -46,7 +46,7 @@ void write_stringz_as_sami(char *string, struct encoder_ctx *context, LLONG ms_s
 	while (begin<unescaped+len)
 	{
 		unsigned int u = encode_line (el, begin);
-		if (ccx_options.encoding!=CCX_ENC_UNICODE)
+		if (context->encoding!=CCX_ENC_UNICODE)
 		{
 			dbg_print(CCX_DMT_DECODER_608, "\r");
 			dbg_print(CCX_DMT_DECODER_608, "%s\n",subline);
@@ -59,7 +59,7 @@ void write_stringz_as_sami(char *string, struct encoder_ctx *context, LLONG ms_s
 	}
 
     sprintf ((char *) str,"</P></SYNC>\r\n");
-    if (ccx_options.encoding!=CCX_ENC_UNICODE)
+    if (context->encoding!=CCX_ENC_UNICODE)
     {
         dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
     }
@@ -68,7 +68,7 @@ void write_stringz_as_sami(char *string, struct encoder_ctx *context, LLONG ms_s
     sprintf ((char *) str,
 		"<SYNC start=%llu><P class=\"UNKNOWNCC\">&nbsp;</P></SYNC>\r\n\r\n",
 		(unsigned long long)ms_end);
-    if (ccx_options.encoding!=CCX_ENC_UNICODE)
+    if (context->encoding!=CCX_ENC_UNICODE)
     {
         dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
     }
@@ -161,7 +161,7 @@ int write_cc_buffer_as_sami(struct eia608_screen *data, struct encoder_ctx *cont
     sprintf ((char *) str,
 		"<SYNC start=%llu><P class=\"UNKNOWNCC\">\r\n",
 		(unsigned long long)startms);
-    if (ccx_options.encoding!=CCX_ENC_UNICODE)
+    if (context->encoding!=CCX_ENC_UNICODE)
     {
         dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
     }
@@ -172,7 +172,7 @@ int write_cc_buffer_as_sami(struct eia608_screen *data, struct encoder_ctx *cont
         if (data->row_used[i])
         {
             int length = get_decoder_line_encoded (subline, i, data);
-            if (ccx_options.encoding!=CCX_ENC_UNICODE)
+            if (context->encoding!=CCX_ENC_UNICODE)
             {
                 dbg_print(CCX_DMT_DECODER_608, "\r");
                 dbg_print(CCX_DMT_DECODER_608, "%s\n",subline);
@@ -185,7 +185,7 @@ int write_cc_buffer_as_sami(struct eia608_screen *data, struct encoder_ctx *cont
         }
     }
     sprintf ((char *) str,"</P></SYNC>\r\n");
-    if (ccx_options.encoding!=CCX_ENC_UNICODE)
+    if (context->encoding!=CCX_ENC_UNICODE)
     {
         dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
     }
@@ -194,7 +194,7 @@ int write_cc_buffer_as_sami(struct eia608_screen *data, struct encoder_ctx *cont
     sprintf ((char *) str,
 		"<SYNC start=%llu><P class=\"UNKNOWNCC\">&nbsp;</P></SYNC>\r\n\r\n",
 		(unsigned long long)endms);
-    if (ccx_options.encoding!=CCX_ENC_UNICODE)
+    if (context->encoding!=CCX_ENC_UNICODE)
     {
         dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
     }

--- a/src/lib_ccx/608_smptett.c
+++ b/src/lib_ccx/608_smptett.c
@@ -38,7 +38,7 @@ void write_stringz_as_smptett(char *string, struct encoder_ctx *context, LLONG m
     mstotime (ms_end-1,&h2,&m2,&s2,&ms2);
 
     sprintf ((char *) str,"<p begin=\"%02u:%02u:%02u.%03u\" end=\"%02u:%02u:%02u.%03u\">\r\n",h1,m1,s1,ms1, h2,m2,s2,ms2);
-    if (ccx_options.encoding!=CCX_ENC_UNICODE)
+    if (context->encoding!=CCX_ENC_UNICODE)
     {
         dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
     }
@@ -72,7 +72,7 @@ void write_stringz_as_smptett(char *string, struct encoder_ctx *context, LLONG m
     while (begin<unescaped+len)
     {
         unsigned int u = encode_line (el, begin);
-        if (ccx_options.encoding!=CCX_ENC_UNICODE)
+        if (context->encoding!=CCX_ENC_UNICODE)
         {
             dbg_print(CCX_DMT_DECODER_608, "\r");
             dbg_print(CCX_DMT_DECODER_608, "%s\n",subline);
@@ -85,14 +85,14 @@ void write_stringz_as_smptett(char *string, struct encoder_ctx *context, LLONG m
     }
 
     sprintf ((char *) str,"</p>\n");
-    if (ccx_options.encoding!=CCX_ENC_UNICODE)
+    if (context->encoding!=CCX_ENC_UNICODE)
     {
         dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
     }
 	used = encode_line(context->buffer,(unsigned char *) str);
 	write(context->out->fh, context->buffer, used);
     sprintf ((char *) str,"<p begin=\"%02u:%02u:%02u.%03u\">\n\n",h2,m2,s2,ms2);
-    if (ccx_options.encoding!=CCX_ENC_UNICODE)
+    if (context->encoding!=CCX_ENC_UNICODE)
     {
         dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
     }
@@ -184,7 +184,7 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
 
     sprintf ((char *) str,"<p begin=\"%02u:%02u:%02u.%03u\" end=\"%02u:%02u:%02u.%03u\">\n",h1,m1,s1,ms1, h2,m2,s2,ms2);
 
-    if (ccx_options.encoding!=CCX_ENC_UNICODE)
+    if (context->encoding!=CCX_ENC_UNICODE)
     {
         dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
     }
@@ -195,7 +195,7 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
         if (data->row_used[i])
         {
             int length = get_decoder_line_encoded (subline, i, data);
-            if (ccx_options.encoding!=CCX_ENC_UNICODE)
+            if (context->encoding!=CCX_ENC_UNICODE)
             {
                 dbg_print(CCX_DMT_DECODER_608, "\r");
                 dbg_print(CCX_DMT_DECODER_608, "%s\n",subline);
@@ -207,14 +207,14 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
         }
     }
     sprintf ((char *) str,"</p>\n");
-    if (ccx_options.encoding!=CCX_ENC_UNICODE)
+    if (context->encoding!=CCX_ENC_UNICODE)
     {
         dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
     }
 	used = encode_line(context->buffer,(unsigned char *) str);
 	write (context->out->fh, context->buffer, used);
 
-    if (ccx_options.encoding!=CCX_ENC_UNICODE)
+    if (context->encoding!=CCX_ENC_UNICODE)
     {
         dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
     }

--- a/src/lib_ccx/608_srt.c
+++ b/src/lib_ccx/608_srt.c
@@ -53,7 +53,7 @@ void write_stringz_as_srt(char *string, struct encoder_ctx *context, LLONG ms_st
 	while (begin<unescaped+len)
 	{
 		unsigned int u = encode_line (el, begin);
-		if (ccx_options.encoding!=CCX_ENC_UNICODE)
+		if (context->encoding != CCX_ENC_UNICODE)
 		{
 			dbg_print(CCX_DMT_DECODER_608, "\r");
 			dbg_print(CCX_DMT_DECODER_608, "%s\n",subline);
@@ -180,12 +180,12 @@ int write_cc_buffer_as_srt(struct eia608_screen *data, struct encoder_ctx *conte
 	{
 		if (data->row_used[i])
 		{
-			if (ccx_options.sentence_cap)
+			if (context->sentence_cap)
 			{
 				capitalize (i,data);
 				correct_case(i,data);
 			}
-			if (ccx_options.autodash && ccx_options.trim_subs)
+			if (context->autodash && context->trim_subs)
 			{
 				int first=0, last=31, center1=-1, center2=-1;
 				unsigned char *line = data->characters[i];
@@ -243,7 +243,7 @@ int write_cc_buffer_as_srt(struct eia608_screen *data, struct encoder_ctx *conte
 
 			}
 			int length = get_decoder_line_encoded (subline, i, data);
-			if (ccx_options.encoding!=CCX_ENC_UNICODE)
+			if (context->encoding!=CCX_ENC_UNICODE)
 			{
 				dbg_print(CCX_DMT_DECODER_608, "\r");
 				dbg_print(CCX_DMT_DECODER_608, "%s\n",subline);

--- a/src/lib_ccx/ccx_common_option.c
+++ b/src/lib_ccx/ccx_common_option.c
@@ -2,7 +2,6 @@
 #include "ccx_encoders_common.h"
 #include "utility.h"
 
-struct ccx_s_options ccx_options;
 /* Parameters */
 void init_options (struct ccx_s_options *options)
 {

--- a/src/lib_ccx/ccx_decoders_608.c
+++ b/src/lib_ccx/ccx_decoders_608.c
@@ -109,7 +109,7 @@ void clear_eia608_cc_buffer(ccx_decoder_608_context *context, struct eia608_scre
 	{
 		memset(data->characters[i], ' ', CCX_DECODER_608_SCREEN_WIDTH);
 		data->characters[i][CCX_DECODER_608_SCREEN_WIDTH] = 0;
-		memset(data->colors[i], context->settings.default_color, CCX_DECODER_608_SCREEN_WIDTH + 1);
+		memset(data->colors[i], context->settings->default_color, CCX_DECODER_608_SCREEN_WIDTH + 1);
 		memset(data->fonts[i], FONT_REGULAR, CCX_DECODER_608_SCREEN_WIDTH + 1);
 		data->row_used[i]=0;
 	}
@@ -120,7 +120,7 @@ void ccx_decoder_608_dinit_library(void **ctx)
 {
 	freep(ctx);
 }
-ccx_decoder_608_context* ccx_decoder_608_init_library(ccx_decoder_608_settings settings, int channel,
+ccx_decoder_608_context* ccx_decoder_608_init_library(struct ccx_decoder_608_settings *settings, int channel,
 		int field, int trim_subs,
 		enum ccx_encoding_type encoding, int *halt,
 		int cc_to_stdout, LLONG subs_delay,
@@ -160,7 +160,7 @@ ccx_decoder_608_context* ccx_decoder_608_init_library(ccx_decoder_608_settings s
 	data->output_format = output_format;
 
 	data->settings = settings;
-	data->current_color = data->settings.default_color;
+	data->current_color = data->settings->default_color;
 
 	clear_eia608_cc_buffer(data, &data->buffer1);
 	clear_eia608_cc_buffer(data, &data->buffer2);
@@ -207,7 +207,7 @@ void delete_to_end_of_row(ccx_decoder_608_context *context)
 			// TODO: This can change the 'used' situation of a column, so we'd
 			// need to check and correct.
 			use_buffer->characters[context->cursor_row][i] = ' ';
-			use_buffer->colors[context->cursor_row][i] = context->settings.default_color;
+			use_buffer->colors[context->cursor_row][i] = context->settings->default_color;
 			use_buffer->fonts[context->cursor_row][i] = context->font;
 		}
 	}
@@ -289,8 +289,8 @@ int write_cc_buffer(ccx_decoder_608_context *context, struct cc_subtitle *sub)
 	LLONG end_time;
 
 
-	if (context->settings.screens_to_process != -1 &&
-		context->screenfuls_counter >= context->settings.screens_to_process)
+	if (context->settings->screens_to_process != -1 &&
+		context->screenfuls_counter >= context->settings->screens_to_process)
 	{
 		// We are done.
 		*context->halt=1;
@@ -534,13 +534,13 @@ int roll_up(ccx_decoder_608_context *context)
 	for (int j = 0; j<(1 + context->cursor_row - keep_lines); j++)
 	{
 		memset(use_buffer->characters[j], ' ', CCX_DECODER_608_SCREEN_WIDTH);
-		memset(use_buffer->colors[j], context->settings.default_color, CCX_DECODER_608_SCREEN_WIDTH);
+		memset(use_buffer->colors[j], context->settings->default_color, CCX_DECODER_608_SCREEN_WIDTH);
 		memset(use_buffer->fonts[j], FONT_REGULAR, CCX_DECODER_608_SCREEN_WIDTH);
 		use_buffer->characters[j][CCX_DECODER_608_SCREEN_WIDTH] = 0;
 		use_buffer->row_used[j]=0;
 	}
 	memset(use_buffer->characters[lastrow], ' ', CCX_DECODER_608_SCREEN_WIDTH);
-	memset(use_buffer->colors[lastrow], context->settings.default_color, CCX_DECODER_608_SCREEN_WIDTH);
+	memset(use_buffer->colors[lastrow], context->settings->default_color, CCX_DECODER_608_SCREEN_WIDTH);
 	memset(use_buffer->fonts[lastrow], FONT_REGULAR, CCX_DECODER_608_SCREEN_WIDTH);
 
 	use_buffer->characters[lastrow][CCX_DECODER_608_SCREEN_WIDTH] = 0;
@@ -646,12 +646,12 @@ void handle_command(/*const */ unsigned char c1, const unsigned char c2, ccx_dec
 	if ((c1==0x14 || c1==0x1C) && c2==0x2b)
 		command = COM_RESUMETEXTDISPLAY;
 
-	if ((command == COM_ROLLUP2 || command == COM_ROLLUP3 || command == COM_ROLLUP4) && context->settings.force_rollup == 1)
+	if ((command == COM_ROLLUP2 || command == COM_ROLLUP3 || command == COM_ROLLUP4) && context->settings->force_rollup == 1)
 		command=COM_FAKE_RULLUP1;
 
-	if ((command == COM_ROLLUP3 || command == COM_ROLLUP4) && context->settings.force_rollup == 2)
+	if ((command == COM_ROLLUP3 || command == COM_ROLLUP4) && context->settings->force_rollup == 2)
 		command=COM_ROLLUP2;
-	else if (command == COM_ROLLUP4 && context->settings.force_rollup == 3)
+	else if (command == COM_ROLLUP4 && context->settings->force_rollup == 3)
 		command=COM_ROLLUP3;
 
 	ccx_common_logging.debug_ftn(CCX_DMT_DECODER_608, "\rCommand begin: %02X %02X (%s)\n", c1, c2, command_type[command]);
@@ -756,7 +756,7 @@ void handle_command(/*const */ unsigned char c1, const unsigned char c2, ccx_dec
 				{
 					if (write_cc_buffer(context, sub))
 						context->screenfuls_counter++;
-					if (context->settings.no_rollup)
+					if (context->settings->no_rollup)
 						erase_memory(context, true); // Make sure the lines we just wrote aren't written again
 				}
 			}
@@ -802,7 +802,7 @@ void handle_command(/*const */ unsigned char c1, const unsigned char c2, ccx_dec
 			context->current_visible_start_ms = get_visible_start();
 			context->cursor_column = 0;
 			context->cursor_row = 0;
-			context->current_color = context->settings.default_color;
+			context->current_color = context->settings->default_color;
 			context->font = FONT_REGULAR;
 			context->mode = MODE_POPON;
 			break;
@@ -926,7 +926,7 @@ void handle_pac(unsigned char c1, unsigned char c2, ccx_decoder_608_context *con
 	int indent=pac2_attribs[c2][2];
 	ccx_common_logging.debug_ftn(CCX_DMT_DECODER_608, "  --  Position: %d:%d, color: %s,  font: %s\n", row,
 		indent, color_text[context->current_color][0], font_text[context->font]);
-	if (context->settings.default_color == COL_USERDEFINED && (context->current_color == COL_WHITE || context->current_color == COL_TRANSPARENT))
+	if (context->settings->default_color == COL_USERDEFINED && (context->current_color == COL_WHITE || context->current_color == COL_TRANSPARENT))
 		context->current_color = COL_USERDEFINED;
 	if (context->mode != MODE_TEXT)
 	{
@@ -949,7 +949,7 @@ void handle_pac(unsigned char c1, unsigned char c2, ccx_decoder_608_context *con
 			if (use_buffer->row_used[j])
 			{
 				memset(use_buffer->characters[j], ' ', CCX_DECODER_608_SCREEN_WIDTH);
-				memset(use_buffer->colors[j], context->settings.default_color, CCX_DECODER_608_SCREEN_WIDTH);
+				memset(use_buffer->colors[j], context->settings->default_color, CCX_DECODER_608_SCREEN_WIDTH);
 				memset(use_buffer->fonts[j], FONT_REGULAR, CCX_DECODER_608_SCREEN_WIDTH);
 				use_buffer->characters[j][CCX_DECODER_608_SCREEN_WIDTH] = 0;
 				use_buffer->row_used[j] = 0;
@@ -980,7 +980,7 @@ void erase_both_memories(ccx_decoder_608_context *context, struct cc_subtitle *s
 	context->current_visible_start_ms = get_visible_start();
 	context->cursor_column = 0;
 	context->cursor_row = 0;
-	context->current_color = context->settings.default_color;
+	context->current_color = context->settings->default_color;
 	context->font = FONT_REGULAR;
 
 	erase_memory(context, true);
@@ -1205,7 +1205,7 @@ int process608(const unsigned char *data, int length, void *private_data, struct
 				//	   current_field, cb_field1, cb_field2, cb_708 );
 			}
 
-			if (wrote_to_screen && context->settings.direct_rollup && // If direct_rollup is enabled and
+			if (wrote_to_screen && context->settings->direct_rollup && // If direct_rollup is enabled and
 					(context->mode == MODE_FAKE_ROLLUP_1 || // we are in rollup mode, write now.
 					 context->mode == MODE_ROLLUP_2 ||
 					 context->mode == MODE_ROLLUP_3 ||

--- a/src/lib_ccx/ccx_decoders_608.c
+++ b/src/lib_ccx/ccx_decoders_608.c
@@ -1076,9 +1076,10 @@ int disCommand(unsigned char hi, unsigned char lo, ccx_decoder_608_context *cont
 }
 
 /* If wb is NULL, then only XDS will be processed */
-int process608(const unsigned char *data, int length, ccx_decoder_608_context *context, struct cc_subtitle *sub)
+int process608(const unsigned char *data, int length, void *private_data, struct cc_subtitle *sub)
 {
 	struct ccx_decoder_608_report  *report = NULL;
+	ccx_decoder_608_context *context = private_data;
 	static int textprinted = 0;
 	int i;
 	if (context)

--- a/src/lib_ccx/ccx_decoders_608.h
+++ b/src/lib_ccx/ccx_decoders_608.h
@@ -1,5 +1,5 @@
-#ifndef __608_H__
-
+#ifndef CCX_DECODER_608_H
+#define CCX_DECODER_608_H 
 #include "ccx_common_platform.h"
 #include "ccx_common_structs.h"
 #include "ccx_decoders_structs.h"
@@ -28,7 +28,7 @@ typedef struct ccx_decoder_608_settings
 
 typedef struct ccx_decoder_608_context
 {
-	ccx_decoder_608_settings settings;
+	ccx_decoder_608_settings *settings;
 	eia608_screen buffer1;
 	eia608_screen buffer2;
 	int cursor_row, cursor_column;
@@ -121,7 +121,7 @@ void ccx_decoder_608_dinit_library(void **ctx);
 /*
  *
  */
-ccx_decoder_608_context* ccx_decoder_608_init_library(ccx_decoder_608_settings settings, int channel,
+ccx_decoder_608_context* ccx_decoder_608_init_library(struct ccx_decoder_608_settings *settings, int channel,
 		int field, int trim_subs,
 		enum ccx_encoding_type encoding, int *halt,
 		int cc_to_stdout, LLONG subs_delay,
@@ -150,5 +150,4 @@ void handle_end_of_data(ccx_decoder_608_context *context, struct cc_subtitle *su
 
 int write_cc_buffer(ccx_decoder_608_context *context, struct cc_subtitle *sub);
 
-#define __608_H__
 #endif

--- a/src/lib_ccx/ccx_decoders_608.h
+++ b/src/lib_ccx/ccx_decoders_608.h
@@ -132,7 +132,7 @@ ccx_decoder_608_context* ccx_decoder_608_init_library(ccx_decoder_608_settings s
  *
  * @param length length of data passed
  *
- * @param context context of cc608 where important information related to 608
+ * @param private_data context of cc608 where important information related to 608
  * 		  are stored.
  *
  * @param sub pointer to subtitle should be memset to 0 when passed first time
@@ -140,7 +140,7 @@ ccx_decoder_608_context* ccx_decoder_608_init_library(ccx_decoder_608_settings s
  *
  * @return number of bytes used from data, -1 when any error is encountered
  */
-int process608(const unsigned char *data, int length, ccx_decoder_608_context *context, struct cc_subtitle *sub);
+int process608(const unsigned char *data, int length, void *private_data, struct cc_subtitle *sub);
 
 /**
  * Issue a EraseDisplayedMemory here so if there's any captions pending

--- a/src/lib_ccx/ccx_decoders_common.c
+++ b/src/lib_ccx/ccx_decoders_common.c
@@ -280,22 +280,22 @@ struct lib_cc_decode* init_cc_decode (struct ccx_decoders_common_settings_t *set
 
 	// Prepare 608 context
 	ctx->context_cc608_field_1 = ccx_decoder_608_init_library(
-		ccx_options.settings_608,
-		ccx_options.cc_channel,
+		setting->settings_608,
+		setting->cc_channel,
 		1,
-		ccx_options.trim_subs,
-		ccx_options.encoding,
+		setting->trim_subs,
+		setting->encoding,
 		&ctx->processed_enough,
 		setting->cc_to_stdout,
 		setting->subs_delay,
 		setting->output_format
 		);
 	ctx->context_cc608_field_2 = ccx_decoder_608_init_library(
-		ccx_options.settings_608,
-		ccx_options.cc_channel,
+		setting->settings_608,
+		setting->cc_channel,
 		2,
-		ccx_options.trim_subs,
-		ccx_options.encoding,
+		setting->trim_subs,
+		setting->encoding,
 		&ctx->processed_enough,
 		setting->cc_to_stdout,
 		setting->subs_delay,
@@ -311,7 +311,7 @@ struct lib_cc_decode* init_cc_decode (struct ccx_decoders_common_settings_t *set
 	memcpy(&ctx->extraction_start, &setting->extraction_start,sizeof(struct ccx_boundary_time));
 	memcpy(&ctx->extraction_end, &setting->extraction_end,sizeof(struct ccx_boundary_time));
 
-	if (ccx_options.send_to_srv)
+	if (setting->send_to_srv)
 		ctx->writedata = net_send_cc;
 	else if (setting->output_format==CCX_OF_RAW || setting->output_format==CCX_OF_DVDRAW)
 		ctx->writedata = writeraw;

--- a/src/lib_ccx/ccx_decoders_common.c
+++ b/src/lib_ccx/ccx_decoders_common.c
@@ -306,8 +306,25 @@ struct lib_cc_decode* init_cc_decode (struct ccx_decoders_common_settings_t *set
 	ctx->write_format =  setting->output_format;
 	ctx->subs_delay =  setting->subs_delay;
 	ctx->wbout1 = setting->wbout1;
+	ctx->extract = setting->extract;
+	ctx->fullbin = setting->fullbin;
 	memcpy(&ctx->extraction_start, &setting->extraction_start,sizeof(struct ccx_boundary_time));
 	memcpy(&ctx->extraction_end, &setting->extraction_end,sizeof(struct ccx_boundary_time));
+
+	if (ccx_options.send_to_srv)
+		ctx->writedata = net_send_cc;
+	else if (setting->output_format==CCX_OF_RAW || setting->output_format==CCX_OF_DVDRAW)
+		ctx->writedata = writeraw;
+	else if (setting->output_format==CCX_OF_SMPTETT ||
+		setting->output_format==CCX_OF_SAMI ||
+		setting->output_format==CCX_OF_SRT ||
+		setting->output_format==CCX_OF_TRANSCRIPT ||
+		setting->output_format==CCX_OF_SPUPNG ||
+		setting->output_format==CCX_OF_NULL)
+		ctx->writedata = process608;
+	else
+		fatal(CCX_COMMON_EXIT_BUG_BUG, "Invalid Write Format Selected");
+
 	return ctx;
 }
 void dinit_cc_decode(struct lib_cc_decode **ctx)

--- a/src/lib_ccx/ccx_decoders_common.h
+++ b/src/lib_ccx/ccx_decoders_common.h
@@ -5,6 +5,7 @@
 #include "ccx_common_constants.h"
 #include "ccx_common_structs.h"
 #include "ccx_decoders_structs.h"
+#include "ccx_common_option.h"
 
 extern unsigned char encoded_crlf[16]; // We keep it encoded here so we don't have to do it many times
 extern unsigned int encoded_crlf_length;

--- a/src/lib_ccx/ccx_decoders_structs.h
+++ b/src/lib_ccx/ccx_decoders_structs.h
@@ -83,6 +83,8 @@ struct ccx_decoders_common_settings_t
 	struct ccx_boundary_time extraction_start, extraction_end; // Segment we actually process
 	void *wbout1;
 	int cc_to_stdout;
+	int extract; // Extract 1st, 2nd or both fields
+	int fullbin; // Disable pruning of padding cc blocks
 };
 struct lib_cc_decode
 {
@@ -101,6 +103,10 @@ struct lib_cc_decode
 	void *wbout1;
 	void *wbout2;
 	LLONG subs_delay; // ms to delay (or advance) subs
+	int extract; // Extract 1st, 2nd or both fields
+	int fullbin; // Disable pruning of padding cc blocks
+
+	void (*writedata)(const unsigned char *data, int length, void *private_data, struct cc_subtitle *sub);
 };
 
 #endif

--- a/src/lib_ccx/ccx_decoders_structs.h
+++ b/src/lib_ccx/ccx_decoders_structs.h
@@ -106,7 +106,7 @@ struct lib_cc_decode
 	int extract; // Extract 1st, 2nd or both fields
 	int fullbin; // Disable pruning of padding cc blocks
 
-	void (*writedata)(const unsigned char *data, int length, void *private_data, struct cc_subtitle *sub);
+	int (*writedata)(const unsigned char *data, int length, void *private_data, struct cc_subtitle *sub);
 };
 
 #endif

--- a/src/lib_ccx/ccx_decoders_structs.h
+++ b/src/lib_ccx/ccx_decoders_structs.h
@@ -85,6 +85,11 @@ struct ccx_decoders_common_settings_t
 	int cc_to_stdout;
 	int extract; // Extract 1st, 2nd or both fields
 	int fullbin; // Disable pruning of padding cc blocks
+	struct ccx_decoder_608_settings *settings_608; //  Contains the settings for the 608 decoder.
+	int cc_channel; // Channel we want to dump in srt mode
+	int trim_subs; // Remove spaces at sides?
+	enum ccx_encoding_type encoding;
+	unsigned send_to_srv;
 };
 struct lib_cc_decode
 {

--- a/src/lib_ccx/ccx_decoders_xds.c
+++ b/src/lib_ccx/ccx_decoders_xds.c
@@ -684,7 +684,6 @@ int xds_do_current_and_future (struct cc_subtitle *sub)
 				if (cur_xds_packet_class==XDS_CLASS_CURRENT &&
 					strcmp (xds_program_name, current_xds_program_name)) // Change of program
 				{
-					//if (!ccx_options.gui_mode_reports)
 					ccx_common_logging.log_ftn ("\rXDS Notice: Program is now %s\n", xds_program_name);
 					strncpy (current_xds_program_name,xds_program_name, 33);
 					ccx_common_logging.gui_ftn(CCX_COMMON_LOGGING_GUI_XDS_PROGRAM_NAME, xds_program_name);

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -48,11 +48,11 @@ static const char *smptett_header = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
 void write_subtitle_file_footer(struct encoder_ctx *ctx,struct ccx_s_write *out)
 {
 	int used;
-	switch (ccx_options.write_format)
+	switch (ctx->write_format)
 	{
 		case CCX_OF_SAMI:
 			sprintf ((char *) str,"</BODY></SAMI>\n");
-			if (ccx_options.encoding!=CCX_ENC_UNICODE)
+			if (ctx->encoding!=CCX_ENC_UNICODE)
 			{
 				dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
 			}
@@ -61,7 +61,7 @@ void write_subtitle_file_footer(struct encoder_ctx *ctx,struct ccx_s_write *out)
 			break;
 		case CCX_OF_SMPTETT:
 			sprintf ((char *) str,"    </div>\n  </body>\n</tt>\n");
-			if (ccx_options.encoding!=CCX_ENC_UNICODE)
+			if (ctx->encoding!=CCX_ENC_UNICODE)
 			{
 				dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
 			}
@@ -79,7 +79,7 @@ void write_subtitle_file_footer(struct encoder_ctx *ctx,struct ccx_s_write *out)
 void write_subtitle_file_header(struct encoder_ctx *ctx,struct ccx_s_write *out)
 {
 	int used;
-	switch (ccx_options.write_format)
+	switch (ctx->write_format)
 	{
 		case CCX_OF_SRT: // Subrip subtitles have no header
 			break;
@@ -96,10 +96,10 @@ void write_subtitle_file_header(struct encoder_ctx *ctx,struct ccx_s_write *out)
 			write(out->fh, ctx->buffer, used);
 			break;
 		case CCX_OF_RCWT: // Write header
-			if (ccx_options.teletext_mode == CCX_TXT_IN_USE)
+			if (ctx->teletext_mode == CCX_TXT_IN_USE)
 				rcwt_header[7] = 2; // sets file format version
 
-			if (ccx_options.send_to_srv)
+			if (ctx->send_to_srv)
 				net_send_header(rcwt_header, sizeof(rcwt_header));
 			else
 				write(out->fh, rcwt_header, sizeof(rcwt_header));
@@ -121,13 +121,13 @@ void write_cc_line_as_transcript2(struct eia608_screen *data, struct encoder_ctx
 	unsigned h2,m2,s2,ms2;
 	LLONG start_time = data->start_time;
 	LLONG end_time = data->end_time;
-	if (ccx_options.sentence_cap)
+	if (context->sentence_cap)
 	{
 		capitalize (line_number,data);
 		correct_case(line_number,data);
 	}
-	int length = get_decoder_line_basic (subline, line_number, data,ccx_options.trim_subs,ccx_options.encoding);
-	if (ccx_options.encoding!=CCX_ENC_UNICODE)
+	int length = get_decoder_line_basic (subline, line_number, data, context->trim_subs, context->encoding);
+	if (context->encoding!=CCX_ENC_UNICODE)
 	{
 		dbg_print(CCX_DMT_DECODER_608, "\r");
 		dbg_print(CCX_DMT_DECODER_608, "%s\n",subline);
@@ -143,9 +143,9 @@ void write_cc_line_as_transcript2(struct eia608_screen *data, struct encoder_ctx
 			return;
 		}
 
-		if (ccx_options.transcript_settings.showStartTime){
+		if (context->transcript_settings->showStartTime){
 			char buf1[80];
-			if (ccx_options.transcript_settings.relativeTimestamp){
+			if (context->transcript_settings->relativeTimestamp){
 				millis_to_date(start_time + context->subs_delay, buf1, context->date_format, context->millis_separator);
 				fdprintf(context->out->fh, "%s|", buf1);
 			}
@@ -155,13 +155,13 @@ void write_cc_line_as_transcript2(struct eia608_screen *data, struct encoder_ctx
 				int start_time_dec = (start_time + context->subs_delay) % 1000;
 				struct tm *start_time_struct = gmtime(&start_time_int);
 				strftime(buf1, sizeof(buf1), "%Y%m%d%H%M%S", start_time_struct);
-				fdprintf(context->out->fh, "%s%c%03d|", buf1,ccx_options.millis_separator,start_time_dec);
+				fdprintf(context->out->fh, "%s%c%03d|", buf1,context->millis_separator,start_time_dec);
 			}
 		}
 
-		if (ccx_options.transcript_settings.showEndTime){
+		if (context->transcript_settings->showEndTime){
 			char buf2[80];
-			if (ccx_options.transcript_settings.relativeTimestamp){
+			if (context->transcript_settings->relativeTimestamp){
 				millis_to_date(end_time, buf2, context->date_format, context->millis_separator);
 				fdprintf(context->out->fh, "%s|", buf2);
 			}
@@ -171,14 +171,14 @@ void write_cc_line_as_transcript2(struct eia608_screen *data, struct encoder_ctx
 				int end_time_dec = (end_time + context->subs_delay) % 1000;
 				struct tm *end_time_struct = gmtime(&end_time_int);
 				strftime(buf2, sizeof(buf2), "%Y%m%d%H%M%S", end_time_struct);
-				fdprintf(context->out->fh, "%s%c%03d|", buf2,ccx_options.millis_separator,end_time_dec);
+				fdprintf(context->out->fh, "%s%c%03d|", buf2,context->millis_separator,end_time_dec);
 			}
 		}
 
-		if (ccx_options.transcript_settings.showCC){
+		if (context->transcript_settings->showCC){
 			fdprintf(context->out->fh, "CC%d|", data->my_field == 1 ? data->channel : data->channel + 2); // Data from field 2 is CC3 or 4
 		}
-		if (ccx_options.transcript_settings.showMode){
+		if (context->transcript_settings->showMode){
 			const char *mode = "???";
 			switch (data->mode)
 			{
@@ -268,10 +268,10 @@ int write_cc_bitmap_as_transcript(struct cc_subtitle *sub, struct encoder_ctx *c
 			while (token)
 			{
 
-				if (ccx_options.transcript_settings.showStartTime)
+				if (context->transcript_settings->showStartTime)
 				{
 					char buf1[80];
-					if (ccx_options.transcript_settings.relativeTimestamp)
+					if (context->transcript_settings->relativeTimestamp)
 					{
 						millis_to_date(start_time + context->subs_delay, buf1);
 						fdprintf(context->out->fh, "%s|", buf1);
@@ -283,14 +283,14 @@ int write_cc_bitmap_as_transcript(struct cc_subtitle *sub, struct encoder_ctx *c
 						int start_time_dec = (start_time + context->subs_delay) % 1000;
 						struct tm *start_time_struct = gmtime(&start_time_int);
 						strftime(buf1, sizeof(buf1), "%Y%m%d%H%M%S", start_time_struct);
-						fdprintf(context->out->fh, "%s%c%03d|", buf1,ccx_options.millis_separator,start_time_dec);
+						fdprintf(context->out->fh, "%s%c%03d|", buf1,context->millis_separator,start_time_dec);
 					}
 				}
 
-				if (ccx_options.transcript_settings.showEndTime)
+				if (context->transcript_settings->showEndTime)
 				{
 					char buf2[80];
-					if (ccx_options.transcript_settings.relativeTimestamp)
+					if (context->transcript_settings->relativeTimestamp)
 					{
 						millis_to_date(end_time, buf2);
 						fdprintf(context->out->fh, "%s|", buf2);
@@ -302,14 +302,14 @@ int write_cc_bitmap_as_transcript(struct cc_subtitle *sub, struct encoder_ctx *c
 						int end_time_dec = end_time % 1000;
 						struct tm *end_time_struct = gmtime(&end_time_int);
 						strftime(buf2, sizeof(buf2), "%Y%m%d%H%M%S", end_time_struct);
-						fdprintf(context->out->fh, "%s%c%03d|", buf2,ccx_options.millis_separator,end_time_dec);
+						fdprintf(context->out->fh, "%s%c%03d|", buf2,context->millis_separator,end_time_dec);
 					}
 				}
-				if (ccx_options.transcript_settings.showCC)
+				if (context->transcript_settings->showCC)
 				{
 					fdprintf(context->out->fh,"%s|",language[sub->lang_index]);
 				}
-				if (ccx_options.transcript_settings.showMode)
+				if (context->transcript_settings->showMode)
 				{
 					fdprintf(context->out->fh,"DVB|");
 				}
@@ -333,24 +333,24 @@ void try_to_add_end_credits(struct encoder_ctx *context, struct ccx_s_write *out
 	if (out->fh == -1)
 		return;
 	window=get_fts()-context->last_displayed_subs_ms-1;
-	if (window<ccx_options.endcreditsforatleast.time_in_ms) // Won't happen, window is too short
+	if (window < context->endcreditsforatleast.time_in_ms) // Won't happen, window is too short
 		return;
-	length=ccx_options.endcreditsforatmost.time_in_ms > window ?
-		window : ccx_options.endcreditsforatmost.time_in_ms;
+	length=context->endcreditsforatmost.time_in_ms > window ?
+		window : context->endcreditsforatmost.time_in_ms;
 
 	st=get_fts()-length-1;
 	end=get_fts();
 
-	switch (ccx_options.write_format)
+	switch (context->write_format)
 	{
 		case CCX_OF_SRT:
-			write_stringz_as_srt(ccx_options.end_credits_text, context, st, end);
+			write_stringz_as_srt(context->end_credits_text, context, st, end);
 			break;
 		case CCX_OF_SAMI:
-			write_stringz_as_sami(ccx_options.end_credits_text, context, st, end);
+			write_stringz_as_sami(context->end_credits_text, context, st, end);
 			break;
 		case CCX_OF_SMPTETT:
-			write_stringz_as_smptett(ccx_options.end_credits_text, context, st, end);
+			write_stringz_as_smptett(context->end_credits_text, context, st, end);
 			break ;
 		default:
 			// Do nothing for the rest
@@ -364,31 +364,31 @@ void try_to_add_start_credits(struct encoder_ctx *context,LLONG start_ms)
 	LLONG l = start_ms + context->subs_delay;
     // We have a windows from last_displayed_subs_ms to l - we need to see if it fits
 
-    if (l<ccx_options.startcreditsnotbefore.time_in_ms) // Too early
+    if (l < context->startcreditsnotbefore.time_in_ms) // Too early
         return;
 
-    if (context->last_displayed_subs_ms+1 > ccx_options.startcreditsnotafter.time_in_ms) // Too late
+    if (context->last_displayed_subs_ms+1 > context->startcreditsnotafter.time_in_ms) // Too late
         return;
 
-    st = ccx_options.startcreditsnotbefore.time_in_ms>(context->last_displayed_subs_ms+1) ?
-        ccx_options.startcreditsnotbefore.time_in_ms : (context->last_displayed_subs_ms+1); // When would credits actually start
+    st = context->startcreditsnotbefore.time_in_ms>(context->last_displayed_subs_ms+1) ?
+        context->startcreditsnotbefore.time_in_ms : (context->last_displayed_subs_ms+1); // When would credits actually start
 
-    end = ccx_options.startcreditsnotafter.time_in_ms<(l-1) ?
-        ccx_options.startcreditsnotafter.time_in_ms : (l-1);
+    end = context->startcreditsnotafter.time_in_ms<(l-1) ?
+        context->startcreditsnotafter.time_in_ms : (l-1);
 
     window = end-st; // Allowable time in MS
 
-    if (ccx_options.startcreditsforatleast.time_in_ms>window) // Window is too short
+    if (context->startcreditsforatleast.time_in_ms>window) // Window is too short
         return;
 
-    length=ccx_options.startcreditsforatmost.time_in_ms > window ?
-        window : ccx_options.startcreditsforatmost.time_in_ms;
+    length=context->startcreditsforatmost.time_in_ms > window ?
+        window : context->startcreditsforatmost.time_in_ms;
 
     dbg_print(CCX_DMT_VERBOSE, "Last subs: %lld   Current position: %lld\n",
         context->last_displayed_subs_ms, l);
     dbg_print(CCX_DMT_VERBOSE, "Not before: %lld   Not after: %lld\n",
-        ccx_options.startcreditsnotbefore.time_in_ms,
-		ccx_options.startcreditsnotafter.time_in_ms);
+        context->startcreditsnotbefore.time_in_ms,
+		context->startcreditsnotafter.time_in_ms);
     dbg_print(CCX_DMT_VERBOSE, "Start of window: %lld   End of window: %lld\n",st,end);
 
     if (window>length+2)
@@ -398,16 +398,16 @@ void try_to_add_start_credits(struct encoder_ctx *context,LLONG start_ms)
         st+=(pad/2);
     }
     end=st+length;
-    switch (ccx_options.write_format)
+    switch (context->write_format)
     {
         case CCX_OF_SRT:
-            write_stringz_as_srt(ccx_options.start_credits_text,context,st,end);
+            write_stringz_as_srt(context->start_credits_text,context,st,end);
             break;
         case CCX_OF_SAMI:
-			write_stringz_as_sami(ccx_options.start_credits_text, context, st, end);
+			write_stringz_as_sami(context->start_credits_text, context, st, end);
             break;
         case CCX_OF_SMPTETT:
-			write_stringz_as_smptett(ccx_options.start_credits_text, context, st, end);
+			write_stringz_as_smptett(context->start_credits_text, context, st, end);
             break;
         default:
             // Do nothing for the rest
@@ -435,6 +435,19 @@ int init_encoder(struct encoder_ctx *ctx, struct ccx_s_write *out, struct ccx_s_
 	ctx->sentence_cap = opt->sentence_cap;
 	ctx->autodash = opt->autodash;
 	ctx->trim_subs = opt->trim_subs;
+	ctx->write_format = opt->write_format;
+	ctx->start_credits_text = opt->start_credits_text;
+	ctx->end_credits_text = opt->end_credits_text;
+	ctx->transcript_settings = &opt->transcript_settings;
+	ctx->startcreditsnotbefore = opt->startcreditsnotbefore;
+	ctx->startcreditsnotafter = opt->startcreditsnotafter;
+	ctx->startcreditsforatleast = opt->startcreditsforatleast;
+	ctx->startcreditsforatmost = opt->startcreditsforatmost;
+	ctx->endcreditsforatleast = opt->endcreditsforatleast;
+	ctx->endcreditsforatmost = opt->endcreditsforatmost;
+	ctx->teletext_mode = opt->teletext_mode;
+	ctx->send_to_srv = opt->send_to_srv;
+	ctx->gui_mode_reports = opt->gui_mode_reports;
 	write_subtitle_file_header(ctx,out);
 
 	return 0;
@@ -455,7 +468,7 @@ void set_encoder_startcredits_displayed(struct encoder_ctx *ctx, int startcredit
 void dinit_encoder(struct encoder_ctx *ctx)
 {
 
-	if (ccx_options.end_credits_text!=NULL)
+	if (ctx->end_credits_text!=NULL)
 		try_to_add_end_credits(ctx,ctx->out);
 	write_subtitle_file_footer(ctx,ctx->out);
 	freep(&ctx->buffer);
@@ -472,8 +485,6 @@ int encode_sub(struct encoder_ctx *context, struct cc_subtitle *sub)
 		for(data = sub->data; sub->nb_data ; sub->nb_data--,data++)
 		{
 			// Determine context based on channel. This replaces the code that was above, as this was incomplete (for cases where -12 was used for example)
-			//if (ccx_options.extract!=1)
-			//context++;
 			if (data->my_field == 2)
 				context++;
 
@@ -491,20 +502,20 @@ int encode_sub(struct encoder_ctx *context, struct cc_subtitle *sub)
 
 			if(!data->start_time)
 				break;
-			switch (ccx_options.write_format)
+			switch (context->write_format)
 			{
 			case CCX_OF_SRT:
-				if (!context->startcredits_displayed && ccx_options.start_credits_text!=NULL)
+				if (!context->startcredits_displayed && context->start_credits_text!=NULL)
 					try_to_add_start_credits(context, data->start_time);
 				wrote_something = write_cc_buffer_as_srt(data, context);
 				break;
 			case CCX_OF_SAMI:
-				if (!context->startcredits_displayed && ccx_options.start_credits_text!=NULL)
+				if (!context->startcredits_displayed && context->start_credits_text!=NULL)
 					try_to_add_start_credits(context, data->start_time);
 				wrote_something = write_cc_buffer_as_sami(data, context);
 				break;
 			case CCX_OF_SMPTETT:
-				if (!context->startcredits_displayed && ccx_options.start_credits_text!=NULL)
+				if (!context->startcredits_displayed && context->start_credits_text!=NULL)
 					try_to_add_start_credits(context, data->start_time);
 				wrote_something = write_cc_buffer_as_smptett(data, context);
 				break;
@@ -520,25 +531,25 @@ int encode_sub(struct encoder_ctx *context, struct cc_subtitle *sub)
 			if (wrote_something)
 				context->last_displayed_subs_ms=get_fts() + context->subs_delay;
 
-			if (ccx_options.gui_mode_reports)
+			if (context->gui_mode_reports)
 				write_cc_buffer_to_gui(sub->data, context);
 		}
 		freep(&sub->data);
 	}
 	if(sub->type == CC_BITMAP)
 	{
-		switch (ccx_options.write_format)
+		switch (context->write_format)
 		{
 		case CCX_OF_SRT:
-			if (!context->startcredits_displayed && ccx_options.start_credits_text!=NULL)
+			if (!context->startcredits_displayed && context->start_credits_text!=NULL)
 				try_to_add_start_credits(context, sub->start_time);
 			wrote_something = write_cc_bitmap_as_srt(sub, context);
 		case CCX_OF_SAMI:
-			if (!context->startcredits_displayed && ccx_options.start_credits_text!=NULL)
+			if (!context->startcredits_displayed && context->start_credits_text!=NULL)
 				try_to_add_start_credits(context, sub->start_time);
 			wrote_something = write_cc_bitmap_as_sami(sub, context);
 		case CCX_OF_SMPTETT:
-			if (!context->startcredits_displayed && ccx_options.start_credits_text!=NULL)
+			if (!context->startcredits_displayed && context->start_credits_text!=NULL)
 				try_to_add_start_credits(context, sub->start_time);
 			wrote_something = write_cc_bitmap_as_smptett(sub, context);
 		case CCX_OF_TRANSCRIPT:

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -6,7 +6,6 @@
 #include "ocr.h"
 #include "ccx_decoders_608.h"
 #include "ccx_decoders_xds.h"
-#include "ccx_common_option.h"
 
 // These are the default settings for plain transcripts. No times, no CC or caption mode, and no XDS.
 ccx_encoders_transcript_format ccx_encoders_default_transcript_settings =
@@ -419,7 +418,7 @@ void try_to_add_start_credits(struct encoder_ctx *context,LLONG start_ms)
 
 
 }
-int init_encoder(struct encoder_ctx *ctx,struct ccx_s_write *out)
+int init_encoder(struct encoder_ctx *ctx, struct ccx_s_write *out, struct ccx_s_options *opt)
 {
 	ctx->buffer = (unsigned char *) malloc (INITIAL_ENC_BUFFER_CAPACITY);
 	if (ctx->buffer==NULL)
@@ -429,6 +428,8 @@ int init_encoder(struct encoder_ctx *ctx,struct ccx_s_write *out)
 	ctx->out = out;
 	/** used in case of SUB_EOD_MARKER */
 	ctx->prev_start = -1;
+
+	ctx->encoding = opt->encoding;
 	write_subtitle_file_header(ctx,out);
 
 	return 0;

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -146,7 +146,7 @@ void write_cc_line_as_transcript2(struct eia608_screen *data, struct encoder_ctx
 		if (ccx_options.transcript_settings.showStartTime){
 			char buf1[80];
 			if (ccx_options.transcript_settings.relativeTimestamp){
-				millis_to_date(start_time + context->subs_delay, buf1);
+				millis_to_date(start_time + context->subs_delay, buf1, context->date_format, context->millis_separator);
 				fdprintf(context->out->fh, "%s|", buf1);
 			}
 			else {
@@ -162,7 +162,7 @@ void write_cc_line_as_transcript2(struct eia608_screen *data, struct encoder_ctx
 		if (ccx_options.transcript_settings.showEndTime){
 			char buf2[80];
 			if (ccx_options.transcript_settings.relativeTimestamp){
-				millis_to_date(end_time, buf2);
+				millis_to_date(end_time, buf2, context->date_format, context->millis_separator);
 				fdprintf(context->out->fh, "%s|", buf2);
 			}
 			else {

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -430,6 +430,11 @@ int init_encoder(struct encoder_ctx *ctx, struct ccx_s_write *out, struct ccx_s_
 	ctx->prev_start = -1;
 
 	ctx->encoding = opt->encoding;
+	ctx->date_format = opt->date_format;
+	ctx->millis_separator = opt->millis_separator;
+	ctx->sentence_cap = opt->sentence_cap;
+	ctx->autodash = opt->autodash;
+	ctx->trim_subs = opt->trim_subs;
 	write_subtitle_file_header(ctx,out);
 
 	return 0;

--- a/src/lib_ccx/ccx_encoders_common.h
+++ b/src/lib_ccx/ccx_encoders_common.h
@@ -35,6 +35,8 @@ struct encoder_ctx
 	LLONG last_displayed_subs_ms;
 	int startcredits_displayed;
 	enum ccx_encoding_type encoding;
+	enum ccx_output_date_format date_format;
+	char millis_separator;
 };
 
 #define INITIAL_ENC_BUFFER_CAPACITY	2048

--- a/src/lib_ccx/ccx_encoders_common.h
+++ b/src/lib_ccx/ccx_encoders_common.h
@@ -37,6 +37,9 @@ struct encoder_ctx
 	enum ccx_encoding_type encoding;
 	enum ccx_output_date_format date_format;
 	char millis_separator;
+	int sentence_cap ; // FIX CASE? = Fix case?
+	int trim_subs; // "    Remove spaces at sides?    "
+	int autodash; // Add dashes (-) before each speaker automatically?
 };
 
 #define INITIAL_ENC_BUFFER_CAPACITY	2048

--- a/src/lib_ccx/ccx_encoders_common.h
+++ b/src/lib_ccx/ccx_encoders_common.h
@@ -40,6 +40,17 @@ struct encoder_ctx
 	int sentence_cap ; // FIX CASE? = Fix case?
 	int trim_subs; // "    Remove spaces at sides?    "
 	int autodash; // Add dashes (-) before each speaker automatically?
+	enum ccx_output_format write_format; // 0=Raw, 1=srt, 2=SMI
+	/* Credit stuff */
+	char *start_credits_text;
+	char *end_credits_text;
+	struct ccx_encoders_transcript_format *transcript_settings; // Keeps the settings for generating transcript output files.
+	struct ccx_boundary_time startcreditsnotbefore, startcreditsnotafter; // Where to insert start credits, if possible
+	struct ccx_boundary_time startcreditsforatleast, startcreditsforatmost; // How long to display them?
+	struct ccx_boundary_time endcreditsforatleast, endcreditsforatmost;
+	unsigned int teletext_mode; // 0=Disabled, 1 = Not found, 2=Found
+	unsigned int send_to_srv;
+	int gui_mode_reports; // If 1, output in stderr progress updates so the GUI can grab them
 };
 
 #define INITIAL_ENC_BUFFER_CAPACITY	2048

--- a/src/lib_ccx/ccx_encoders_common.h
+++ b/src/lib_ccx/ccx_encoders_common.h
@@ -5,6 +5,7 @@
 #include "ccx_decoders_structs.h"
 #include "ccx_encoders_structs.h"
 #include "ccx_encoders_helpers.h"
+#include "ccx_common_option.h"
 
 #define REQUEST_BUFFER_CAPACITY(ctx,length) if (length>ctx->capacity) \
 {ctx->capacity = length * 2; ctx->buffer = (unsigned char*)realloc(ctx->buffer, ctx->capacity); \
@@ -33,6 +34,7 @@ struct encoder_ctx
 	LLONG subs_delay;
 	LLONG last_displayed_subs_ms;
 	int startcredits_displayed;
+	enum ccx_encoding_type encoding;
 };
 
 #define INITIAL_ENC_BUFFER_CAPACITY	2048
@@ -44,10 +46,11 @@ struct encoder_ctx
  *
  * @param ctx preallocated encoder ctx
  * @param out output context
+ * @param opt Option to initilaize encoder cfg params
  *
  * @return 0 on SUCESS, -1 on failure
  */
-int init_encoder(struct encoder_ctx *ctx,struct ccx_s_write *out);
+int init_encoder(struct encoder_ctx *ctx, struct ccx_s_write *out, struct ccx_s_options *opt);
 
 /**
  * try to add end credits in subtitle file and then write subtitle

--- a/src/lib_ccx/ccx_mp4.h
+++ b/src/lib_ccx/ccx_mp4.h
@@ -1,0 +1,11 @@
+#ifndef CXX_MP4_H
+#define CXX_MP4_H
+
+
+struct ccx_s_mp4Cfg
+{
+	unsigned int mp4vidtrack :1;
+};
+
+int processmp4 (struct lib_ccx_ctx *ctx,struct ccx_s_mp4Cfg *cfg, char *file,void *enc_ctx);
+#endif

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -601,7 +601,7 @@ void general_loop(struct lib_ccx_ctx *ctx, void *enc_ctx)
 
         static LLONG last_pts = 0x01FFFFFFFFLL;
 
-		if (ccx_options.hauppauge_mode)
+		if (ctx->hauppauge_mode)
 		{
 			got = process_raw_with_field(ctx, &dec_sub);
 			if (pts_set)
@@ -678,7 +678,7 @@ void general_loop(struct lib_ccx_ctx *ctx, void *enc_ctx)
         }
         pos+=got;
 
-        if (ccx_options.live_stream)
+        if (ctx->live_stream)
         {
             int cur_sec = (int) (get_fts() / 1000);
             int th=cur_sec/10;
@@ -715,7 +715,7 @@ void general_loop(struct lib_ccx_ctx *ctx, void *enc_ctx)
     if (has_ccdata_buffered)
         process_hdcc(ctx, &dec_sub);
 
-    if (ctx->total_past!=ctx->total_inputsize && ccx_options.binary_concat && !dec_ctx->processed_enough)
+    if (ctx->total_past!=ctx->total_inputsize && ctx->binary_concat && !dec_ctx->processed_enough)
     {
         mprint("\n\n\n\nATTENTION!!!!!!\n");
         mprint("Processing of %s %d ended prematurely %lld < %lld, please send bug report.\n\n",

--- a/src/lib_ccx/lib_ccx.c
+++ b/src/lib_ccx/lib_ccx.c
@@ -19,6 +19,10 @@ static struct ccx_decoders_common_settings_t *init_decoder_setting(
 	memcpy(&setting->extraction_start,&opt->extraction_start,sizeof(struct ccx_boundary_time));
 	memcpy(&setting->extraction_end,&opt->extraction_end,sizeof(struct ccx_boundary_time));
 	setting->cc_to_stdout = opt->cc_to_stdout;
+	setting->settings_608 = &opt->settings_608;
+	setting->cc_channel = opt->cc_channel;
+	setting->trim_subs = opt->trim_subs;
+	setting->send_to_srv = opt->send_to_srv;
 	return setting;
 }
 static void dinit_decoder_setting (struct ccx_decoders_common_settings_t **setting)
@@ -106,6 +110,9 @@ struct lib_ccx_ctx* init_libraries(struct ccx_s_options *opt)
 
 	ctx->cc_to_stdout = opt->cc_to_stdout;
 
+	ctx->hauppauge_mode = opt->hauppauge_mode;
+	ctx->live_stream = opt->live_stream;
+	ctx->binary_concat = opt->binary_concat;
 	build_parity_table();
 	return ctx;
 }

--- a/src/lib_ccx/lib_ccx.c
+++ b/src/lib_ccx/lib_ccx.c
@@ -14,6 +14,8 @@ static struct ccx_decoders_common_settings_t *init_decoder_setting(
 	setting->subs_delay = opt->subs_delay;
 	setting->output_format = opt->write_format;
 	setting->fix_padding = opt->fix_padding;
+	setting->extract = opt->extract;
+	setting->fullbin = opt->fullbin;
 	memcpy(&setting->extraction_start,&opt->extraction_start,sizeof(struct ccx_boundary_time));
 	memcpy(&setting->extraction_end,&opt->extraction_end,sizeof(struct ccx_boundary_time));
 	setting->cc_to_stdout = opt->cc_to_stdout;

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -352,7 +352,7 @@ void print_file_report(struct lib_ccx_ctx *ctx);
 
 // output.c
 void init_write(struct ccx_s_write *wb, char *filename);
-void writeraw (const unsigned char *data, int length, struct ccx_s_write *wb);
+void writeraw (const unsigned char *data, int length, ccx_decoder_608_context *context, struct cc_subtitle *sub);
 void writedata(const unsigned char *data, int length, ccx_decoder_608_context *context, struct cc_subtitle *sub);
 void flushbuffer (struct lib_ccx_ctx *ctx, struct ccx_s_write *wb, int closefile);
 void writercwtdata (struct lib_cc_decode *ctx, const unsigned char *data);

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -240,6 +240,12 @@ struct lib_ccx_ctx
 	long capbufsize;
 	unsigned char *capbuf;
 	long capbuflen; // Bytes read in capbuf
+
+	unsigned hauppauge_mode; // If 1, use PID=1003, process specially and so on
+	int live_stream; /* -1 -> Not a complete file but a live stream, without timeout
+                       0 -> A regular file
+                      >0 -> Live stream with a timeout of this value in seconds */
+	int binary_concat; // Disabled by -ve or --videoedited
 };
 #ifdef DEBUG_TELEXCC
 int main_telxcc (int argc, char *argv[]);

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -335,8 +335,6 @@ void store_hdcc(struct lib_ccx_ctx *ctx, unsigned char *cc_data, int cc_count, i
 			LLONG current_fts_now,struct cc_subtitle *sub);
 void anchor_hdcc(int seq);
 void process_hdcc (struct lib_ccx_ctx *ctx, struct cc_subtitle *sub);
-// mp4.c
-int processmp4 (struct lib_ccx_ctx *ctx, char *file,void *enc_ctx);
 
 // params_dump.c
 void params_dump(struct lib_ccx_ctx *ctx);

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -126,6 +126,16 @@ struct ccx_s_teletext_config {
 	// uint8_t se_mode : 1; // search engine compatible mode => Uses CCExtractor's write_format
 	// uint64_t utc_refvalue; // UTC referential value => Moved to ccx_decoders_common, so can be used for other decoders (608/xds) too
 	uint16_t user_page; // Page selected by user, which MIGHT be different to 'page' depending on autodetection stuff
+	ccx_encoders_transcript_format *transcript_settings; // Keeps the settings for generating transcript output files.
+	int levdistmincnt, levdistmaxpct; // Means 2 fails or less is "the same", 10% or less is also "the same"
+	struct ccx_boundary_time extraction_start, extraction_end; // Segment we actually process
+	enum ccx_output_format write_format; // 0=Raw, 1=srt, 2=SMI
+	int gui_mode_reports; // If 1, output in stderr progress updates so the GUI can grab them
+	enum ccx_output_date_format date_format;
+	int noautotimeref; // Do NOT set time automatically?
+	unsigned send_to_srv;
+	enum ccx_encoding_type encoding;
+	int nofontcolor;
 };
 #define MAX_PID 65536
 struct lib_ccx_ctx

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -136,6 +136,7 @@ struct ccx_s_teletext_config {
 	unsigned send_to_srv;
 	enum ccx_encoding_type encoding;
 	int nofontcolor;
+	char millis_separator;
 };
 #define MAX_PID 65536
 struct lib_ccx_ctx
@@ -352,8 +353,7 @@ void print_file_report(struct lib_ccx_ctx *ctx);
 
 // output.c
 void init_write(struct ccx_s_write *wb, char *filename);
-void writeraw (const unsigned char *data, int length, ccx_decoder_608_context *context, struct cc_subtitle *sub);
-void writedata(const unsigned char *data, int length, ccx_decoder_608_context *context, struct cc_subtitle *sub);
+int writeraw (const unsigned char *data, int length, void *private_data, struct cc_subtitle *sub);
 void flushbuffer (struct lib_ccx_ctx *ctx, struct ccx_s_write *wb, int closefile);
 void writercwtdata (struct lib_cc_decode *ctx, const unsigned char *data);
 
@@ -388,8 +388,8 @@ bool_t in_array(uint16_t *array, uint16_t length, uint16_t element) ;
 int hex2int (char high, char low);
 void timestamp_to_srttime(uint64_t timestamp, char *buffer);
 void timestamp_to_smptetttime(uint64_t timestamp, char *buffer);
-void millis_to_date (uint64_t timestamp, char *buffer) ;
 int levenshtein_dist (const uint64_t *s1, const uint64_t *s2, unsigned s1len, unsigned s2len);
+void millis_to_date (uint64_t timestamp, char *buffer, enum ccx_output_date_format date_format, char millis_separator);
 #ifndef _WIN32
 void m_signal(int sig, void (*func)(int));
 #endif

--- a/src/lib_ccx/networking.c
+++ b/src/lib_ccx/networking.c
@@ -137,7 +137,7 @@ void net_send_header(const unsigned char *data, size_t len)
 	}
 }
 
-void net_send_cc(const unsigned char *data, size_t len)
+int net_send_cc(const unsigned char *data, int len, void *private_data, struct cc_subtitle *sub)
 {
 	assert(srv_sd > 0);
 

--- a/src/lib_ccx/networking.h
+++ b/src/lib_ccx/networking.h
@@ -6,7 +6,7 @@
 void connect_to_srv(const char *addr, const char *port, const char *cc_desc);
 
 void net_send_header(const unsigned char *data, size_t len);
-void net_send_cc(const unsigned char *data, size_t len);
+int net_send_cc(const unsigned char *data, int length, void *private_data, struct cc_subtitle *sub);
 
 int start_tcp_srv(const char *port, const char *pwd);
 

--- a/src/lib_ccx/output.c
+++ b/src/lib_ccx/output.c
@@ -16,11 +16,12 @@ void init_write (struct ccx_s_write *wb,char *filename)
     wb->filename=filename;
 }
 
-void writeraw (const unsigned char *data, int length, ccx_decoder_608_context *context, struct cc_subtitle *sub)
+int writeraw (const unsigned char *data, int length, void *private_data, struct cc_subtitle *sub)
 {
+	ccx_decoder_608_context *context = private_data;
 	// Don't do anything for empty data
 	if (data==NULL)
-		return;
+		return -1;
 
 	/* TODO dont write directly to file instead follow complete path and write raw data in sub and in above 
            layer choose whether u want to write it to file or not */

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -1683,6 +1683,7 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 	tlt_config.send_to_srv = opt->send_to_srv;
 	tlt_config.encoding = opt->encoding;
 	tlt_config.nofontcolor = opt->nofontcolor;
+	tlt_config.millis_separator = opt->millis_separator;
 }
 
 int detect_input_file_overwrite(struct lib_ccx_ctx *ctx, const char *output_filename)

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -1669,6 +1669,20 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 	}
 	if(opt->ts_forced_program != -1)
 		opt->ts_forced_program_selected = 1;
+
+	// Init telexcc redundant options
+	tlt_config.transcript_settings = &opt->transcript_settings;
+	tlt_config.levdistmincnt = opt->levdistmincnt;
+	tlt_config.levdistmaxpct = opt->levdistmaxpct;
+	tlt_config.extraction_start = opt->extraction_start;
+	tlt_config.extraction_end = opt->extraction_end;
+	tlt_config.write_format = opt->write_format;
+	tlt_config.gui_mode_reports = opt->gui_mode_reports;
+	tlt_config.date_format = opt->date_format;
+	tlt_config.noautotimeref = opt->noautotimeref;
+	tlt_config.send_to_srv = opt->send_to_srv;
+	tlt_config.encoding = opt->encoding;
+	tlt_config.nofontcolor = opt->nofontcolor;
 }
 
 int detect_input_file_overwrite(struct lib_ccx_ctx *ctx, const char *output_filename)

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -205,64 +205,64 @@ int add_file_sequence (struct ccx_s_options *opt, char *filename)
 	return 0;
 }
 
-void set_output_format (const char *format)
+void set_output_format (struct ccx_s_options *opt, const char *format)
 {
 	while (*format=='-')
 		format++;
 
-	if (ccx_options.send_to_srv && strcmp(format, "bin")!=0)
+	if (opt->send_to_srv && strcmp(format, "bin")!=0)
 	{
 		mprint("Output format is changed to bin\n");
 		format = "bin";
 	}
 
 	if (strcmp (format,"srt")==0)
-		ccx_options.write_format=CCX_OF_SRT;
+		opt->write_format=CCX_OF_SRT;
 	else if (strcmp (format,"sami")==0 || strcmp (format,"smi")==0)
-		ccx_options.write_format=CCX_OF_SAMI;
+		opt->write_format=CCX_OF_SAMI;
 	else if (strcmp (format,"transcript")==0 || strcmp (format,"txt")==0)
 	{
-		ccx_options.write_format=CCX_OF_TRANSCRIPT;
+		opt->write_format=CCX_OF_TRANSCRIPT;
 	}
 	else if (strcmp (format,"timedtranscript")==0 || strcmp (format,"ttxt")==0)
 	{
-		ccx_options.write_format=CCX_OF_TRANSCRIPT;
-		if (ccx_options.date_format==ODF_NONE)
-			ccx_options.date_format=ODF_HHMMSSMS;
+		opt->write_format=CCX_OF_TRANSCRIPT;
+		if (opt->date_format==ODF_NONE)
+			opt->date_format=ODF_HHMMSSMS;
 		// Sets the right things so that timestamps and the mode are printed.
-		if (!ccx_options.transcript_settings.isFinal){
-			ccx_options.transcript_settings.showStartTime = 1;
-			ccx_options.transcript_settings.showEndTime = 1;
-			ccx_options.transcript_settings.showCC = 0;
-			ccx_options.transcript_settings.showMode = 1;
+		if (!opt->transcript_settings.isFinal){
+			opt->transcript_settings.showStartTime = 1;
+			opt->transcript_settings.showEndTime = 1;
+			opt->transcript_settings.showCC = 0;
+			opt->transcript_settings.showMode = 1;
 		}
 	}
 	else if (strcmp (format,"report")==0)
 	{
-		ccx_options.write_format=CCX_OF_NULL;
-		ccx_options.messages_target=0;
-		ccx_options.print_file_reports=1;
-		ccx_options.ts_autoprogram=1;
+		opt->write_format=CCX_OF_NULL;
+		opt->messages_target=0;
+		opt->print_file_reports=1;
+		opt->ts_autoprogram=1;
 	}
 	else if (strcmp (format,"raw")==0)
-		ccx_options.write_format=CCX_OF_RAW;
+		opt->write_format=CCX_OF_RAW;
 	else if (strcmp (format, "smptett")==0)
-		ccx_options.write_format=CCX_OF_SMPTETT ;
+		opt->write_format=CCX_OF_SMPTETT ;
 	else if (strcmp (format,"bin")==0)
-		ccx_options.write_format=CCX_OF_RCWT;
+		opt->write_format=CCX_OF_RCWT;
 	else if (strcmp (format,"null")==0)
-		ccx_options.write_format=CCX_OF_NULL;
+		opt->write_format=CCX_OF_NULL;
 	else if (strcmp (format,"dvdraw")==0)
-		ccx_options.write_format=CCX_OF_DVDRAW;
+		opt->write_format=CCX_OF_DVDRAW;
 	else if (strcmp (format,"spupng")==0)
-		ccx_options.write_format=CCX_OF_SPUPNG;
+		opt->write_format=CCX_OF_SPUPNG;
 	else
 		fatal (EXIT_MALFORMED_PARAMETER, "Unknown output file format: %s\n", format);
 }
 
 void set_input_format (struct ccx_s_options *opt, const char *format)
 {
-	if (ccx_options.input_source == CCX_DS_TCP && strcmp(format, "bin")!=0)
+	if (opt->input_source == CCX_DS_TCP && strcmp(format, "bin")!=0)
 	{
 		mprint("Intput format is changed to bin\n");
 		format = "bin";
@@ -831,13 +831,13 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		if (strcmp (argv[i],"-bi")==0 ||
 				strcmp (argv[i],"--bufferinput")==0)
 		{
-			ccx_options.buffer_input = 1;
+			opt->buffer_input = 1;
 			continue;
 		}
 		if (strcmp (argv[i],"-nobi")==0 ||
 				strcmp (argv[i],"--nobufferinput")==0)
 		{
-			ccx_options.buffer_input = 0;
+			opt->buffer_input = 0;
 			continue;
 		}
 		if ((strcmp (argv[i],"-bs")==0 || strcmp (argv[i],"--buffersize")==0) && i<argc-1)
@@ -850,27 +850,27 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		}
 		if (strcmp (argv[i],"-dru")==0)
 		{
-			ccx_options.settings_608.direct_rollup = 1;
+			opt->settings_608.direct_rollup = 1;
 			continue;
 		}
 		if (strcmp (argv[i],"-nofc")==0 ||
 				strcmp (argv[i],"--nofontcolor")==0)
 		{
-			ccx_options.nofontcolor=1;
+			opt->nofontcolor=1;
 			continue;
 		}
 		if (strcmp(argv[i], "-bom") == 0){
-			ccx_options.no_bom = 0;
+			opt->no_bom = 0;
 			continue;
 		}
 		if (strcmp(argv[i], "-nobom") == 0){
-			ccx_options.no_bom = 1;
+			opt->no_bom = 1;
 			continue;
 		}
 		if (strcmp (argv[i],"-nots")==0 ||
 				strcmp (argv[i],"--notypesetting")==0)
 		{
-			ccx_options.notypesetting=1;
+			opt->notypesetting=1;
 			continue;
 		}
 
@@ -900,11 +900,11 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 			i++;
 			if(!strcmp (argv[i],"teletext"))
 			{
-				ccx_options.codec = CCX_CODEC_TELETEXT;
+				opt->codec = CCX_CODEC_TELETEXT;
 			}
 			else if(!strcmp (argv[i],"dvbsub"))
 			{
-				ccx_options.codec = CCX_CODEC_DVB;
+				opt->codec = CCX_CODEC_DVB;
 			}
 			else
 			{
@@ -919,11 +919,11 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 			i++;
 			if(!strcmp (argv[i],"teletext"))
 			{
-				ccx_options.nocodec = CCX_CODEC_TELETEXT;
+				opt->nocodec = CCX_CODEC_TELETEXT;
 			}
 			else if(!strcmp (argv[i],"dvbsub"))
 			{
-				ccx_options.nocodec = CCX_CODEC_DVB;
+				opt->nocodec = CCX_CODEC_DVB;
 			}
 			else
 			{
@@ -939,12 +939,12 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 				strcmp (argv[i],"--timedtranscript")==0 || strcmp (argv[i],"-ttxt")==0 ||
 				strcmp (argv[i],"-null")==0)
 		{
-			set_output_format (argv[i]);
+			set_output_format (opt, argv[i]);
 			continue;
 		}
 		if (strncmp (argv[i],"-out=", 5)==0)
 		{
-			set_output_format (argv[i]+5);
+			set_output_format (opt, argv[i]+5);
 			continue;
 		}
 
@@ -952,14 +952,14 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		if ((strcmp (argv[i],"--startcreditstext")==0)
 				&& i<argc-1)
 		{
-			ccx_options.start_credits_text=argv[i+1];
+			opt->start_credits_text=argv[i+1];
 			i++;
 			continue;
 		}
 		if ((strcmp (argv[i],"--startcreditsnotbefore")==0)
 				&& i<argc-1)
 		{
-			if (stringztoms (argv[i+1],&ccx_options.startcreditsnotbefore)==-1)
+			if (stringztoms (argv[i+1],&opt->startcreditsnotbefore)==-1)
 			{
 				fatal (EXIT_MALFORMED_PARAMETER, "--startcreditsnotbefore only accepts SS, MM:SS or HH:MM:SS\n");
 			}
@@ -969,7 +969,7 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		if ((strcmp (argv[i],"--startcreditsnotafter")==0)
 				&& i<argc-1)
 		{
-			if (stringztoms (argv[i+1],&ccx_options.startcreditsnotafter)==-1)
+			if (stringztoms (argv[i+1],&opt->startcreditsnotafter)==-1)
 			{
 				fatal (EXIT_MALFORMED_PARAMETER, "--startcreditsnotafter only accepts SS, MM:SS or HH:MM:SS\n");
 			}
@@ -979,7 +979,7 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		if ((strcmp (argv[i],"--startcreditsforatleast")==0)
 				&& i<argc-1)
 		{
-			if (stringztoms (argv[i+1],&ccx_options.startcreditsforatleast)==-1)
+			if (stringztoms (argv[i+1],&opt->startcreditsforatleast)==-1)
 			{
 				fatal (EXIT_MALFORMED_PARAMETER, "--startcreditsforatleast only accepts SS, MM:SS or HH:MM:SS\n");
 			}
@@ -989,7 +989,7 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		if ((strcmp (argv[i],"--startcreditsforatmost")==0)
 				&& i<argc-1)
 		{
-			if (stringztoms (argv[i+1],&ccx_options.startcreditsforatmost)==-1)
+			if (stringztoms (argv[i+1],&opt->startcreditsforatmost)==-1)
 			{
 				fatal (EXIT_MALFORMED_PARAMETER, "--startcreditsforatmost only accepts SS, MM:SS or HH:MM:SS\n");
 			}
@@ -1000,14 +1000,14 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		if  ((strcmp (argv[i],"--endcreditstext")==0 )
 				&& i<argc-1)
 		{
-			ccx_options.end_credits_text=argv[i+1];
+			opt->end_credits_text=argv[i+1];
 			i++;
 			continue;
 		}
 		if ((strcmp (argv[i],"--endcreditsforatleast")==0)
 				&& i<argc-1)
 		{
-			if (stringztoms (argv[i+1],&ccx_options.endcreditsforatleast)==-1)
+			if (stringztoms (argv[i+1],&opt->endcreditsforatleast)==-1)
 			{
 				fatal (EXIT_MALFORMED_PARAMETER, "--endcreditsforatleast only accepts SS, MM:SS or HH:MM:SS\n");
 			}
@@ -1017,7 +1017,7 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		if ((strcmp (argv[i],"--endcreditsforatmost")==0)
 				&& i<argc-1)
 		{
-			if (stringztoms (argv[i+1],&ccx_options.endcreditsforatmost)==-1)
+			if (stringztoms (argv[i+1],&opt->endcreditsforatmost)==-1)
 			{
 				fatal (EXIT_MALFORMED_PARAMETER, "--startcreditsforatmost only accepts SS, MM:SS or HH:MM:SS\n");
 			}
@@ -1029,30 +1029,30 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		if (strcmp (argv[i],"-ve")==0 ||
 				strcmp (argv[i],"--videoedited")==0)
 		{
-			ccx_options.binary_concat=0;
+			opt->binary_concat=0;
 			continue;
 		}
 		if (strcmp (argv[i],"-12")==0)
 		{
-			ccx_options.extract = 12;
+			opt->extract = 12;
 			continue;
 		}
 		if (strcmp (argv[i],"-gt")==0 ||
 				strcmp (argv[i],"--goptime")==0)
 		{
-			ccx_options.use_gop_as_pts = 1;
+			opt->use_gop_as_pts = 1;
 			continue;
 		}
 		if (strcmp (argv[i],"-nogt")==0 ||
 				strcmp (argv[i],"--nogoptime")==0)
 		{
-			ccx_options.use_gop_as_pts = -1; // Don't use even if we would want to
+			opt->use_gop_as_pts = -1; // Don't use even if we would want to
 			continue;
 		}
 		if (strcmp (argv[i],"-fp")==0 ||
 				strcmp (argv[i],"--fixpadding")==0)
 		{
-			ccx_options.fix_padding = 1;
+			opt->fix_padding = 1;
 			continue;
 		}
 		if (strcmp (argv[i],"-90090")==0)
@@ -1063,51 +1063,51 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		if (strcmp (argv[i],"-noru")==0 ||
 				strcmp (argv[i],"--norollup")==0)
 		{
-			ccx_options.settings_608.no_rollup = 1;
+			opt->settings_608.no_rollup = 1;
 			continue;
 		}
 		if (strcmp (argv[i],"-ru1")==0)
 		{
-			ccx_options.settings_608.force_rollup = 1;
+			opt->settings_608.force_rollup = 1;
 			continue;
 		}
 		if (strcmp (argv[i],"-ru2")==0)
 		{
-			ccx_options.settings_608.force_rollup = 2;
+			opt->settings_608.force_rollup = 2;
 			continue;
 		}
 		if (strcmp (argv[i],"-ru3")==0)
 		{
-			ccx_options.settings_608 .force_rollup = 3;
+			opt->settings_608 .force_rollup = 3;
 			continue;
 		}
 		if (strcmp (argv[i],"-trim")==0)
 		{
-			ccx_options.trim_subs=1;
+			opt->trim_subs=1;
 			continue;
 		}
 		if (strcmp (argv[i],"--gui_mode_reports")==0)
 		{
-			ccx_options.gui_mode_reports=1;
+			opt->gui_mode_reports=1;
 			continue;
 		}
 		if (strcmp (argv[i],"--no_progress_bar")==0)
 		{
-			ccx_options.no_progress_bar=1;
+			opt->no_progress_bar=1;
 			continue;
 		}
 		if (strcmp (argv[i],"--sentencecap")==0 ||
 				strcmp (argv[i],"-sc")==0)
 		{
-			ccx_options.sentence_cap=1;
+			opt->sentence_cap=1;
 			continue;
 		}
 		if ((strcmp (argv[i],"--capfile")==0 ||
 					strcmp (argv[i],"-caf")==0)
 				&& i<argc-1)
 		{
-			ccx_options.sentence_cap=1;
-			ccx_options.sentence_cap_file=argv[i+1];
+			opt->sentence_cap=1;
+			opt->sentence_cap_file=argv[i+1];
 			i++;
 			continue;
 		}
@@ -1116,18 +1116,18 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		{
 			if (i==argc-1 // Means no following argument
 					|| !isanumber (argv[i+1])) // Means is not a number
-				ccx_options.ts_forced_program = (unsigned)-1; // Autodetect
+				opt->ts_forced_program = (unsigned)-1; // Autodetect
 			else
 			{
-				ccx_options.ts_forced_program=atoi_hex (argv[i+1]);
-				ccx_options.ts_forced_program_selected=1;
+				opt->ts_forced_program=atoi_hex (argv[i+1]);
+				opt->ts_forced_program_selected=1;
 				i++;
 			}
 			continue;
 		}
 		if (strcmp (argv[i],"-autoprogram")==0)
 		{
-			ccx_options.ts_autoprogram=1;
+			opt->ts_autoprogram=1;
 			continue;
 		}
 		if (strcmp (argv[i],"--stream")==0 ||
@@ -1135,10 +1135,10 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		{
 			if (i==argc-1 // Means no following argument
 					|| !isanumber (argv[i+1])) // Means is not a number
-				ccx_options.live_stream=-1; // Live stream without timeout
+				opt->live_stream=-1; // Live stream without timeout
 			else
 			{
-				ccx_options.live_stream=atoi_hex (argv[i+1]);
+				opt->live_stream=atoi_hex (argv[i+1]);
 				i++;
 			}
 			continue;
@@ -1152,7 +1152,7 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 				fatal (EXIT_MALFORMED_PARAMETER, "--defaultcolor expects a 7 character parameter that starts with #\n");
 			}
 			strcpy ((char *) usercolor_rgb,argv[i+1]);
-			ccx_options.settings_608.default_color = COL_USERDEFINED;
+			opt->settings_608.default_color = COL_USERDEFINED;
 			i++;
 			continue;
 		}
@@ -1168,8 +1168,8 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		if ((strcmp (argv[i],"-scr")==0 ||
 					strcmp (argv[i],"--screenfuls")==0) && i<argc-1)
 		{
-			ccx_options.settings_608.screens_to_process = atoi_hex(argv[i + 1]);
-			if (ccx_options.settings_608.screens_to_process<0)
+			opt->settings_608.screens_to_process = atoi_hex(argv[i + 1]);
+			if (opt->settings_608.screens_to_process<0)
 			{
 				fatal (EXIT_MALFORMED_PARAMETER, "--screenfuls only accepts positive integers.\n");
 			}
@@ -1178,7 +1178,7 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		}
 		if (strcmp (argv[i],"-startat")==0 && i<argc-1)
 		{
-			if (stringztoms (argv[i+1],&ccx_options.extraction_start)==-1)
+			if (stringztoms (argv[i+1],&opt->extraction_start)==-1)
 			{
 				fatal (EXIT_MALFORMED_PARAMETER, "-startat only accepts SS, MM:SS or HH:MM:SS\n");
 			}
@@ -1187,7 +1187,7 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		}
 		if (strcmp (argv[i],"-endat")==0 && i<argc-1)
 		{
-			if (stringztoms (argv[i+1],&ccx_options.extraction_end)==-1)
+			if (stringztoms (argv[i+1],&opt->extraction_end)==-1)
 			{
 				fatal (EXIT_MALFORMED_PARAMETER, "-endat only accepts SS, MM:SS or HH:MM:SS\n");
 			}
@@ -1196,184 +1196,184 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		}
 		if (strcmp (argv[i],"-1")==0)
 		{
-			ccx_options.extract = 1;
+			opt->extract = 1;
 			continue;
 		}
 		if (strcmp (argv[i],"-2")==0)
 		{
-			ccx_options.extract = 2;
+			opt->extract = 2;
 			continue;
 		}
 		if (strcmp (argv[i],"-cc2")==0 || strcmp (argv[i],"-CC2")==0)
 		{
-			ccx_options.cc_channel=2;
+			opt->cc_channel=2;
 			continue;
 		}
 		if (strcmp (argv[i],"-stdout")==0)
 		{
-			if (ccx_options.messages_target==1) // Only change this if still stdout. -quiet could set it to 0 for example
-				ccx_options.messages_target=2; // stderr
+			if (opt->messages_target==1) // Only change this if still stdout. -quiet could set it to 0 for example
+				opt->messages_target=2; // stderr
 			opt->cc_to_stdout=1;
 			continue;
 		}
 		if (strcmp (argv[i],"-quiet")==0)
 		{
-			ccx_options.messages_target=0;
+			opt->messages_target=0;
 			continue;
 		}
 		if (strcmp (argv[i],"-debug")==0)
 		{
-			ccx_options.debug_mask |= CCX_DMT_VERBOSE;
+			opt->debug_mask |= CCX_DMT_VERBOSE;
 			continue;
 		}
 		if (strcmp (argv[i],"-608")==0)
 		{
-			ccx_options.debug_mask |= CCX_DMT_DECODER_608;
+			opt->debug_mask |= CCX_DMT_DECODER_608;
 			continue;
 		}
 		if (strcmp (argv[i],"-deblev")==0)
 		{
-			ccx_options.debug_mask |= CCX_DMT_LEVENSHTEIN;
+			opt->debug_mask |= CCX_DMT_LEVENSHTEIN;
 			continue;
 		}
 		if (strcmp (argv[i],"-levdistmincnt")==0 && i<argc-1)
 		{
-			ccx_options.levdistmincnt = atoi_hex(argv[i+1]);
+			opt->levdistmincnt = atoi_hex(argv[i+1]);
 			i++;
 			continue;
 		}
 		if (strcmp (argv[i],"-levdistmaxpct")==0 && i<argc-1)
 		{
-			ccx_options.levdistmaxpct = atoi_hex(argv[i+1]);
+			opt->levdistmaxpct = atoi_hex(argv[i+1]);
 			i++;
 			continue;
 		}
 		if (strcmp (argv[i],"-708")==0)
 		{
-			ccx_options.debug_mask |= CCX_DMT_708;
+			opt->debug_mask |= CCX_DMT_708;
 			continue;
 		}
 		if (strcmp (argv[i],"-goppts")==0)
 		{
-			ccx_options.debug_mask |= CCX_DMT_TIME;
+			opt->debug_mask |= CCX_DMT_TIME;
 			continue;
 		}
 		if (strcmp (argv[i],"-vides")==0)
 		{
-			ccx_options.debug_mask |= CCX_DMT_VIDES;
+			opt->debug_mask |= CCX_DMT_VIDES;
 			continue;
 		}
 		if (strcmp (argv[i],"-xds")==0)
 		{
 			// XDS can be set regardless of -UCLA (isFinal) usage.
-			ccx_options.transcript_settings.xds = 1;
+			opt->transcript_settings.xds = 1;
 			continue;
 		}
 		if (strcmp (argv[i],"-xdsdebug")==0)
 		{
-			ccx_options.debug_mask |= CCX_DMT_DECODER_XDS;
+			opt->debug_mask |= CCX_DMT_DECODER_XDS;
 			continue;
 		}
 		if (strcmp (argv[i],"-parsedebug")==0)
 		{
-			ccx_options.debug_mask |= CCX_DMT_PARSE;
+			opt->debug_mask |= CCX_DMT_PARSE;
 			continue;
 		}
 		if (strcmp (argv[i],"-parsePAT")==0 || strcmp (argv[i],"-parsepat")==0)
 		{
-			ccx_options.debug_mask |= CCX_DMT_PAT;
+			opt->debug_mask |= CCX_DMT_PAT;
 			continue;
 		}
 		if (strcmp (argv[i],"-parsePMT")==0 || strcmp (argv[i],"-parsepmt")==0)
 		{
-			ccx_options.debug_mask |= CCX_DMT_PMT;
+			opt->debug_mask |= CCX_DMT_PMT;
 			continue;
 		}
 		if (strcmp (argv[i],"-investigate_packets")==0)
 		{
-			ccx_options.investigate_packets=1;
+			opt->investigate_packets=1;
 			continue;
 		}
 		if (strcmp (argv[i],"-cbraw")==0)
 		{
-			ccx_options.debug_mask |= CCX_DMT_CBRAW;
+			opt->debug_mask |= CCX_DMT_CBRAW;
 			continue;
 		}
 		if (strcmp (argv[i],"-tverbose")==0)
 		{
-			ccx_options.debug_mask |= CCX_DMT_TELETEXT;
+			opt->debug_mask |= CCX_DMT_TELETEXT;
 			tlt_config.verbose=1;
 			continue;
 		}
 		if (strcmp (argv[i],"-fullbin")==0)
 		{
-			ccx_options.fullbin = 1;
+			opt->fullbin = 1;
 			continue;
 		}
 		if (strcmp (argv[i],"-nosync")==0)
 		{
-			ccx_options.nosync = 1;
+			opt->nosync = 1;
 			continue;
 		}
 		if (strcmp (argv[i],"-haup")==0 || strcmp (argv[i],"--hauppauge")==0)
 		{
-			ccx_options.hauppauge_mode = 1;
+			opt->hauppauge_mode = 1;
 			continue;
 		}
 		if (strcmp (argv[i],"-mp4vidtrack")==0)
 		{
-			ccx_options.mp4vidtrack = 1;
+			opt->mp4vidtrack = 1;
 			continue;
 		}
 		if (strstr (argv[i],"-unicode")!=NULL)
 		{
-			ccx_options.encoding=CCX_ENC_UNICODE;
+			opt->encoding=CCX_ENC_UNICODE;
 			continue;
 		}
 		if (strstr (argv[i],"-utf8")!=NULL)
 		{
-			ccx_options.encoding=CCX_ENC_UTF_8;
+			opt->encoding=CCX_ENC_UTF_8;
 			continue;
 		}
 		if (strstr (argv[i],"-latin1")!=NULL)
 		{
-			ccx_options.encoding=CCX_ENC_LATIN_1;
+			opt->encoding=CCX_ENC_LATIN_1;
 			continue;
 		}
 		if (strcmp (argv[i],"-poc")==0 || strcmp (argv[i],"--usepicorder")==0)
 		{
-			ccx_options.usepicorder = 1;
+			opt->usepicorder = 1;
 			continue;
 		}
 		if (strstr (argv[i],"-myth")!=NULL)
 		{
-			ccx_options.auto_myth=1;
+			opt->auto_myth=1;
 			continue;
 		}
 		if (strstr (argv[i],"-nomyth")!=NULL)
 		{
-			ccx_options.auto_myth=0;
+			opt->auto_myth=0;
 			continue;
 		}
 		if (strstr (argv[i],"-wtvconvertfix")!=NULL)
 		{
-			ccx_options.wtvconvertfix=1;
+			opt->wtvconvertfix=1;
 			continue;
 		}
 		if (strstr (argv[i],"-wtvmpeg2")!=NULL)
 		{
-			ccx_options.wtvmpeg2=1;
+			opt->wtvmpeg2=1;
 			continue;
 		}
 		if (strcmp (argv[i],"-o")==0 && i<argc-1)
 		{
-			ccx_options.output_filename=argv[i+1];
+			opt->output_filename=argv[i+1];
 			i++;
 			continue;
 		}
 		if (strcmp (argv[i],"-cf")==0 && i<argc-1)
 		{
-			ccx_options.out_elementarystream_filename=argv[i+1];
+			opt->out_elementarystream_filename=argv[i+1];
 			i++;
 			continue;
 		}
@@ -1399,20 +1399,20 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		}
 		if (strcmp (argv[i],"-datapid")==0 && i<argc-1)
 		{
-			ccx_options.ts_cappid = atoi_hex(argv[i+1]);
-			ccx_options.ts_forced_cappid=1;
+			opt->ts_cappid = atoi_hex(argv[i+1]);
+			opt->ts_forced_cappid=1;
 			i++;
 			continue;
 		}
 		if (strcmp (argv[i],"-datastreamtype")==0 && i<argc-1)
 		{
-			ccx_options.ts_datastreamtype = atoi_hex(argv[i+1]);
+			opt->ts_datastreamtype = atoi_hex(argv[i+1]);
 			i++;
 			continue;
 		}
 		if (strcmp (argv[i],"-streamtype")==0 && i<argc-1)
 		{
-			ccx_options.ts_forced_streamtype = atoi_hex(argv[i+1]);
+			opt->ts_forced_streamtype = atoi_hex(argv[i+1]);
 			i++;
 			continue;
 		}
@@ -1421,47 +1421,47 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		{
 			tlt_config.page = atoi_hex(argv[i+1]);
 			tlt_config.user_page = tlt_config.page;
-			ccx_options.teletext_mode=CCX_TXT_IN_USE;
+			opt->teletext_mode=CCX_TXT_IN_USE;
 			i++;
 			continue;
 		}
 		if (strcmp (argv[i],"-UCLA")==0 || strcmp (argv[i],"-ucla")==0)
 		{
-			ccx_options.millis_separator='.';
-			ccx_options.no_bom = 1;
-			if (!ccx_options.transcript_settings.isFinal){
-				ccx_options.transcript_settings.showStartTime = 1;
-				ccx_options.transcript_settings.showEndTime = 1;
-				ccx_options.transcript_settings.showCC = 1;
-				ccx_options.transcript_settings.showMode = 1;
-				ccx_options.transcript_settings.relativeTimestamp = 0;
-				ccx_options.transcript_settings.isFinal = 1;
+			opt->millis_separator='.';
+			opt->no_bom = 1;
+			if (!opt->transcript_settings.isFinal){
+				opt->transcript_settings.showStartTime = 1;
+				opt->transcript_settings.showEndTime = 1;
+				opt->transcript_settings.showCC = 1;
+				opt->transcript_settings.showMode = 1;
+				opt->transcript_settings.relativeTimestamp = 0;
+				opt->transcript_settings.isFinal = 1;
 			}
 			continue;
 		}
 		if (strcmp (argv[i],"-lf")==0 || strcmp (argv[i],"-LF")==0)
 		{
-			ccx_options.line_terminator_lf = 1;
+			opt->line_terminator_lf = 1;
 			continue;
 		}
 		if (strcmp (argv[i],"-noautotimeref")==0)
 		{
-			ccx_options.noautotimeref = 1;
+			opt->noautotimeref = 1;
 			continue;
 		}
 		if (strcmp (argv[i],"-autodash")==0)
 		{
-			ccx_options.autodash = 1;
+			opt->autodash = 1;
 			continue;
 		}
 		if (strcmp (argv[i],"-xmltv")==0)
 		{
 			if (i==argc-1 // Means no following argument
 					|| !isanumber (argv[i+1])) // Means is not a number
-			ccx_options.xmltv = 1;
+			opt->xmltv = 1;
 			else
 			{
-				ccx_options.xmltv=atoi_hex (argv[i+1]);
+				opt->xmltv=atoi_hex (argv[i+1]);
 				i++;
 			}
 			continue;
@@ -1471,10 +1471,10 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		{
 			if (i==argc-1 // Means no following argument
 					|| !isanumber (argv[i+1])) // Means is not a number
-			ccx_options.xmltvliveinterval = 10;
+			opt->xmltvliveinterval = 10;
 			else
 			{
-				ccx_options.xmltvliveinterval=atoi_hex (argv[i+1]);
+				opt->xmltvliveinterval=atoi_hex (argv[i+1]);
 				i++;
 			}
 			continue;
@@ -1484,17 +1484,17 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		{
 			if (i==argc-1 // Means no following argument
 					|| !isanumber (argv[i+1])) // Means is not a number
-			ccx_options.xmltvoutputinterval = 0;
+			opt->xmltvoutputinterval = 0;
 			else
 			{
-				ccx_options.xmltvoutputinterval=atoi_hex (argv[i+1]);
+				opt->xmltvoutputinterval=atoi_hex (argv[i+1]);
 				i++;
 			}
 			continue;
 		}
 		if (strcmp (argv[i],"-xmltvonlycurrent")==0)
 		{
-			ccx_options.xmltvonlycurrent=1;
+			opt->xmltvonlycurrent=1;
 			i++;
 			continue;
 		}
@@ -1510,45 +1510,45 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 			}
 			utc_refvalue = t;
 			i++;
-			ccx_options.noautotimeref= 1; // If set by user don't attempt to fix
+			opt->noautotimeref= 1; // If set by user don't attempt to fix
 			continue;
 		}
 		if (strcmp (argv[i],"-sects")==0)
 		{
-			ccx_options.date_format=ODF_SECONDS;
+			opt->date_format=ODF_SECONDS;
 			continue;
 		}
 		if (strcmp (argv[i],"-datets")==0)
 		{
-			ccx_options.date_format=ODF_DATE;
+			opt->date_format=ODF_DATE;
 			continue;
 		}
 		if (strcmp (argv[i],"-teletext")==0)
 		{
-			ccx_options.codec = CCX_CODEC_TELETEXT;
-			ccx_options.teletext_mode=CCX_TXT_IN_USE;
+			opt->codec = CCX_CODEC_TELETEXT;
+			opt->teletext_mode=CCX_TXT_IN_USE;
 			continue;
 		}
 		if (strcmp (argv[i],"-noteletext")==0)
 		{
-			ccx_options.nocodec = CCX_CODEC_TELETEXT;
-			ccx_options.teletext_mode=CCX_TXT_FORBIDDEN;
+			opt->nocodec = CCX_CODEC_TELETEXT;
+			opt->teletext_mode=CCX_TXT_FORBIDDEN;
 			continue;
 		}
 		/* Custom transcript */
 		if (strcmp(argv[i], "-customtxt") == 0 && i<argc - 1){
 			char *format = argv[i + 1];
 			if (strlen(format) == 7){
-				if (ccx_options.date_format == ODF_NONE)
-					ccx_options.date_format = ODF_HHMMSSMS; // Necessary for displaying times, if any would be used.
-				if (!ccx_options.transcript_settings.isFinal){
-					ccx_options.transcript_settings.showStartTime = format[0] - '0';
-					ccx_options.transcript_settings.showEndTime = format[1] - '0';
-					ccx_options.transcript_settings.showMode = format[2] - '0';
-					ccx_options.transcript_settings.showCC = format[3] - '0';
-					ccx_options.transcript_settings.relativeTimestamp = format[4] - '0';
-					ccx_options.transcript_settings.xds = format[5] - '0';
-					ccx_options.transcript_settings.useColors = format[6] - '0';
+				if (opt->date_format == ODF_NONE)
+					opt->date_format = ODF_HHMMSSMS; // Necessary for displaying times, if any would be used.
+				if (!opt->transcript_settings.isFinal){
+					opt->transcript_settings.showStartTime = format[0] - '0';
+					opt->transcript_settings.showEndTime = format[1] - '0';
+					opt->transcript_settings.showMode = format[2] - '0';
+					opt->transcript_settings.showCC = format[3] - '0';
+					opt->transcript_settings.relativeTimestamp = format[4] - '0';
+					opt->transcript_settings.xds = format[5] - '0';
+					opt->transcript_settings.useColors = format[6] - '0';
 				} else {
 					// Throw exception
 					fatal(EXIT_INCOMPATIBLE_PARAMETERS, "customtxt cannot be set after -UCLA is used!");
@@ -1568,32 +1568,32 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 			if (colon)
 			{
 				*colon = '\0';
-				ccx_options.udpaddr = argv[i + 1];
-				ccx_options.udpport = atoi_hex(colon + 1);
+				opt->udpaddr = argv[i + 1];
+				opt->udpport = atoi_hex(colon + 1);
 			}
 			else
 			{
-				ccx_options.udpaddr = NULL;
-				ccx_options.udpport = atoi_hex(argv[i + 1]);
+				opt->udpaddr = NULL;
+				opt->udpport = atoi_hex(argv[i + 1]);
 			}
 
-			ccx_options.input_source=CCX_DS_NETWORK;
+			opt->input_source=CCX_DS_NETWORK;
 			i++;
 			continue;
 		}
 
 		if (strcmp (argv[i],"-sendto")==0 && i<argc-1)
 		{
-			ccx_options.send_to_srv = 1;
+			opt->send_to_srv = 1;
 
-			set_output_format("bin");
+			set_output_format(opt, "bin");
 
 			char *addr = argv[i + 1];
 			if (*addr == '[')
 			{
 				addr++;
 
-				ccx_options.srv_addr = addr;
+				opt->srv_addr = addr;
 
 				char *br = strchr(addr, ']');
 				if (br == NULL)
@@ -1602,19 +1602,19 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 
 				br++; /* Colon */
 				if (*br != '\0')
-					ccx_options.srv_port = br + 1;
+					opt->srv_port = br + 1;
 
 				i++;
 				continue;
 			}
 
-			ccx_options.srv_addr = argv[i + 1];
+			opt->srv_addr = argv[i + 1];
 
 			char *colon = strchr(argv[i + 1], ':');
 			if (colon != NULL)
 			{
 				*colon = '\0';
-				ccx_options.srv_port = colon + 1;
+				opt->srv_port = colon + 1;
 			}
 
 			i++;
@@ -1623,8 +1623,8 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 
 		if (strcmp (argv[i],"-tcp")==0 && i<argc-1)
 		{
-			ccx_options.tcpport = argv[i + 1];
-			ccx_options.input_source = CCX_DS_TCP;
+			opt->tcpport = argv[i + 1];
+			opt->input_source = CCX_DS_TCP;
 
 			set_input_format(opt, "bin");
 
@@ -1634,7 +1634,7 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 
 		if (strcmp (argv[i],"-tcppassword")==0 && i<argc-1)
 		{
-			ccx_options.tcp_password = argv[i + 1];
+			opt->tcp_password = argv[i + 1];
 
 			i++;
 			continue;
@@ -1642,7 +1642,7 @@ void parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 
 		if (strcmp (argv[i],"-tcpdesc")==0 && i<argc-1)
 		{
-			ccx_options.tcp_desc = argv[i + 1];
+			opt->tcp_desc = argv[i + 1];
 
 			i++;
 			continue;

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -935,15 +935,10 @@ void process_telx_packet(struct lib_ccx_ctx *ctx, data_unit_t data_unit_id, tele
 
 void tlt_write_rcwt(struct lib_ccx_ctx *ctx, uint8_t data_unit_id, uint8_t *packet, uint64_t timestamp)
 {
-	if (tlt_config.send_to_srv) {
-		net_send_cc((unsigned char *) &data_unit_id, sizeof(uint8_t));
-		net_send_cc((unsigned char *) &timestamp, sizeof(uint64_t));
-		net_send_cc((unsigned char *) packet, 44);
-	} else  {
-		writeraw((unsigned char *) &data_unit_id, sizeof(uint8_t), &ctx->wbout1);
-		writeraw((unsigned char *) &timestamp, sizeof(uint64_t), &ctx->wbout1);
-		writeraw((unsigned char *) packet, 44, &ctx->wbout1);
-	}
+	struct lib_cc_decode *dec_ctx = ctx->dec_ctx;
+	dec_ctx->writedata((unsigned char *) &data_unit_id, sizeof(uint8_t), dec_ctx->context_cc608_field_1, NULL);
+	dec_ctx->writedata((unsigned char *) &timestamp, sizeof(uint64_t), dec_ctx->context_cc608_field_1, NULL);
+	dec_ctx->writedata((unsigned char *) packet, 44, dec_ctx->context_cc608_field_1, NULL);
 }
 
 void tlt_read_rcwt(struct lib_ccx_ctx *ctx)

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -364,12 +364,12 @@ void telxcc_dump_prev_page (struct lib_ccx_ctx *ctx)
 		return;
 
 	if (tlt_config.transcript_settings->showStartTime){
-		millis_to_date(prev_show_timestamp, c_temp1); // Note: Delay not added here because it was already accounted for
+		millis_to_date(prev_show_timestamp, c_temp1, tlt_config.date_format, tlt_config.millis_separator); // Note: Delay not added here because it was already accounted for
 		fdprintf(ctx->wbout1.fh, "%s|", c_temp1);
 	}
 	if (tlt_config.transcript_settings->showEndTime)
 	{
-		millis_to_date (prev_hide_timestamp, c_temp2);
+		millis_to_date (prev_hide_timestamp, c_temp2, tlt_config.date_format, tlt_config.millis_separator);
 		fdprintf(ctx->wbout1.fh,"%s|",c_temp2);
 	}
 	if (tlt_config.transcript_settings->showCC){

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -144,7 +144,7 @@ typedef struct {
 } teletext_page_t;
 
 // application config global variable
-struct ccx_s_teletext_config tlt_config = { NO, 0, 0, 0, NO, NO, 0 };
+struct ccx_s_teletext_config tlt_config = { NO, 0, 0, 0, NO, NO, 0, NULL};
 
 // macro -- output only when increased verbosity was turned on
 #define VERBOSE_ONLY if (tlt_config.verbose == YES)
@@ -363,19 +363,19 @@ void telxcc_dump_prev_page (struct lib_ccx_ctx *ctx)
 	if (!page_buffer_prev)
 		return;
 
-	if (ccx_options.transcript_settings.showStartTime){
+	if (tlt_config.transcript_settings->showStartTime){
 		millis_to_date(prev_show_timestamp, c_temp1); // Note: Delay not added here because it was already accounted for
 		fdprintf(ctx->wbout1.fh, "%s|", c_temp1);
 	}
-	if (ccx_options.transcript_settings.showEndTime)
+	if (tlt_config.transcript_settings->showEndTime)
 	{
 		millis_to_date (prev_hide_timestamp, c_temp2);
 		fdprintf(ctx->wbout1.fh,"%s|",c_temp2);
 	}
-	if (ccx_options.transcript_settings.showCC){
+	if (tlt_config.transcript_settings->showCC){
 		fdprintf(ctx->wbout1.fh, "%.3u|", bcd_page_to_int(tlt_config.page));
 	}
-	if (ccx_options.transcript_settings.showMode){
+	if (tlt_config.transcript_settings->showMode){
 		fdprintf(ctx->wbout1.fh, "TLT|");
 	}
 
@@ -405,10 +405,10 @@ int fuzzy_memcmp (const char *c1, const char *c2, const uint64_t *ucs2_buf1, uns
 {
 	size_t l;
 	size_t short_len=ucs2_buf1_len<ucs2_buf2_len?ucs2_buf1_len:ucs2_buf2_len;
-	size_t max=(short_len*ccx_options.levdistmaxpct)/100;
+	size_t max=(short_len * tlt_config.levdistmaxpct)/100;
 	unsigned upto=(ucs2_buf1_len<ucs2_buf2_len)?ucs2_buf1_len:ucs2_buf2_len;
-	if (max<ccx_options.levdistmincnt)
-		max=ccx_options.levdistmincnt;
+	if (max < tlt_config.levdistmincnt)
+		max=tlt_config.levdistmincnt;
 
 	// For the second string, only take the first chars (up to the first string length, that's upto).
 	l = (size_t) levenshtein_dist (ucs2_buf1,ucs2_buf2,ucs2_buf1_len,upto);
@@ -418,8 +418,8 @@ int fuzzy_memcmp (const char *c1, const char *c2, const uint64_t *ucs2_buf1, uns
 }
 
 void process_page(struct lib_ccx_ctx *ctx, teletext_page_t *page) {
-    if ((ccx_options.extraction_start.set && page->hide_timestamp < ccx_options.extraction_start.time_in_ms) ||
-        (ccx_options.extraction_end.set && page->show_timestamp > ccx_options.extraction_end.time_in_ms) ||
+    if ((tlt_config.extraction_start.set && page->hide_timestamp < tlt_config.extraction_start.time_in_ms) ||
+        (tlt_config.extraction_end.set && page->show_timestamp > tlt_config.extraction_end.time_in_ms) ||
         page->hide_timestamp == 0) {
         return;
     }
@@ -495,7 +495,7 @@ void process_page(struct lib_ccx_ctx *ctx, teletext_page_t *page) {
 		uint8_t font_tag_opened = NO;
 
         if (line_count > 1) {
-            switch (ccx_options.write_format) {
+            switch (tlt_config.write_format) {
                 case CCX_OF_TRANSCRIPT:
                     page_buffer_add_string(" ");
                     break;
@@ -507,7 +507,7 @@ void process_page(struct lib_ccx_ctx *ctx, teletext_page_t *page) {
             }
         }
 
-		if (ccx_options.gui_mode_reports)
+		if (tlt_config.gui_mode_reports)
 		{
 			fprintf (stderr, "###SUBTITLE#");
 			if (!time_reported)
@@ -535,7 +535,7 @@ void process_page(struct lib_ccx_ctx *ctx, teletext_page_t *page) {
 			}
 
 			if (col == col_start) {
-				if ((foreground_color != 0x7) && !ccx_options.nofontcolor) {
+				if ((foreground_color != 0x7) && !tlt_config.nofontcolor) {
 					sprintf (c_tempb, "<font color=\"%s\">", TTXT_COLOURS[foreground_color]);
 					page_buffer_add_string (c_tempb);
 					// if (ctx->wbout1.fh!=-1) fdprintf(ctx->wbout1.fh, "<font color=\"%s\">", TTXT_COLOURS[foreground_color]);
@@ -547,7 +547,7 @@ void process_page(struct lib_ccx_ctx *ctx, teletext_page_t *page) {
 				if (v <= 0x7) {
 					// ETS 300 706, chapter 12.2: Unless operating in "Hold Mosaics" mode,
 					// each character space occupied by a spacing attribute is displayed as a SPACE.
-					if (!ccx_options.nofontcolor) {
+					if (!tlt_config.nofontcolor) {
 						if (font_tag_opened == YES) {
 							page_buffer_add_string ("</font>");
 							// if (ctx->wbout1.fh!=-1) fdprintf(ctx->wbout1.fh, "</font> ");
@@ -574,7 +574,7 @@ void process_page(struct lib_ccx_ctx *ctx, teletext_page_t *page) {
 
 				if (v >= 0x20) {
 						// translate some chars into entities, if in colour mode
-						if (!ccx_options.nofontcolor) {
+						if (!tlt_config.nofontcolor) {
 							for (uint8_t i = 0; i < array_length(ENTITIES); i++)
 									if (v == ENTITIES[i].character) {
 												//if (ctx->wbout1.fh!=-1) fdprintf(ctx->wbout1.fh, "%s", ENTITIES[i].entity);
@@ -590,27 +590,27 @@ void process_page(struct lib_ccx_ctx *ctx, teletext_page_t *page) {
 				if (v >= 0x20) {
 					//if (ctx->wbout1.fh!=-1) fdprintf(ctx->wbout1.fh, "%s", u);
 					page_buffer_add_string (u);
-					if (ccx_options.gui_mode_reports) // For now we just handle the easy stuff
+					if (tlt_config.gui_mode_reports) // For now we just handle the easy stuff
 						fprintf (stderr,"%s",u);
 				}
 			}
 		}
 
 		// no tag will left opened!
-		if ((!ccx_options.nofontcolor) && (font_tag_opened == YES)) {
+		if ((!tlt_config.nofontcolor) && (font_tag_opened == YES)) {
 			//if (ctx->wbout1.fh!=-1) fdprintf(ctx->wbout1.fh, "</font>");
 			page_buffer_add_string ("</font>");
 			font_tag_opened = NO;
 		}
 
-		if (ccx_options.gui_mode_reports)
+		if (tlt_config.gui_mode_reports)
 		{
 			fprintf (stderr,"\n");
 		}
 	}
 	time_reported=0;
 
-	switch (ccx_options.write_format)
+	switch (tlt_config.write_format)
 	{
 		case CCX_OF_TRANSCRIPT:
 			if (page_buffer_prev_used==0)
@@ -669,7 +669,7 @@ void process_page(struct lib_ccx_ctx *ctx, teletext_page_t *page) {
 	page_buffer_cur_used=0;
 	if (page_buffer_cur)
 		page_buffer_cur[0]=0;
-	if (ccx_options.gui_mode_reports)
+	if (tlt_config.gui_mode_reports)
 		fflush (stderr);
 }
 
@@ -921,7 +921,7 @@ void process_telx_packet(struct lib_ccx_ctx *ctx, data_unit_t data_unit_id, tele
 
 				dbg_print (CCX_DMT_TELETEXT, "- Transmission mode = %s\n", (transmission_mode == TRANSMISSION_MODE_SERIAL ? "serial" : "parallel"));
 
-				if (ccx_options.write_format == CCX_OF_TRANSCRIPT && ccx_options.date_format==ODF_DATE && !ccx_options.noautotimeref) {
+				if (tlt_config.write_format == CCX_OF_TRANSCRIPT && tlt_config.date_format==ODF_DATE && !tlt_config.noautotimeref) {
                     mprint ("- Broadcast Service Data Packet received, resetting UTC referential value to %s", ctime(&t0));
                     utc_refvalue = t;
                     states.pts_initialized = NO;
@@ -935,7 +935,7 @@ void process_telx_packet(struct lib_ccx_ctx *ctx, data_unit_t data_unit_id, tele
 
 void tlt_write_rcwt(struct lib_ccx_ctx *ctx, uint8_t data_unit_id, uint8_t *packet, uint64_t timestamp)
 {
-	if (ccx_options.send_to_srv) {
+	if (tlt_config.send_to_srv) {
 		net_send_cc((unsigned char *) &data_unit_id, sizeof(uint8_t));
 		net_send_cc((unsigned char *) &timestamp, sizeof(uint64_t));
 		net_send_cc((unsigned char *) packet, 44);
@@ -1080,7 +1080,7 @@ void tlt_process_pes_packet(struct lib_ccx_ctx *ctx, uint8_t *buffer, uint16_t s
 				// reverse endianess (via lookup table), ETS 300 706, chapter 7.1
 				for (uint8_t j = 0; j < data_unit_len; j++) buffer[i + j] = REVERSE_8[buffer[i + j]];
 
-				if (ccx_options.write_format == CCX_OF_RCWT)
+				if (tlt_config.write_format == CCX_OF_RCWT)
 					tlt_write_rcwt(ctx, data_unit_id, &buffer[i], last_timestamp);
 				else
 					// FIXME: This explicit type conversion could be a problem some day -- do not need to be platform independant
@@ -1184,7 +1184,7 @@ void telxcc_init(struct lib_ccx_ctx *ctx)
 	if (!telxcc_inited)
 	{
 		telxcc_inited=1;
-		if (ctx->wbout1.fh!=-1 && ccx_options.encoding!=CCX_ENC_UTF_8) // If encoding it UTF8 then this was already done
+		if (ctx->wbout1.fh!=-1 && tlt_config.encoding!=CCX_ENC_UTF_8) // If encoding it UTF8 then this was already done
 			fdprintf(ctx->wbout1.fh, "\xef\xbb\xbf");
 		memset (seen_sub_page,0,MAX_TLT_PAGES*sizeof (short int));
 	}
@@ -1193,7 +1193,7 @@ void telxcc_init(struct lib_ccx_ctx *ctx)
 // Close output
 void telxcc_close(struct lib_ccx_ctx *ctx)
 {
-	if (telxcc_inited && ccx_options.write_format != CCX_OF_RCWT)
+	if (telxcc_inited && tlt_config.write_format != CCX_OF_RCWT)
 	{
 		// output any pending close caption
 		if (page_buffer.tainted == YES) {

--- a/src/lib_ccx/utility.c
+++ b/src/lib_ccx/utility.c
@@ -67,7 +67,7 @@ void millis_to_date (uint64_t timestamp, char *buffer, enum ccx_output_date_form
 			secs=(time_t) (timestamp/1000);
 			millis=(time_t) (timestamp%1000);
 			sprintf (buffer, "%lu%c%03u", (unsigned long) secs,
-				ccx_options.millis_separator,(unsigned) millis);
+				millis_separator,(unsigned) millis);
 			break;
 		case ODF_DATE:
 			secs=(time_t) (timestamp/1000);

--- a/src/lib_ccx/utility.c
+++ b/src/lib_ccx/utility.c
@@ -45,13 +45,13 @@ int levenshtein_dist (const uint64_t *s1, const uint64_t *s2, unsigned s1len, un
 	return v;
 }
 
-void millis_to_date (uint64_t timestamp, char *buffer)
+void millis_to_date (uint64_t timestamp, char *buffer, enum ccx_output_date_format date_format, char millis_separator)
 {
 	time_t secs;
 	unsigned int millis;
 	char c_temp[80];
 	struct tm *time_struct=NULL;
-	switch (ccx_options.date_format)
+	switch (date_format)
 	{
 		case ODF_NONE:
 			buffer[0]=0;
@@ -74,8 +74,7 @@ void millis_to_date (uint64_t timestamp, char *buffer)
 			millis=(unsigned int) (timestamp%1000);
             time_struct = gmtime(&secs);
             strftime(c_temp, sizeof(c_temp), "%Y%m%d%H%M%S", time_struct);
-			sprintf (buffer,"%s%c%03u",c_temp,
-				ccx_options.millis_separator,millis);
+			sprintf (buffer,"%s%c%03u", c_temp, millis_separator, millis);
 			break;
 
 		default:


### PR DESCRIPTION
now use of global options ccx_options left only in ts parser(PAT, PMT)

Tested pull request using Willem TestSuite.

