### PR TITLE
Cosmetic: Reordering definitions in the `ccx_encoders_common.h`

### DIFF
--- a/src/lib_ccx/ccx_encoders_common.h
+++ b/src/lib_ccx/ccx_encoders_common.h
@@ -161,41 +161,39 @@ void dinit_encoder(struct encoder_ctx **arg, LLONG current_fts);
  */
 int encode_sub(struct encoder_ctx *ctx,struct cc_subtitle *sub);
 
-int write_cc_buffer_as_g608(struct eia608_screen *data, struct encoder_ctx *context);
+int write_cc_buffer_as_srt            (struct eia608_screen *data, struct encoder_ctx *context);
+int write_cc_buffer_as_webvtt         (struct eia608_screen *data, struct encoder_ctx *context);
+int write_cc_buffer_as_sami           (struct eia608_screen *data, struct encoder_ctx *context);
+int write_cc_buffer_as_smptett        (struct eia608_screen *data, struct encoder_ctx *context);
+void write_cc_buffer_to_gui           (struct eia608_screen *data, struct encoder_ctx *context);
 
-int write_cc_buffer_as_srt(struct eia608_screen *data, struct encoder_ctx *context);
-int write_cc_subtitle_as_srt(struct cc_subtitle *sub, struct encoder_ctx *context);
-int write_stringz_as_srt(char *string, struct encoder_ctx *context, LLONG ms_start, LLONG ms_end);
+int write_cc_buffer_as_g608           (struct eia608_screen *data, struct encoder_ctx *context);
+int write_cc_buffer_as_transcript2    (struct eia608_screen *data, struct encoder_ctx *context);
 
-int write_cc_buffer_as_webvtt(struct eia608_screen *data, struct encoder_ctx *context);
-int write_cc_subtitle_as_webvtt(struct cc_subtitle *sub, struct encoder_ctx *context);
-int write_stringz_as_webvtt(char *string, struct encoder_ctx *context, LLONG ms_start, LLONG ms_end);
+void write_cc_line_as_transcript2     (struct eia608_screen *data, struct encoder_ctx *context, int line_number);
 
-int write_cc_buffer_as_sami(struct eia608_screen *data, struct encoder_ctx *context);
-int write_stringz_as_sami(char *string, struct encoder_ctx *context, LLONG ms_start, LLONG ms_end);
-int write_cc_subtitle_as_sami(struct cc_subtitle *sub, struct encoder_ctx *context);
+int write_cc_subtitle_as_srt          (struct cc_subtitle *sub, struct encoder_ctx *context);
+int write_cc_subtitle_as_webvtt       (struct cc_subtitle *sub, struct encoder_ctx *context);
+int write_cc_subtitle_as_sami         (struct cc_subtitle *sub, struct encoder_ctx *context);
+int write_cc_subtitle_as_smptett      (struct cc_subtitle *sub, struct encoder_ctx *context);
+int write_cc_subtitle_as_spupng       (struct cc_subtitle *sub, struct encoder_ctx *context);
+int write_cc_subtitle_as_transcript   (struct cc_subtitle *sub, struct encoder_ctx *context);
 
-int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *context);
-void write_stringz_as_smptett(char *string, struct encoder_ctx *context, LLONG ms_start, LLONG ms_end);
-int write_cc_subtitle_as_smptett(struct cc_subtitle *sub, struct encoder_ctx *context);
 
-void write_cc_buffer_to_gui(struct eia608_screen *data, struct encoder_ctx *context);
+int write_stringz_as_srt              (char *string, struct encoder_ctx *context, LLONG ms_start, LLONG ms_end);
+int write_stringz_as_webvtt           (char *string, struct encoder_ctx *context, LLONG ms_start, LLONG ms_end);
+int write_stringz_as_sami             (char *string, struct encoder_ctx *context, LLONG ms_start, LLONG ms_end);
+void write_stringz_as_smptett         (char *string, struct encoder_ctx *context, LLONG ms_start, LLONG ms_end);
 
-int write_cc_bitmap_as_spupng(struct cc_subtitle *sub, struct encoder_ctx *context);
-int write_cc_subtitle_as_spupng(struct cc_subtitle *sub, struct encoder_ctx *context);
 
-int write_cc_bitmap_as_srt(struct cc_subtitle *sub, struct encoder_ctx *context);
-int write_cc_bitmap_as_webvtt(struct cc_subtitle *sub, struct encoder_ctx *context);
-int write_cc_bitmap_as_sami(struct cc_subtitle *sub, struct encoder_ctx *context);
-int write_cc_bitmap_as_smptett(struct cc_subtitle *sub, struct encoder_ctx *context);
-
-int write_cc_bitmap_to_sentence_buffer(struct cc_subtitle *sub, struct encoder_ctx *context);
-int write_cc_bitmap_as_libcurl(struct cc_subtitle *sub, struct encoder_ctx *context);
-
-int write_cc_bitmap_as_transcript(struct cc_subtitle *sub, struct encoder_ctx *context);
-int write_cc_buffer_as_transcript2(struct eia608_screen *data, struct encoder_ctx *context);
-void write_cc_line_as_transcript2(struct eia608_screen *data, struct encoder_ctx *context, int line_number);
-int write_cc_subtitle_as_transcript(struct cc_subtitle *sub, struct encoder_ctx *context);
+int write_cc_bitmap_as_srt             (struct cc_subtitle *sub, struct encoder_ctx *context);
+int write_cc_bitmap_as_webvtt          (struct cc_subtitle *sub, struct encoder_ctx *context);
+int write_cc_bitmap_as_sami            (struct cc_subtitle *sub, struct encoder_ctx *context);
+int write_cc_bitmap_as_smptett         (struct cc_subtitle *sub, struct encoder_ctx *context);
+int write_cc_bitmap_as_spupng          (struct cc_subtitle *sub, struct encoder_ctx *context);
+int write_cc_bitmap_as_transcript      (struct cc_subtitle *sub, struct encoder_ctx *context);
+int write_cc_bitmap_to_sentence_buffer (struct cc_subtitle *sub, struct encoder_ctx *context);
+int write_cc_bitmap_as_libcurl         (struct cc_subtitle *sub, struct encoder_ctx *context);
 
 
 


### PR DESCRIPTION
Reordering definitions in the `ccx_encoders_common.h` to make it easier to read.

I just changed the order of definitions in .h file and added some spaces