### PR TITLE
Bug Fix for DVB Color

### DIFF
--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -409,6 +409,10 @@ char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* i
 				}
 
 				h0=h;
+
+				freep(&histogram);
+				freep(&mcit);
+				freep(&iot);
 				
 			} while (TessPageIteratorNext((TessPageIterator *)ri,level));
 

--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -207,7 +207,7 @@ char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* i
 	text_out = TessBaseAPIGetUTF8Text(ctx->api);
 
 	// Begin color detection
-	if(ccx_options.dvbcolor)
+	if(ccx_options.dvbcolor && strlen(text_out)>0)
 	{
 		float h0 = -100;
 		int written_tag = 0;

--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -432,6 +432,8 @@ char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* i
 			}
 		}
 
+		TessResultIteratorDelete(ri);
+
 	}
 	// End Color Detection
 


### PR DESCRIPTION
Fixing segfault for an empty line returned by Tesseract.
Also freeing color tables.