### PR TITLE
Fixing issues with ISDB

### DIFF
--- a/src/lib_ccx/ccx_common_option.c
+++ b/src/lib_ccx/ccx_common_option.c
@@ -57,6 +57,7 @@ void init_options (struct ccx_s_options *options)
 	options->xmltvonlycurrent=0; // 0 off 1 on
 	options->keep_output_closed = 0; // By default just keep the file open.
 	options->force_flush = 0; // Don't flush whenever content is writtern.
+	options->ucla = 0; // By default, -UCLA not used
 
 	options->transcript_settings = ccx_encoders_default_transcript_settings;
 	options->millis_separator=',';

--- a/src/lib_ccx/ccx_common_option.h
+++ b/src/lib_ccx/ccx_common_option.h
@@ -36,6 +36,7 @@ struct encoder_cfg
 	enum ccx_output_format write_format; // 0=Raw, 1=srt, 2=SMI
 	int keep_output_closed;
 	int force_flush; // Force flush on content write
+	int ucla; // 1 if -UCLA used, 0 if not
 	
 	enum ccx_encoding_type encoding;
 	enum ccx_output_date_format date_format;
@@ -115,6 +116,7 @@ struct ccx_s_options // Options from user parameters
 	int xmltvonlycurrent; // 0 off 1 on
 	int keep_output_closed;
 	int force_flush; // Force flush on content write
+	int ucla; // 1 if UCLA used, 0 if not
 
 	ccx_encoders_transcript_format transcript_settings; // Keeps the settings for generating transcript output files.
 	enum ccx_output_date_format date_format;

--- a/src/lib_ccx/ccx_decoders_isdb.c
+++ b/src/lib_ccx/ccx_decoders_isdb.c
@@ -1388,6 +1388,7 @@ int isdbsub_decode(struct lib_cc_decode *dec_ctx, const uint8_t *buf, size_t buf
 	const uint8_t *header_end = NULL;
 	int ret = 0;
 	ISDBSubContext *ctx = dec_ctx->private_data;
+	ctx->timestamp = get_fts(dec_ctx->timing, dec_ctx->current_field);
 	if(*buf++ != 0x80)
 	{
 		mprint("\nNot a Syncronised PES\n");

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -577,19 +577,19 @@ int write_cc_subtitle_as_transcript(struct cc_subtitle *sub, struct encoder_ctx 
 
 			if (context->transcript_settings->showStartTime)
 			{
-				char buf[80];
+				char buf1[80];
 				if (context->transcript_settings->relativeTimestamp)
 				{
-					millis_to_date(start_time + context->subs_delay, buf, context->date_format, context->millis_separator);
-					fdprintf(context->out->fh, "%s|", buf);
+					millis_to_date(start_time + context->subs_delay, buf1, context->date_format, context->millis_separator);
+					fdprintf(context->out->fh, "%s|", buf1);
 				}
 				else
 				{
 					time_t start_time_int = (start_time + context->subs_delay) / 1000;
 					int start_time_dec = (start_time + context->subs_delay) % 1000;
 					struct tm *start_time_struct = gmtime(&start_time_int);
-					strftime(buf, sizeof(buf), "%Y%m%d%H%M%S", start_time_struct);
-					fdprintf(context->out->fh, "%s%c%03d|", buf, context->millis_separator, start_time_dec);
+					strftime(buf1, sizeof(buf1), "%Y%m%d%H%M%S", start_time_struct);
+					fdprintf(context->out->fh, "%s%c%03d|", buf1, context->millis_separator, start_time_dec);
 				}
 			}
 
@@ -598,7 +598,7 @@ int write_cc_subtitle_as_transcript(struct cc_subtitle *sub, struct encoder_ctx 
 				char buf[80];
 				if (context->transcript_settings->relativeTimestamp)
 				{
-					millis_to_date(end_time, buf, context->date_format, context->millis_separator);
+					millis_to_date(end_time + context->subs_delay, buf, context->date_format, context->millis_separator);
 					fdprintf(context->out->fh, "%s|", buf);
 				}
 				else
@@ -616,7 +616,7 @@ int write_cc_subtitle_as_transcript(struct cc_subtitle *sub, struct encoder_ctx 
 				if(context->in_fileformat == 1)
 					//TODO, data->my_field == 1 ? data->channel : data->channel + 2); // Data from field 2 is CC3 or 4
 					fdprintf(context->out->fh, "CC?|");
-				else
+				else if (!context->ucla)
 					fdprintf(context->out->fh, sub->info);
 			}
 			if (context->transcript_settings->showMode)
@@ -1067,6 +1067,7 @@ static int init_output_ctx(struct encoder_ctx *ctx, struct encoder_cfg *cfg)
 	ctx->nb_out = nb_lang;
 	ctx->keep_output_closed = cfg->keep_output_closed;
 	ctx->force_flush = cfg->force_flush;
+	ctx->ucla = cfg->ucla;
 
 	if(cfg->cc_to_stdout == CCX_FALSE && cfg->send_to_srv == CCX_FALSE)
 	{
@@ -1256,6 +1257,7 @@ struct encoder_ctx *init_encoder(struct encoder_cfg *opt)
 	ctx->extract = opt->extract;
 	ctx->keep_output_closed = opt->keep_output_closed;
 	ctx->force_flush = opt->force_flush;
+	ctx->ucla = opt->ucla;
 
 	ctx->subline = (unsigned char *) malloc (SUBLINESIZE);
 	if(!ctx->subline)

--- a/src/lib_ccx/ccx_encoders_common.h
+++ b/src/lib_ccx/ccx_encoders_common.h
@@ -54,6 +54,8 @@ struct encoder_ctx
 	unsigned int keep_output_closed; 
 	/* Force a flush on the file buffer whenever content is written */
 	int force_flush;
+	/* Keep track of whether -UCLA used */
+	int ucla;
 
 	/* Flag saying BOM to be written in each output file */
 	enum ccx_encoding_type encoding;

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -1492,7 +1492,8 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		}
 		if (strcmp (argv[i],"-UCLA")==0 || strcmp (argv[i],"-ucla")==0)
 		{
-			opt->millis_separator='.';
+			opt->ucla = 1;
+			opt->millis_separator = '.';
 			opt->enc_cfg.no_bom = 1;
 			if (!opt->transcript_settings.isFinal){
 				opt->transcript_settings.showStartTime = 1;
@@ -1823,6 +1824,7 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 	opt->enc_cfg.millis_separator = opt->millis_separator;
 	opt->enc_cfg.no_font_color = opt->nofontcolor;
 	opt->enc_cfg.force_flush = opt->force_flush;
+	opt->enc_cfg.ucla = opt->ucla;
 	opt->enc_cfg.no_type_setting = opt->notypesetting;
 	opt->enc_cfg.subs_delay = opt->subs_delay;
 	if(opt->output_filename && opt->multiprogram == CCX_FALSE)


### PR DESCRIPTION
#284 
The current fix I have used is setting the current timestamp of the detected subtitle line to the FTS at that point. This makes the timestamps increment according to the time the subtitle was found in the file (which is correct), but the end time is considered as the start time of the next subtitle line (which is not always correct). In any case, it is a much more accurate representation and way better than the timestamps not incrementing at all.

Also, this pull request takes care of removing the "NA" in the third column when using -UCLA.