### PR TITLE
Fix #281. Crash issue in small file under 1Mib. & Referring Issue #270. Detailed error message when opening files 

### DIFF
--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -84,8 +84,22 @@ int main(int argc, char *argv[])
 	if (ccx_options.binary_concat)
 	{
 		ctx->total_inputsize=gettotalfilessize(ctx);
-		if (ctx->total_inputsize==-1)
-			fatal (EXIT_UNABLE_TO_DETERMINE_FILE_SIZE, "Failed to determine total file size.\n");
+		if (ctx->total_inputsize < 0)
+		{
+			switch (ctx->total_inputsize)
+			{
+			case -1*ENOENT:
+				fatal(EXIT_NO_INPUT_FILES, "Failed to open file: File not Exist");
+			case -1*EACCES:
+				fatal(EXIT_READ_ERROR, "Failed to open file: Unable to access");
+			case -1*EINVAL:
+				fatal(EXIT_READ_ERROR, "Failed to open file: Invalid opening flag.");
+			case -1*EMFILE:
+				fatal(EXIT_TOO_MANY_INPUT_FILES, "Failed to open file: Too many files are open.");
+			default:
+				fatal(EXIT_READ_ERROR, "Failed to open file: Reason unknown");
+			}
+		}
 	}
 
 #ifndef _WIN32

--- a/src/lib_ccx/ccx_common_constants.h
+++ b/src/lib_ccx/ccx_common_constants.h
@@ -35,7 +35,7 @@ extern unsigned char rcwt_header[11];
 #define EIA_708_BUFFER_LENGTH   2048 // TODO: Find out what the real limit is
 #define TS_PACKET_PAYLOAD_LENGTH     184     // From specs
 #define SUBLINESIZE 2048 // Max. length of a .srt line - TODO: Get rid of this
-#define STARTBYTESLENGTH	(1024*1024)
+#define STARTBYTESLENGTH	(100*1024)
 #define UTF8_MAX_BYTES 6
 
 #define XMLRPC_CHUNK_SIZE (64*1024) // 64 Kb per chunk, to avoid too many realloc()

--- a/src/lib_ccx/file_functions.c
+++ b/src/lib_ccx/file_functions.c
@@ -37,11 +37,23 @@ LLONG gettotalfilessize (struct lib_ccx_ctx *ctx) // -1 if one or more files fai
 #else
 		h = OPEN (ctx->inputfile[i], O_RDONLY);
 #endif
-		if (h == -1)
-		{
-			mprint ("\rUnable to open %s\r\n", ctx->inputfile[i]);
-			return -1;
+
+		if (h == -1) {
+			switch (errno)
+			{
+			case ENOENT:
+				return -1 * ENOENT;
+			case EACCES:
+				return -1 * EACCES;
+			case EINVAL:
+				return -1 * EINVAL;
+			case EMFILE:
+				return -1 * EMFILE;
+			default:
+				return -1;
+			}
 		}
+
 		if (!ccx_options.live_stream)
 			ts += getfilesize (h);
 		close (h);


### PR DESCRIPTION
First Commit

Because the default buffer size is set to 1024*1024. When encounters a file smaller than 1Mib, it will determined the file as done reading and close it without going through the processing loop before entering `LSEEK`  in `ccx_demuxer_getfilesize` in file `ccx_demuxer.c`, then it fails. 

The fix is just smaller the buffer size to 100K, which might be a hack but it works for most files.

=================================
Second commit.

Referring Issue #270. Detailed opening file error message.

I commit this before last PR merged, so they seems coming into one PR.