### PR TITLE
Fixing problems with XDS

### DIFF
--- a/src/lib_ccx/ccx_decoders_common.c
+++ b/src/lib_ccx/ccx_decoders_common.c
@@ -341,16 +341,15 @@ struct lib_cc_decode* init_cc_decode (struct ccx_decoders_common_settings_t *set
 
 	ctx->anchor_seq_number = -1;
 	// Init XDS buffers
-	int xds_write_to_file;
 	if(setting->output_format==CCX_OF_TRANSCRIPT)
 	{
-		xds_write_to_file = 1;
+		setting->xds_write_to_file = 1;
 	}
 	else
 	{
-		xds_write_to_file = 0;
+		setting->xds_write_to_file = 0;
 	}
-	ctx->xds_ctx = ccx_decoders_xds_init_library(ctx->timing, xds_write_to_file);
+	ctx->xds_ctx = ccx_decoders_xds_init_library(ctx->timing, setting->xds_write_to_file);
 
 	ctx->vbi_decoder = NULL;
 	return ctx;

--- a/src/lib_ccx/ccx_decoders_common.c
+++ b/src/lib_ccx/ccx_decoders_common.c
@@ -341,7 +341,16 @@ struct lib_cc_decode* init_cc_decode (struct ccx_decoders_common_settings_t *set
 
 	ctx->anchor_seq_number = -1;
 	// Init XDS buffers
-	ctx->xds_ctx = ccx_decoders_xds_init_library(ctx->timing, setting->ignore_xds);
+	int xds_write_to_file;
+	if(setting->output_format==CCX_OF_TRANSCRIPT)
+	{
+		xds_write_to_file = 1;
+	}
+	else
+	{
+		xds_write_to_file = 0;
+	}
+	ctx->xds_ctx = ccx_decoders_xds_init_library(ctx->timing, xds_write_to_file);
 
 	ctx->vbi_decoder = NULL;
 	return ctx;

--- a/src/lib_ccx/ccx_decoders_common.c
+++ b/src/lib_ccx/ccx_decoders_common.c
@@ -341,11 +341,7 @@ struct lib_cc_decode* init_cc_decode (struct ccx_decoders_common_settings_t *set
 
 	ctx->anchor_seq_number = -1;
 	// Init XDS buffers
-	if(setting->output_format==CCX_OF_TRANSCRIPT)
-	{
-		setting->xds_write_to_file = 1;
-	}
-	else
+	if(setting->output_format!=CCX_OF_TRANSCRIPT)
 	{
 		setting->xds_write_to_file = 0;
 	}

--- a/src/lib_ccx/ccx_decoders_common.c
+++ b/src/lib_ccx/ccx_decoders_common.c
@@ -341,11 +341,7 @@ struct lib_cc_decode* init_cc_decode (struct ccx_decoders_common_settings_t *set
 
 	ctx->anchor_seq_number = -1;
 	// Init XDS buffers
-	if(setting->ignore_xds == CCX_TRUE)
-		ctx->xds_ctx = NULL;
-	else
-		ctx->xds_ctx = ccx_decoders_xds_init_library(ctx->timing);
-	//xds_cea608_test(ctx->xds_ctx);
+	ctx->xds_ctx = ccx_decoders_xds_init_library(ctx->timing, setting->ignore_xds);
 
 	ctx->vbi_decoder = NULL;
 	return ctx;

--- a/src/lib_ccx/ccx_decoders_structs.h
+++ b/src/lib_ccx/ccx_decoders_structs.h
@@ -98,7 +98,7 @@ struct ccx_decoders_common_settings_t
 	unsigned int hauppauge_mode; // If 1, use PID=1003, process specially and so on
 	int program_number;
 	enum ccx_code_type codec;
-	int ignore_xds;
+	int xds_write_to_file;
 	void *private_data;
 };
 

--- a/src/lib_ccx/ccx_decoders_xds.c
+++ b/src/lib_ccx/ccx_decoders_xds.c
@@ -115,9 +115,11 @@ typedef struct ccx_decoders_xds_context
 	int cur_xds_packet_type;
 	struct ccx_common_timing_ctx *timing;
 
+	int ignore_xds;
+
 } ccx_decoders_xds_context_t;
 
-struct ccx_decoders_xds_context *ccx_decoders_xds_init_library(struct ccx_common_timing_ctx *timing)
+struct ccx_decoders_xds_context *ccx_decoders_xds_init_library(struct ccx_common_timing_ctx *timing, int ignore_xds)
 {
 	int i;
 	struct ccx_decoders_xds_context *ctx = NULL;
@@ -157,6 +159,8 @@ struct ccx_decoders_xds_context *ccx_decoders_xds_init_library(struct ccx_common
 	ctx->cur_xds_packet_type	= 0;
 	ctx->timing = timing;
 
+	ctx->ignore_xds = ignore_xds;
+
 	return ctx;
 }
 
@@ -192,6 +196,8 @@ int write_xds_string(struct cc_subtitle *sub, struct ccx_decoders_xds_context *c
 
 void xdsprint (struct cc_subtitle *sub, struct ccx_decoders_xds_context *ctx, const char *fmt,...)
 {
+	if(ctx->ignore_xds)
+		return;
 	/* Guess we need no more than 100 bytes. */
 	int n, size = 100;
 	char *p, *np;

--- a/src/lib_ccx/ccx_decoders_xds.c
+++ b/src/lib_ccx/ccx_decoders_xds.c
@@ -115,11 +115,11 @@ typedef struct ccx_decoders_xds_context
 	int cur_xds_packet_type;
 	struct ccx_common_timing_ctx *timing;
 
-	int ignore_xds;
+	int xds_write_to_file; // Set to 1 if XDS data is to be written to file
 
 } ccx_decoders_xds_context_t;
 
-struct ccx_decoders_xds_context *ccx_decoders_xds_init_library(struct ccx_common_timing_ctx *timing, int ignore_xds)
+struct ccx_decoders_xds_context *ccx_decoders_xds_init_library(struct ccx_common_timing_ctx *timing, int xds_write_to_file)
 {
 	int i;
 	struct ccx_decoders_xds_context *ctx = NULL;
@@ -159,7 +159,7 @@ struct ccx_decoders_xds_context *ccx_decoders_xds_init_library(struct ccx_common
 	ctx->cur_xds_packet_type	= 0;
 	ctx->timing = timing;
 
-	ctx->ignore_xds = ignore_xds;
+	ctx->xds_write_to_file = xds_write_to_file;
 
 	return ctx;
 }
@@ -196,7 +196,7 @@ int write_xds_string(struct cc_subtitle *sub, struct ccx_decoders_xds_context *c
 
 void xdsprint (struct cc_subtitle *sub, struct ccx_decoders_xds_context *ctx, const char *fmt,...)
 {
-	if(ctx->ignore_xds)
+	if(!ctx->xds_write_to_file)
 		return;
 	/* Guess we need no more than 100 bytes. */
 	int n, size = 100;

--- a/src/lib_ccx/ccx_decoders_xds.h
+++ b/src/lib_ccx/ccx_decoders_xds.h
@@ -7,7 +7,7 @@ struct ccx_decoders_xds_context;
 void process_xds_bytes (struct ccx_decoders_xds_context *ctx, const unsigned char hi, int lo);
 void do_end_of_xds (struct cc_subtitle *sub, struct ccx_decoders_xds_context *ctx, unsigned char expected_checksum);
 
-struct ccx_decoders_xds_context *ccx_decoders_xds_init_library(struct ccx_common_timing_ctx *timing);
+struct ccx_decoders_xds_context *ccx_decoders_xds_init_library(struct ccx_common_timing_ctx *timing, int ignore_xds);
 
 void xds_cea608_test();
 #endif

--- a/src/lib_ccx/ccx_decoders_xds.h
+++ b/src/lib_ccx/ccx_decoders_xds.h
@@ -7,7 +7,7 @@ struct ccx_decoders_xds_context;
 void process_xds_bytes (struct ccx_decoders_xds_context *ctx, const unsigned char hi, int lo);
 void do_end_of_xds (struct cc_subtitle *sub, struct ccx_decoders_xds_context *ctx, unsigned char expected_checksum);
 
-struct ccx_decoders_xds_context *ccx_decoders_xds_init_library(struct ccx_common_timing_ctx *timing, int ignore_xds);
+struct ccx_decoders_xds_context *ccx_decoders_xds_init_library(struct ccx_common_timing_ctx *timing, int xds_write_to_file);
 
 void xds_cea608_test();
 #endif

--- a/src/lib_ccx/lib_ccx.c
+++ b/src/lib_ccx/lib_ccx.c
@@ -31,16 +31,8 @@ static struct ccx_decoders_common_settings_t *init_decoder_setting(
 	setting->cc_channel = opt->cc_channel;
 	setting->send_to_srv = opt->send_to_srv;
 	setting->hauppauge_mode = opt->hauppauge_mode;
-	/* if in transcript setting xds is not selected then set ignore xds flag */
-	if(opt->write_format == CCX_OF_TRANSCRIPT)
-	{
-		setting->ignore_xds = !opt->transcript_settings.xds;
-	}
-	else
-	{
-		// Ignoring XDS for all formats except transcripts
-		setting->ignore_xds = 1;
-	}
+	setting->xds_write_to_file = opt->transcript_settings.xds;
+	
 	return setting;
 }
 static void dinit_decoder_setting (struct ccx_decoders_common_settings_t **setting)

--- a/src/lib_ccx/lib_ccx.c
+++ b/src/lib_ccx/lib_ccx.c
@@ -32,7 +32,15 @@ static struct ccx_decoders_common_settings_t *init_decoder_setting(
 	setting->send_to_srv = opt->send_to_srv;
 	setting->hauppauge_mode = opt->hauppauge_mode;
 	/* if in transcript setting xds is not selected then set ignore xds flag */
-	setting->ignore_xds = !opt->transcript_settings.xds;
+	if(opt->write_format == CCX_OF_TRANSCRIPT)
+	{
+		setting->ignore_xds = !opt->transcript_settings.xds;
+	}
+	else
+	{
+		// Ignoring XDS for all formats except transcripts
+		setting->ignore_xds = 1;
+	}
 	return setting;
 }
 static void dinit_decoder_setting (struct ccx_decoders_common_settings_t **setting)

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -1345,6 +1345,7 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		}
 		if (strcmp (argv[i],"-xdsdebug")==0)
 		{
+			opt->transcript_settings.xds = 1;
 			opt->debug_mask |= CCX_DMT_DECODER_XDS;
 			continue;
 		}


### PR DESCRIPTION
Fixes #347 
Always parsing XDS data. (ctx never initialized to null).
When using -xdsdebug, debug data always prints on screen but XDS data is written to file only in case of transcripts.