### PR TITLE
Fixes #139 - Case fixing in teletext

### DIFF
--- a/src/lib_ccx/ccx_encoders_helpers.c
+++ b/src/lib_ccx/ccx_encoders_helpers.c
@@ -73,6 +73,39 @@ void correct_case(int line_num, struct eia608_screen *data)
 	free(line);
 }
 
+void telx_correct_case(char *sub_line)
+{
+	char delim[64] = {
+		' ', '\n', '\r', 0x89, 0x99,
+		'!', '"', '#', '%', '&',
+		'\'', '(', ')', ';', '<',
+		'=', '>', '?', '[', '\\',
+		']', '*', '+', ',', '-',
+		'.', '/', ':', '^', '_',
+		'{', '|', '}', '~', '\0' };
+
+	char *line = strdup(((char*)sub_line));
+	char *oline = (char*)sub_line;
+	char *c = strtok(line, delim);
+	if (c == NULL)
+	{
+		free(line);
+		return;
+	}
+	do
+	{
+		char **index = bsearch(&c, spell_lower, spell_words, sizeof(*spell_lower), string_cmp);
+
+		if (index)
+		{
+			char *correct_c = *(spell_correct + (index - spell_lower));
+			size_t len = strlen(correct_c);
+			memcpy(oline + (c - line), correct_c, len);
+		}
+	} while ((c = strtok(NULL, delim)) != NULL);
+	free(line);
+}
+
 void capitalize(struct encoder_ctx *context, int line_num, struct eia608_screen *data)
 {
 	for (int i = 0; i < CCX_DECODER_608_SCREEN_WIDTH; i++)

--- a/src/lib_ccx/ccx_encoders_helpers.h
+++ b/src/lib_ccx/ccx_encoders_helpers.h
@@ -24,7 +24,7 @@ struct ccx_encoders_helpers_settings_t {
 // Helper functions
 void correct_case(int line_num, struct eia608_screen *data);
 void capitalize(struct encoder_ctx *context, int line_num, struct eia608_screen *data);
-void telx_correct_case();
+void telx_correct_case(char *sub_line);
 unsigned get_decoder_line_encoded_for_gui(unsigned char *buffer, int line_num, struct eia608_screen *data);
 unsigned get_decoder_line_encoded(struct encoder_ctx *ctx, unsigned char *buffer, int line_num, struct eia608_screen *data);
 

--- a/src/lib_ccx/ccx_encoders_helpers.h
+++ b/src/lib_ccx/ccx_encoders_helpers.h
@@ -24,6 +24,7 @@ struct ccx_encoders_helpers_settings_t {
 // Helper functions
 void correct_case(int line_num, struct eia608_screen *data);
 void capitalize(struct encoder_ctx *context, int line_num, struct eia608_screen *data);
+void telx_correct_case();
 unsigned get_decoder_line_encoded_for_gui(unsigned char *buffer, int line_num, struct eia608_screen *data);
 unsigned get_decoder_line_encoded(struct encoder_ctx *ctx, unsigned char *buffer, int line_num, struct eia608_screen *data);
 

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -582,7 +582,7 @@ int process_data(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, str
 	else if (data_node->bufferdatatype == CCX_TELETEXT)
 	{
 		//telxcc_update_gt(dec_ctx->private_data, ctx->demux_ctx->global_timestamp);
-		ret = tlt_process_pes_packet (dec_ctx, data_node->buffer, data_node->len, dec_sub);
+		ret = tlt_process_pes_packet (dec_ctx, data_node->buffer, data_node->len, dec_sub, enc_ctx->sentence_cap);
 		if(ret == CCX_EINVAL)
 			return ret;
 		got = data_node->len;

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -248,7 +248,7 @@ void m_signal(int sig, void (*func)(int));
 void buffered_seek (struct ccx_demuxer *ctx, int offset);
 extern void build_parity_table(void);
 
-int tlt_process_pes_packet(struct lib_cc_decode *dec_ctx, uint8_t *buffer, uint16_t size, struct cc_subtitle *sub);
+int tlt_process_pes_packet(struct lib_cc_decode *dec_ctx, uint8_t *buffer, uint16_t size, struct cc_subtitle *sub, int sentence_cap);
 void* telxcc_init(void);
 void telxcc_close(void **ctx, struct cc_subtitle *sub);
 void tlt_read_rcwt(void *codec, unsigned char *buf, struct cc_subtitle *sub);

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -928,7 +928,6 @@ void process_page(struct TeletextCtx *ctx, teletext_page_t *page, struct cc_subt
 		default:
 			if (ctx->sentence_cap)
 				telx_case_fix(ctx);
-			printf("%s\n", ctx->page_buffer_cur);
 			add_cc_sub_text(sub, ctx->page_buffer_cur, page->show_timestamp,
 				page->hide_timestamp + 1, NULL, "TLT", CCX_ENC_UTF_8);
 	}


### PR DESCRIPTION
Applying modified 'capitalize' and 'correct_case' functions for teletext with the same logic.