### PR TITLE
Add iconv to EXTRA_LIBS in CMakeLists.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ aux_source_directory (${PROJECT_SOURCE_DIR} SOURCEFILE)
 set (EXTRA_LIBS ${EXTRA_LIBS} ccx)
 set (EXTRA_LIBS ${EXTRA_LIBS} png)
 set (EXTRA_LIBS ${EXTRA_LIBS} m)
+set (EXTRA_LIBS ${EXTRA_LIBS} iconv)
 
 ########################################################
 # Build using FFmpeg libraries


### PR DESCRIPTION
Compilation via cmake fails on OS X if libiconv is not specified as a required library:

```
Undefined symbols for architecture x86_64:
  "_iconv", referenced from:
      _EPG_DVB_decode_string in libccx.a(ts_tables_epg.c.o)
  "_iconv_close", referenced from:
      _EPG_DVB_decode_string in libccx.a(ts_tables_epg.c.o)
  "_iconv_open", referenced from:
      _EPG_DVB_decode_string in libccx.a(ts_tables_epg.c.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Adding it to EXTRA_LIBS in CMakeLists.txt is enough to make compilation successful.