### PR TITLE
"mfra" mp4 box weight changed to 1.Fix #273

### DIFF
--- a/src/lib_ccx/stream_functions.c
+++ b/src/lib_ccx/stream_functions.c
@@ -423,7 +423,7 @@ ccx_stream_mp4_box ccx_stream_mp4_boxes[16] = {
 		{ "pdin", 1 }, // Progressive download information
 		{ "moov", 5 }, // Container for all metadata*
 		{ "moof", 4 }, // Movie fragment
-		{ "mfra", 3 }, // Movie fragment random access
+		{ "mfra", 1 }, // Movie fragment random access
 		{ "mdat", 2 }, // Media data container
 		{ "free", 1 }, // Free space
 		{ "skip", 1 }, // Free space

--- a/src/lib_ccx/stream_functions.c
+++ b/src/lib_ccx/stream_functions.c
@@ -195,7 +195,7 @@ int detect_myth( struct ccx_demuxer *ctx )
 {
 	int vbi_blocks=0;
 	// VBI data? if yes, use myth loop
-	// STARTBTYTESLENGTH is 1MB, if the file is shorter we will never detect
+	// STARTBYTESLENGTH is 1MB, if the file is shorter we will never detect
 	// it as a mythTV file
 	if (ctx->startbytes_avail==STARTBYTESLENGTH)
 	{


### PR DESCRIPTION
File-detecting program detect only "mfra" mp4 box in this video which is a trailer and it is assigned weight 3 in ccx_stream_mp4_boxes . So, program detects file as mp4. "mfra" box weight should be "1" so that other box too can confirm file is mp4. 