### PR TITLE
Fixes for --version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ build/
 *.opensdf
 *.user
 *.opendb
+
+####
+# Ignore the header file that is updated upon build
+src/lib_ccx/compile_info.h


### PR DESCRIPTION
- pre-build.sh executable by default now
- git ignore updated so the updated compile_info.h won't show up when
it's being changed after building CCExtractor

as reported by @abhishek-vinjamoori