### PR TITLE
Fixed a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ccextractor
 Carlos' version (mainstream) is the most stable branch.
 
 Extracting subtitles has never been so easy. Just type the following command:
-ccextrator "name of input"
+ccextractor "name of input"
 
 Gui lovers should download the Sorceforge version of CCExtractor, the Git Version is not your cup of tea.
 http://ccextractor.sourceforge.net/download-ccextractor.html


### PR DESCRIPTION
The command that was ccextrator "name of input" should have been ccextractor "name of input"