### PR TITLE
Check for number of args

### DIFF
--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -950,7 +950,7 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 
 		/*user specified subtitle to be selected */
 
-		if(!strcmp (argv[i],"-codec"))
+		if(!strcmp (argv[i],"-codec") && i < argc - 1)
 		{
 			i++;
 			if(!strcmp (argv[i],"teletext"))
@@ -969,7 +969,7 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		}
 		/*user specified subtitle to be selected */
 
-		if(!strcmp (argv[i],"-nocodec"))
+		if(!strcmp (argv[i],"-nocodec") && i < argc - 1)
 		{
 			i++;
 			if(!strcmp (argv[i],"teletext"))


### PR DESCRIPTION
Fixes #326

Usage of -codec and -nocodec options at the end without any following option
gives 'Segmentation fault'.

Added checks to overcome this.

Signed-off-by: Neha Bagari <neha.bagari.eee11@iitbhu.ac.in>