### PR TITLE
Fixing warning errors for GCC while compilation

### DIFF
--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -199,6 +199,8 @@ void print_file_report(struct lib_ccx_ctx *ctx);
 
 // output.c
 void dinit_write(struct ccx_s_write *wb);
+int temporarily_open_output(struct ccx_s_write *wb);
+int temporarily_close_output(struct ccx_s_write *wb);
 int init_write (struct ccx_s_write *wb,char *filename);
 int writeraw (const unsigned char *data, int length, void *private_data, struct cc_subtitle *sub);
 void flushbuffer (struct lib_ccx_ctx *ctx, struct ccx_s_write *wb, int closefile);

--- a/src/lib_ccx/ts_tables_epg.c
+++ b/src/lib_ccx/ts_tables_epg.c
@@ -81,7 +81,7 @@ void EPG_DVB_calc_start_time(struct EPG_event *event, uint64_t time)
 		y = y + k + 1900;
 		m = m - 1 - k*12;
 
-		sprintf(event->start_time_string, "%02ld%02ld%02ld%06llx +0000",y,m,d,time&0xffffff);
+		sprintf(event->start_time_string, "%02ld%02ld%02ld%06"PRIu64 "+0000",y,m,d,time&0xffffff);
 	}
 }
 


### PR DESCRIPTION
Function definitons in output.c
Fixed in lib_ccx.h