### PR TITLE
Small input file fixes

### DIFF
--- a/src/lib_ccx/file_functions.c
+++ b/src/lib_ccx/file_functions.c
@@ -298,6 +298,8 @@ void return_to_buffer (struct ccx_demuxer *ctx, unsigned char *buffer, unsigned 
  */
 size_t buffered_read_opt (struct ccx_demuxer *ctx, unsigned char *buffer, size_t bytes)
 {
+	size_t origin_bytes_length = bytes;
+	size_t file_size;
 	size_t copied   = 0;
 	time_t seconds = 0;
 
@@ -310,6 +312,9 @@ size_t buffered_read_opt (struct ccx_demuxer *ctx, unsigned char *buffer, size_t
 	{
 		// Needs to return data from filebuffer_start+pos to filebuffer_start+pos+bytes-1;
 		int eof = (ctx->infd == -1);
+		if (!eof) {
+			file_size = getfilesize(ctx->infd);
+		}
 
 		while ((!eof || ccx_options.live_stream) && bytes)
 		{
@@ -390,7 +395,7 @@ size_t buffered_read_opt (struct ccx_demuxer *ctx, unsigned char *buffer, size_t
 				{
 					/* If live stream, don't try to switch - acknowledge eof here as it won't
 					   cause a loop end */
-					if (ccx_options.live_stream || !(ccx_options.binary_concat && switch_to_next_file(ctx->parent, copied)))
+					if (ccx_options.live_stream || file_size <= origin_bytes_length || !(ccx_options.binary_concat && switch_to_next_file(ctx->parent, copied)))
 						eof = 1;
 				}
 				ctx->filebuffer_pos = keep;

--- a/src/lib_ccx/file_functions.c
+++ b/src/lib_ccx/file_functions.c
@@ -298,8 +298,7 @@ void return_to_buffer (struct ccx_demuxer *ctx, unsigned char *buffer, unsigned 
  */
 size_t buffered_read_opt (struct ccx_demuxer *ctx, unsigned char *buffer, size_t bytes)
 {
-	size_t origin_bytes_length = bytes;
-	size_t file_size;
+	size_t origin_buffer_size = bytes;
 	size_t copied   = 0;
 	time_t seconds = 0;
 
@@ -312,9 +311,6 @@ size_t buffered_read_opt (struct ccx_demuxer *ctx, unsigned char *buffer, size_t
 	{
 		// Needs to return data from filebuffer_start+pos to filebuffer_start+pos+bytes-1;
 		int eof = (ctx->infd == -1);
-		if (!eof) {
-			file_size = getfilesize(ctx->infd);
-		}
 
 		while ((!eof || ccx_options.live_stream) && bytes)
 		{
@@ -395,7 +391,7 @@ size_t buffered_read_opt (struct ccx_demuxer *ctx, unsigned char *buffer, size_t
 				{
 					/* If live stream, don't try to switch - acknowledge eof here as it won't
 					   cause a loop end */
-					if (ccx_options.live_stream || file_size <= origin_bytes_length || !(ccx_options.binary_concat && switch_to_next_file(ctx->parent, copied)))
+					if (ccx_options.live_stream || ((struct lib_ccx_ctx *)ctx->parent)->inputsize <= origin_buffer_size || !(ccx_options.binary_concat && switch_to_next_file(ctx->parent, copied)))
 						eof = 1;
 				}
 				ctx->filebuffer_pos = keep;


### PR DESCRIPTION
Successor of the #323 PR. Instead of calling it every time when buffered_read_opt is called, it's now using a built in variable that holds the size already.

Closes #277, closes #281, closes #287 