### PR TITLE
Reducing Memory Consumption

### DIFF
--- a/src/lib_ccx/ccx_demuxer.c
+++ b/src/lib_ccx/ccx_demuxer.c
@@ -168,7 +168,7 @@ static int ccx_demuxer_open(struct ccx_demuxer *ctx, const char *file)
 			{
 				case CCX_SM_ELEMENTARY_OR_NOT_FOUND:
 				case CCX_SM_PROGRAM:
-					if ( detect_myth(ctx->parent) )
+					if ( detect_myth(ctx) )
 					{
 						ctx->stream_mode=CCX_SM_MYTH;
 					}

--- a/src/lib_ccx/file_functions.c
+++ b/src/lib_ccx/file_functions.c
@@ -83,18 +83,21 @@ void prepare_for_new_file (struct lib_ccx_ctx *ctx)
 	pts_big_change              = 0;
 	firstcall                   = 1;
 
-	for(int x = 0; x < 0xfff; x++)
+	if(ccx_options.xmltv)
 	{
-		ctx->epg_buffers[x].buffer   = NULL;
-		ctx->epg_buffers[x].ccounter = 0;
+		for(int x = 0; x < 0xfff; x++)
+		{
+			ctx->epg_buffers[x].buffer   = NULL;
+			ctx->epg_buffers[x].ccounter = 0;
+		}
+		for (int i = 0; i < TS_PMT_MAP_SIZE; i++)
+		{
+			ctx->eit_programs[i].array_len = 0;
+			ctx->eit_current_events[i] = -1;
+		}
+		ctx->epg_last_output      = -1;
+		ctx->epg_last_live_output = -1;
 	}
-	for (int i = 0; i < TS_PMT_MAP_SIZE; i++)
-	{
-		ctx->eit_programs[i].array_len = 0;
-		ctx->eit_current_events[i] = -1;
-	}
-	ctx->epg_last_output      = -1;
-	ctx->epg_last_live_output = -1;
 }
 
 /* Close input file if there is one and let the GUI know */

--- a/src/lib_ccx/file_functions.c
+++ b/src/lib_ccx/file_functions.c
@@ -83,7 +83,7 @@ void prepare_for_new_file (struct lib_ccx_ctx *ctx)
 	pts_big_change              = 0;
 	firstcall                   = 1;
 
-	if(ccx_options.xmltv)
+	if(ctx->epg_inited)
 	{
 		for(int x = 0; x < 0xfff; x++)
 		{

--- a/src/lib_ccx/lib_ccx.c
+++ b/src/lib_ccx/lib_ccx.c
@@ -100,6 +100,7 @@ struct lib_ccx_ctx* init_libraries(struct ccx_s_options *opt)
 
 	if(opt->xmltv)
 	{
+		ctx->epg_inited = 1;
 		ctx->epg_buffers = (struct PSI_buffer *)malloc(sizeof(struct PSI_buffer)*(0xfff+1));
 		ctx->eit_programs = (struct EIT_program *)malloc(sizeof(struct EIT_program)*(TS_PMT_MAP_SIZE+1));
 		ctx->eit_current_events = (int32_t *)malloc(sizeof(int32_t)*(TS_PMT_MAP_SIZE+1));
@@ -110,6 +111,14 @@ struct lib_ccx_ctx* init_libraries(struct ccx_s_options *opt)
 		memset(ctx->ATSC_source_pg_map, 0, sizeof(int16_t)*(0xffff));
 		if(!ctx->epg_buffers || !ctx->eit_programs || !ctx->eit_current_events || !ctx->ATSC_source_pg_map)
 			ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "lib_ccx_ctx");
+	}
+	else
+	{
+		ctx->epg_inited = 0;
+		ctx->epg_buffers = NULL;
+		ctx->eit_programs = NULL;
+		ctx->eit_current_events = NULL;
+		ctx->ATSC_source_pg_map = NULL;
 	}
 
 	struct ccx_decoder_608_report *report_608 = malloc(sizeof(struct ccx_decoder_608_report));
@@ -223,8 +232,7 @@ void dinit_libraries( struct lib_ccx_ctx **ctx)
 	}
 
 	// free EPG memory
-	if(ccx_options.xmltv)
-		EPG_free(lctx);
+	EPG_free(lctx);
 	freep(&lctx->freport.data_from_608);
 	freep(&lctx->freport.data_from_708);
 	ccx_demuxer_delete(&lctx->demux_ctx);

--- a/src/lib_ccx/lib_ccx.c
+++ b/src/lib_ccx/lib_ccx.c
@@ -98,6 +98,20 @@ struct lib_ccx_ctx* init_libraries(struct ccx_s_options *opt)
 		ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "lib_ccx_ctx");
 	memset(ctx, 0, sizeof(struct lib_ccx_ctx));
 
+	if(opt->xmltv)
+	{
+		ctx->epg_buffers = (struct PSI_buffer *)malloc(sizeof(struct PSI_buffer)*(0xfff+1));
+		ctx->eit_programs = (struct EIT_program *)malloc(sizeof(struct EIT_program)*(TS_PMT_MAP_SIZE+1));
+		ctx->eit_current_events = (int32_t *)malloc(sizeof(int32_t)*(TS_PMT_MAP_SIZE+1));
+		ctx->ATSC_source_pg_map = (int16_t *)malloc(sizeof(int16_t)*(0xffff));
+		memset(ctx->epg_buffers, 0, sizeof(struct PSI_buffer)*(0xfff+1));
+		memset(ctx->eit_programs, 0, sizeof(struct EIT_program)*(TS_PMT_MAP_SIZE+1));
+		memset(ctx->eit_current_events, 0, sizeof(int32_t)*(TS_PMT_MAP_SIZE+1));
+		memset(ctx->ATSC_source_pg_map, 0, sizeof(int16_t)*(0xffff));
+		if(!ctx->epg_buffers || !ctx->eit_programs || !ctx->eit_current_events || !ctx->ATSC_source_pg_map)
+			ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "lib_ccx_ctx");
+	}
+
 	struct ccx_decoder_608_report *report_608 = malloc(sizeof(struct ccx_decoder_608_report));
 	if (!report_608)
 		ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "report_608");
@@ -209,7 +223,8 @@ void dinit_libraries( struct lib_ccx_ctx **ctx)
 	}
 
 	// free EPG memory
-	EPG_free(lctx);
+	if(ccx_options.xmltv)
+		EPG_free(lctx);
 	freep(&lctx->freport.data_from_608);
 	freep(&lctx->freport.data_from_708);
 	ccx_demuxer_delete(&lctx->demux_ctx);

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -115,10 +115,10 @@ struct lib_ccx_ctx
 
 	unsigned teletext_warning_shown; // Did we detect a possible PAL (with teletext subs) and told the user already?
 
-	struct PSI_buffer epg_buffers[0xfff+1];
-	struct EIT_program eit_programs[TS_PMT_MAP_SIZE+1];
-	int32_t eit_current_events[TS_PMT_MAP_SIZE+1];
-	int16_t ATSC_source_pg_map[0xffff];
+	struct PSI_buffer *epg_buffers;
+	struct EIT_program *eit_programs;
+	int32_t *eit_current_events;
+	int16_t *ATSC_source_pg_map;
 	int epg_last_output; 
 	int epg_last_live_output; 
 	struct file_report freport;

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -115,6 +115,7 @@ struct lib_ccx_ctx
 
 	unsigned teletext_warning_shown; // Did we detect a possible PAL (with teletext subs) and told the user already?
 
+	int epg_inited;
 	struct PSI_buffer *epg_buffers;
 	struct EIT_program *eit_programs;
 	int32_t *eit_current_events;

--- a/src/lib_ccx/ts_tables_epg.c
+++ b/src/lib_ccx/ts_tables_epg.c
@@ -1096,13 +1096,16 @@ void parse_EPG_packet(struct lib_ccx_ctx *ctx)
 
 // Free all memory used for EPG parsing
 void EPG_free(struct lib_ccx_ctx *ctx)
-{
-	if(ccx_options.xmltv==2 || ccx_options.xmltv==3 || ccx_options.send_to_srv)
+{	
+	if(ctx->epg_inited)
 	{
-		if (ccx_options.send_to_srv)
-			EPG_output_net(ctx);
-		else
-			EPG_output_live(ctx);
+		if(ccx_options.xmltv==2 || ccx_options.xmltv==3 || ccx_options.send_to_srv)
+		{
+			if (ccx_options.send_to_srv)
+				EPG_output_net(ctx);
+			else
+				EPG_output_live(ctx);
+		}
 	}
 	free(ctx->epg_buffers);
 	free(ctx->eit_programs);

--- a/src/lib_ccx/ts_tables_epg.c
+++ b/src/lib_ccx/ts_tables_epg.c
@@ -1097,7 +1097,6 @@ void parse_EPG_packet(struct lib_ccx_ctx *ctx)
 // Free all memory used for EPG parsing
 void EPG_free(struct lib_ccx_ctx *ctx)
 {
-	int i = 0, j;
 	if(ccx_options.xmltv==2 || ccx_options.xmltv==3 || ccx_options.send_to_srv)
 	{
 		if (ccx_options.send_to_srv)
@@ -1105,28 +1104,8 @@ void EPG_free(struct lib_ccx_ctx *ctx)
 		else
 			EPG_output_live(ctx);
 	}
-	for (i = 0; i < TS_PMT_MAP_SIZE; i++)
-	{
-		for(j = 0; j < ctx->eit_programs[i].array_len; j++)
-		{
-			if(ctx->eit_programs[i].epg_events[j].has_simple)
-			{
-				free(ctx->eit_programs[i].epg_events[j].event_name);
-				free(ctx->eit_programs[i].epg_events[j].text);
-			}
-			if(ctx->eit_programs[i].epg_events[j].extended_text!=NULL)
-				free(ctx->eit_programs[i].epg_events[j].extended_text);
-			if(ctx->eit_programs[i].epg_events[j].num_ratings>0)
-				free(ctx->eit_programs[i].epg_events[j].ratings);
-			if(ctx->eit_programs[i].epg_events[j].num_categories>0)
-				free(ctx->eit_programs[i].epg_events[j].categories);
-		}
-		ctx->eit_programs[i].array_len=0;
-	}
-	
-	for (i = 0; i < 0xfff; i++)
-	{
-		if(ctx->epg_buffers[i].buffer!=NULL)
-			free(ctx->epg_buffers[i].buffer);
-	}
+	free(ctx->epg_buffers);
+	free(ctx->eit_programs);
+	free(ctx->eit_current_events);
+	free(ctx->ATSC_source_pg_map);
 }


### PR DESCRIPTION
Fixes #353 
EPG variables were being initialized and taking up memory or around 180 MB while never being used. Fixed this by initializing them only when necessary.

Also includes a fix to passing the wrong context to the detect_myth() function, which was surprisingly still working with the live repository.