### PR TITLE
Eliminate the Mac OS warning

### DIFF
--- a/mac/README.MAC.TXT
+++ b/mac/README.MAC.TXT
@@ -1,8 +1,0 @@
-Note: I don't currently have a Mac to test Mac builds. An effort is done to ensure that CCExtractor is portable,
-which is why it compiles and works in Mac without any effort. But the build script (any of its 2 lines) is not
-maintained. If it doesn't compile for this version please fix and send me the new file so I can add it to the
-official version.
-
-I know this sucks but I can't really do much more. 
-
-Carlos


### PR DESCRIPTION
I've tested this on two machines running Mac OS 10.11.3. As long as gcc is installed (via Xcode or otherwise), everything works fine. This disclaimer does not appear to be warranted.