### PR TITLE
Fixed issue #288 : Segfault on using -sc for a blank line

### DIFF
--- a/src/lib_ccx/ccx_encoders_helpers.c
+++ b/src/lib_ccx/ccx_encoders_helpers.c
@@ -33,6 +33,26 @@ static const char *spell_builtin[] =
 
 int string_cmp2(const void *p1, const void *p2, void *arg)
 {
+	int flag = 0;
+	if(p1==NULL||p2==NULL)
+	{	
+		dbg_print (CCX_DMT_GENERIC_NOTICES, "\rNull pointer passed to string_cmp2\n");
+		flag = 1;
+	}
+	if(*(char**)p1==NULL)
+	{
+		dbg_print (CCX_DMT_GENERIC_NOTICES, "\rValue of arg1 of string_cmp2 is NULL\n");
+		flag = 1;
+	}
+	if(*(char**)p2==NULL)
+	{
+		dbg_print (CCX_DMT_GENERIC_NOTICES, "\rValue of arg2 of string_cmp2 is NULL\n");
+		flag = 1;
+	}
+	if(flag==1)
+	{
+		return 1; //Returning any non-zero value will not cause the seg-fault.
+	}
 	return strcasecmp(*(char**)p1, *(char**)p2);
 }
 int string_cmp(const void *p1, const void *p2)


### PR DESCRIPTION
The seg-fault would happen if the value of string p1 or p2 is null, which happens in a blank line. Returning a non-zero value for string_cmp2 (1 chosen arbitrarily here) if the null case happens prevents the seg-fault from happening.