### PR TITLE
flushing cc buffer every I, P slice for both fields

### DIFF
--- a/src/lib_ccx/avc_functions.c
+++ b/src/lib_ccx/avc_functions.c
@@ -984,7 +984,7 @@ void slice_header (struct lib_ccx_ctx *ctx, unsigned char *heabuf, unsigned char
 	}
 
 	// if slices are buffered - flush
-	if (isref && !bottom_field_flag)
+	if (isref)
 	{
 		dvprint("\nReference pic! [%s]\n", slice_types[slice_type]);
 		dbg_print(CCX_DMT_TIME, "\nReference pic! [%s] maxrefcnt: %3d\n",


### PR DESCRIPTION
fixes espn.ts but affects /repository/newRepository/TestFiles/XDS/9.mpg which is already broken. (it seems that it extracts more data now http://gsocdev.ccextractor.org/~ruslan/tests/Testsuite_Report_2015-06-10_081012/Report__XDS_2015-06-10_081753.html )