### PR TITLE
GCI: Clean up function names and refactor some code.

### DIFF
--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -119,7 +119,7 @@ int main(int argc, char *argv[])
 
 	if (ccx_options.binary_concat)
 	{
-		ctx->total_inputsize=gettotalfilessize(ctx);
+		ctx->total_inputsize=get_total_file_size(ctx);
 		if (ctx->total_inputsize < 0)
 		{
 			switch (ctx->total_inputsize)

--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -233,6 +233,8 @@ int main(int argc, char *argv[])
 			case CCX_SM_HEX_DUMP:
 				close_input_file(ctx); // processhex will open it in text mode
 				processhex (ctx, ctx->inputfile[0]);
+				close_input_file(ctx); // process_hex will open it in text mode
+				process_hex (ctx, ctx->inputfile[0]);
 				break;
 #endif
 			case CCX_SM_AUTODETECT:

--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -231,8 +231,6 @@ int main(int argc, char *argv[])
 				break;
 #ifdef WTV_DEBUG
 			case CCX_SM_HEX_DUMP:
-				close_input_file(ctx); // processhex will open it in text mode
-				processhex (ctx, ctx->inputfile[0]);
 				close_input_file(ctx); // process_hex will open it in text mode
 				process_hex (ctx, ctx->inputfile[0]);
 				break;

--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
 	ret = parse_parameters (&ccx_options, argc, argv);
 	if (ret == EXIT_NO_INPUT_FILES)
 	{
-		usage ();
+		print_usage ();
 		fatal (EXIT_NO_INPUT_FILES, "(This help screen was shown because there were no input files)\n");
 	}
 	else if (ret == EXIT_WITH_HELP)

--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -84,8 +84,8 @@ int main(int argc, char *argv[])
 
 #ifdef WITH_LIBCURL
 	curl_global_init(CURL_GLOBAL_ALL);
- 
-  	/* get a curl handle */ 
+
+  	/* get a curl handle */
   	curl = curl_easy_init();
 	if (!curl)
 	{
@@ -205,7 +205,7 @@ int main(int argc, char *argv[])
 			case CCX_SM_FFMPEG:
 #endif
 				if (!ccx_options.use_gop_as_pts) // If !0 then the user selected something
-					ccx_options.use_gop_as_pts = 0; 
+					ccx_options.use_gop_as_pts = 0;
 				mprint ("\rAnalyzing data in general mode\n");
 				general_loop(ctx);
 				break;
@@ -244,22 +244,22 @@ int main(int argc, char *argv[])
 		{
 			mprint("\n");
 			dbg_print(CCX_DMT_DECODER_608, "\nTime stamps after last caption block was written:\n");
-			dbg_print(CCX_DMT_DECODER_608, "GOP: %s	  \n", print_mstime(gop_time.ms) );
-	
+			dbg_print(CCX_DMT_DECODER_608, "GOP: %s	  \n", print_mstime_static(gop_time.ms) );
+
 			dbg_print(CCX_DMT_DECODER_608, "GOP: %s (%+3dms incl.)\n",
-				print_mstime((LLONG)(gop_time.ms
+				print_mstime_static((LLONG)(gop_time.ms
 				-first_gop_time.ms
 				+get_fts_max(dec_ctx->timing)-fts_at_gop_start)),
 				(int)(get_fts_max(dec_ctx->timing)-fts_at_gop_start));
 			// When padding is active the CC block time should be within
 			// 1000/29.97 us of the differences.
 			dbg_print(CCX_DMT_DECODER_608, "Max. FTS:	   %s  (without caption blocks since then)\n",
-				print_mstime(get_fts_max(dec_ctx->timing)));
+				print_mstime_static(get_fts_max(dec_ctx->timing)));
 
 			if (dec_ctx->codec == CCX_CODEC_ATSC_CC)
 			{
 				mprint ("\nTotal frames time:	  %s  (%u frames at %.2ffps)\n",
-				print_mstime( (LLONG)(total_frames_count*1000/current_fps) ),
+				print_mstime_static( (LLONG)(total_frames_count*1000/current_fps) ),
 				total_frames_count, current_fps);
 			}
 
@@ -273,7 +273,7 @@ int main(int argc, char *argv[])
 			// Add one frame as fts_max marks the beginning of the last frame,
 			// but we need the end.
 			dec_ctx->timing->fts_global += dec_ctx->timing->fts_max + (LLONG) (1000.0/current_fps);
-			// CFS: At least in Hauppage mode, cb_field can be responsible for ALL the 
+			// CFS: At least in Hauppage mode, cb_field can be responsible for ALL the
 			// timing (cb_fields having a huge number and fts_now and fts_global being 0 all
 			// the time), so we need to take that into account in fts_global before resetting
 			// counters.
@@ -284,11 +284,11 @@ int main(int argc, char *argv[])
 			else
 				dec_ctx->timing->fts_global += cb_708*1001/3;
 			// Reset counters - This is needed if some captions are still buffered
-			// and need to be written after the last file is processed.		
+			// and need to be written after the last file is processed.
 			cb_field1 = 0; cb_field2 = 0; cb_708 = 0;
 			dec_ctx->timing->fts_now = 0;
 			dec_ctx->timing->fts_max = 0;
-		
+
 #ifdef ENABLE_SHARING
 			if (ccx_options.sharing_enabled)
 			{
@@ -299,20 +299,20 @@ int main(int argc, char *argv[])
 
 		if (dec_ctx->total_pulldownframes)
 			mprint ("incl. pulldown frames:  %s  (%u frames at %.2ffps)\n",
-					print_mstime( (LLONG)(dec_ctx->total_pulldownframes*1000/current_fps) ),
+					print_mstime_static( (LLONG)(dec_ctx->total_pulldownframes*1000/current_fps) ),
 					dec_ctx->total_pulldownframes, current_fps);
 		if (dec_ctx->timing->pts_set >= 1 && dec_ctx->timing->min_pts != 0x01FFFFFFFFLL)
 		{
 			LLONG postsyncms = (LLONG) (dec_ctx->frames_since_last_gop*1000/current_fps);
 			mprint ("\nMin PTS:				%s\n",
-					print_mstime( dec_ctx->timing->min_pts/(MPEG_CLOCK_FREQ/1000) - dec_ctx->timing->fts_offset));
+					print_mstime_static( dec_ctx->timing->min_pts/(MPEG_CLOCK_FREQ/1000) - dec_ctx->timing->fts_offset));
 			if (pts_big_change)
 				mprint ("(Reference clock was reset at some point, Min PTS is approximated)\n");
 			mprint ("Max PTS:				%s\n",
-					print_mstime( dec_ctx->timing->sync_pts/(MPEG_CLOCK_FREQ/1000) + postsyncms));
+					print_mstime_static( dec_ctx->timing->sync_pts/(MPEG_CLOCK_FREQ/1000) + postsyncms));
 
 			mprint ("Length:				 %s\n",
-					print_mstime( dec_ctx->timing->sync_pts/(MPEG_CLOCK_FREQ/1000) + postsyncms
+					print_mstime_static( dec_ctx->timing->sync_pts/(MPEG_CLOCK_FREQ/1000) + postsyncms
 								  - dec_ctx->timing->min_pts/(MPEG_CLOCK_FREQ/1000) + dec_ctx->timing->fts_offset ));
 		}
 
@@ -321,15 +321,15 @@ int main(int argc, char *argv[])
 		if (gop_time.inited && first_gop_time.inited && stream_mode != CCX_SM_ASF)
 		{
 			mprint ("\nInitial GOP time:	   %s\n",
-				print_mstime(first_gop_time.ms));
+				print_mstime_static(first_gop_time.ms));
 			mprint ("Final GOP time:		 %s%+3dF\n",
-				print_mstime(gop_time.ms),
+				print_mstime_static(gop_time.ms),
 				dec_ctx->frames_since_last_gop);
 			mprint ("Diff. GOP length:	   %s%+3dF",
-				print_mstime(gop_time.ms - first_gop_time.ms),
+				print_mstime_static(gop_time.ms - first_gop_time.ms),
 				dec_ctx->frames_since_last_gop);
 			mprint ("	(%s)\n\n",
-				print_mstime(gop_time.ms - first_gop_time.ms
+				print_mstime_static(gop_time.ms - first_gop_time.ms
 				+(LLONG) ((dec_ctx->frames_since_last_gop)*1000/29.97)) );
 		}
 
@@ -361,7 +361,7 @@ int main(int argc, char *argv[])
 
 		}
 
-		
+
 
 		if(is_decoder_processed_enough(ctx) == CCX_TRUE)
 			break;
@@ -380,8 +380,8 @@ int main(int argc, char *argv[])
 	{
 		LLONG ratio=(get_fts_max()/10)/proc_time;
 		unsigned s1=(unsigned) (ratio/100);
-		unsigned s2=(unsigned) (ratio%100);	
-		mprint ("Performance (real length/process time) = %u.%02u\n", 
+		unsigned s2=(unsigned) (ratio%100);
+		mprint ("Performance (real length/process time) = %u.%02u\n",
 			s1, s2);
 	}
 #endif
@@ -390,13 +390,13 @@ int main(int argc, char *argv[])
 	{
 		mprint ("\rNote: Processing was canceled before all data was processed because\n");
 		mprint ("\rone or more user-defined limits were reached.\n");
-	} 
+	}
 	mprint ("This is beta software. Report issues to carlos at ccextractor org...\n");
 	if (show_myth_banner)
 	{
 		mprint ("NOTICE: Due to the major rework in 0.49, we needed to change part of the timing\n");
 		mprint ("code in the MythTV's branch. Please report results to the address above. If\n");
-		mprint ("something is broken it will be fixed. Thanks\n");		
+		mprint ("something is broken it will be fixed. Thanks\n");
 	}
 
 #ifdef CURL

--- a/src/lib_ccx/asf_functions.c
+++ b/src/lib_ccx/asf_functions.c
@@ -422,7 +422,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 			}
 			else if( !memcmp(curpos,ASF_EXTENDED_CONTENT_DESCRIPTION, 16 ) )
 			{
-				dbg_print(CCX_DMT_PARSE, "\nExtended Content Description Object     (size: %lld)\n", hpobjectsize);
+				dbg_print(CCX_DMT_PARSE, "\nExtended Contend Description Object     (size: %lld)\n", hpobjectsize);
 
 				int ContentDescriptorsCount = *((uint16_t*)(curpos+24));
 				unsigned char *econtentpos=curpos+26;

--- a/src/lib_ccx/asf_functions.c
+++ b/src/lib_ccx/asf_functions.c
@@ -39,7 +39,7 @@ uint32_t asf_readval(void *val, int ltype)
 	return rval;
 }
 
-char *guidstr(void *val)
+char *gui_data_string(void *val)
 {
 	static char sbuf[40];
 
@@ -75,31 +75,31 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 	int reentry = 1;
 
 	// Variables for Header Object
-	int64_t DataPacketsCount = 0;
-	int BroadcastFlag = 0;
-	int SeekableFlag = 0;
-	uint32_t MinPacketSize = 0;
-	uint32_t MaxPacketSize = 0;
+	int64_t data_packets_count = 0;
+	int broadcast_flag = 0;
+	int seekable_flag = 0;
+	uint32_t min_packet_size = 0;
+	uint32_t max_packet_size = 0;
 
 	// Data Object Loop
-	int datapacketlength = 0; // Collect the read header bytes
+	int data_packet_length = 0; // Collect the read header bytes
 
 	// Payload parsing information
-	int SequenceType = 0; // ASF
-	int PaddingLType = 0; // ASF
-	uint32_t Sequence = 0;
-	uint32_t SendTime = 0;
+	int sequence_type = 0; // ASF
+	int padding_l_type = 0; // ASF
+	uint32_t sequence = 0;
+	uint32_t send_time = 0;
 
-	int payloadparsersize = 0; // Infered (PacketLType + SequenceType + PaddingLType + 6);
+	int payload_parser_size = 0; // Infered (PacketLType + sequence_type + padding_l_type + 6);
 
-	uint32_t OffsetMediaLength = 0; // ASF
-	uint32_t ReplicatedLength = 0; // ASF
+	uint32_t offset_media_length = 0; // ASF
+	uint32_t replicated_length = 0; // ASF
 
 	// Last media number. Used to determine a new PES, mark uninitialized.
-	uint32_t curmedianumber = 0xFFFFFFFF;
+	uint32_t current_media_number = 0xFFFFFFFF;
 
-	unsigned char *curpos;
-	int64_t getbytes;
+	unsigned char *current_position;
+	int64_t get_bytes;
 	size_t result = 0;
 	struct demuxer_data *data;
 
@@ -194,12 +194,12 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 			asf_data_container.parsebufsize = (long)asf_data_container.HeaderObjectSize;
 		}
 
-		curpos = asf_data_container.parsebuf + 30;
-		getbytes = asf_data_container.HeaderObjectSize - 30;
+		current_position = asf_data_container.parsebuf + 30;
+		get_bytes = asf_data_container.HeaderObjectSize - 30;
 
-		result = buffered_read(ctx->demux_ctx, curpos, (int) getbytes);
+		result = buffered_read(ctx->demux_ctx, current_position, (int) get_bytes);
 		ctx->demux_ctx->past += result;
-		if (result!=getbytes)
+		if (result!=get_bytes)
 		{
 			mprint("Premature end of file!\n");
 			end_of_file=1;
@@ -208,174 +208,174 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 
 		dbg_print(CCX_DMT_PARSE, "Reading header objects\n");
 
-		while (curpos < asf_data_container.parsebuf + asf_data_container.HeaderObjectSize)
+		while (current_position < asf_data_container.parsebuf + asf_data_container.HeaderObjectSize)
 		{
-			int64_t hpobjectsize = *((int64_t*)(curpos+16)); // Local
+			int64_t hpobjectsize = *((int64_t*)(current_position+16)); // Local
 
-			if( !memcmp(curpos, ASF_FILE_PROPERTIES, 16 ) )
+			if( !memcmp(current_position, ASF_FILE_PROPERTIES, 16 ) )
 			{
 				// Mandatory Object, only one.
 				dbg_print(CCX_DMT_PARSE, "\nFile Properties Object     (size: %lld)\n", hpobjectsize);
 
-				asf_data_container.FileSize = *((int64_t*)(curpos + 40));
-				DataPacketsCount = *((int64_t*)(curpos+56));
-				BroadcastFlag = 0x1 & curpos[88];
-				SeekableFlag = 0x2 & curpos[88];
-				MinPacketSize = *((uint32_t*)(curpos+92));
-				MaxPacketSize = *((uint32_t*)(curpos+96));
+				asf_data_container.FileSize = *((int64_t*)(current_position + 40));
+				data_packets_count = *((int64_t*)(current_position+56));
+				broadcast_flag = 0x1 & current_position[88];
+				seekable_flag = 0x2 & current_position[88];
+				min_packet_size = *((uint32_t*)(current_position+92));
+				max_packet_size = *((uint32_t*)(current_position+96));
 
-				dbg_print(CCX_DMT_PARSE, "FileSize: %lld   Packet count: %lld\n", asf_data_container.FileSize, DataPacketsCount);
-				dbg_print(CCX_DMT_PARSE, "Broadcast: %d - Seekable: %d\n", BroadcastFlag, SeekableFlag);
-				dbg_print(CCX_DMT_PARSE, "MiDPS: %d   MaDPS: %d\n", MinPacketSize, MaxPacketSize);
+				dbg_print(CCX_DMT_PARSE, "FileSize: %lld   Packet count: %lld\n", asf_data_container.FileSize, data_packets_count);
+				dbg_print(CCX_DMT_PARSE, "Broadcast: %d - Seekable: %d\n", broadcast_flag, seekable_flag);
+				dbg_print(CCX_DMT_PARSE, "MiDPS: %d   MaDPS: %d\n", min_packet_size, max_packet_size);
 
 			}
-			else if( !memcmp(curpos,ASF_STREAM_PROPERTIES, 16 ) )
+			else if( !memcmp(current_position,ASF_STREAM_PROPERTIES, 16 ) )
 			{
 				dbg_print(CCX_DMT_PARSE, "\nStream Properties Object     (size: %lld)\n", hpobjectsize);
-				if( !memcmp(curpos+24, ASF_VIDEO_MEDIA, 16 ) )
+				if( !memcmp(current_position+24, ASF_VIDEO_MEDIA, 16 ) )
 				{
-					asf_data_container.StreamProperties.VideoStreamNumber = *(curpos + 72) & 0x7F;
+					asf_data_container.StreamProperties.VideoStreamNumber = *(current_position + 72) & 0x7F;
 					dbg_print(CCX_DMT_PARSE, "Stream Type: ASF_Video_Media\n");
 					dbg_print(CCX_DMT_PARSE, "Video Stream Number: %d\n", asf_data_container.StreamProperties.VideoStreamNumber);
 
 				}
-				else if( !memcmp(curpos+24, ASF_AUDIO_MEDIA, 16 ) )
+				else if( !memcmp(current_position+24, ASF_AUDIO_MEDIA, 16 ) )
 				{
-					asf_data_container.StreamProperties.AudioStreamNumber = *(curpos + 72) & 0x7F;
+					asf_data_container.StreamProperties.AudioStreamNumber = *(current_position + 72) & 0x7F;
 					dbg_print(CCX_DMT_PARSE, "Stream Type: ASF_Audio_Media\n");
 					dbg_print(CCX_DMT_PARSE, "Audio Stream Number: %d\n", asf_data_container.StreamProperties.AudioStreamNumber);
 				}
 				else
 				{
 					dbg_print(CCX_DMT_PARSE, "Stream Type: %s\n",
-							guidstr(curpos+24));
-					dbg_print(CCX_DMT_PARSE, "Stream Number: %d\n", *(curpos+72) & 0x7F );
+							gui_data_string(current_position+24));
+					dbg_print(CCX_DMT_PARSE, "Stream Number: %d\n", *(current_position+72) & 0x7F );
 				}
 			}
-			else if( !memcmp(curpos,ASF_HEADER_EXTENSION, 16 ) )
+			else if( !memcmp(current_position,ASF_HEADER_EXTENSION, 16 ) )
 			{
 				dbg_print(CCX_DMT_PARSE, "\nHeader Extension Object     (size: %lld)\n", hpobjectsize);
 
-				int32_t HeaderExtensionDataSize = *((uint32_t*)(curpos+42));
+				int32_t header_extension_data_size = *((uint32_t*)(current_position+42));
 				// Process Header Extension Data
-				if ( HeaderExtensionDataSize )
+				if ( header_extension_data_size )
 				{
-					unsigned char *hecurpos=curpos+46;
+					unsigned char *header_current_position=current_position+46;
 
-					if ( HeaderExtensionDataSize != hpobjectsize - 46 )
-						fatal(EXIT_NOT_CLASSIFIED, "HeaderExtensionDataSize size wrong");
+					if ( header_extension_data_size != hpobjectsize - 46 )
+						fatal(EXIT_NOT_CLASSIFIED, "header_extension_data_size size wrong");
 
 					dbg_print(CCX_DMT_PARSE, "\nReading Header Extension Sub-Objects\n");
-					while( hecurpos < curpos+46 + HeaderExtensionDataSize )
+					while( header_current_position < current_position+46 + header_extension_data_size )
 					{
-						int64_t heobjectsize = *((int64_t*)(hecurpos+16)); // Local
+						int64_t header_object_size = *((int64_t*)(header_current_position+16)); // Local
 
-						if( !memcmp(hecurpos,ASF_EXTENDED_STREAM_PROPERTIES, 16 ) )
+						if( !memcmp(header_current_position,ASF_EXTENDED_STREAM_PROPERTIES, 16 ) )
 						{
-							dbg_print(CCX_DMT_PARSE, "\nExtended Stream Properties Object     (size: %lld)\n", heobjectsize);
-							int StreamNumber = *((uint16_t*)(hecurpos+72));
-							int StreamNameCount = *((uint16_t*)(hecurpos+84));
-							int PayloadExtensionSystemCount = *((uint16_t*)(hecurpos+86));
+							dbg_print(CCX_DMT_PARSE, "\nExtended Stream Properties Object     (size: %lld)\n", header_object_size);
+							int stream_number = *((uint16_t*)(header_current_position+72));
+							int stream_name_count = *((uint16_t*)(header_current_position+84));
+							int payload_ext_system_count = *((uint16_t*)(header_current_position+86));
 
-							unsigned char *estreamproppos=hecurpos+88;
+							unsigned char *stream_prop_position=header_current_position+88;
 
-							int streamnamelength;
+							int stream_name_length;
 
 							dbg_print(CCX_DMT_PARSE, "Stream Number: %d NameCount: %d  ESCount: %d\n",
-									StreamNumber, StreamNameCount, PayloadExtensionSystemCount);
+									stream_number, stream_name_count, payload_ext_system_count);
 
-							if ( StreamNumber >= STREAMNUM )
+							if ( stream_number >= STREAMNUM )
 								fatal(CCX_COMMON_EXIT_BUG_BUG, "STREAMNUM too small. Send bug report!/n");
 
-							for(int i=0; i<StreamNameCount; i++)
+							for(int i=0; i<stream_name_count; i++)
 							{
 								dbg_print(CCX_DMT_PARSE,"%2d. Stream Name Field\n",i);
-								streamnamelength=*((uint16_t*)(estreamproppos+2));
-								estreamproppos+=4+streamnamelength;
+								stream_name_length=*((uint16_t*)(stream_prop_position+2));
+								stream_prop_position+=4+stream_name_length;
 							}
-							int extensionsystemdatasize;
-							int extensionsysteminfolength;
+							int ext_system_data_size;
+							int ext_system_info_length;
 
-							if ( PayloadExtensionSystemCount > PAYEXTNUM )
+							if ( payload_ext_system_count > PAYEXTNUM )
 								fatal(CCX_COMMON_EXIT_BUG_BUG, "PAYEXTNUM too small. Send bug report!/n");
 
-							for(int i=0; i<PayloadExtensionSystemCount; i++)
+							for(int i=0; i<payload_ext_system_count; i++)
 							{
-								extensionsystemdatasize = *((uint16_t*)(estreamproppos+16));
-								extensionsysteminfolength = *((uint32_t*)(estreamproppos+18));
+								ext_system_data_size = *((uint16_t*)(stream_prop_position+16));
+								ext_system_info_length = *((uint32_t*)(stream_prop_position+18));
 
-								asf_data_container.PayloadExtSize[StreamNumber][i] = extensionsystemdatasize;
+								asf_data_container.PayloadExtSize[stream_number][i] = ext_system_data_size;
 
 								dbg_print(CCX_DMT_PARSE,"%2d. Payload Extension GUID: %s Size %d Info Length %d\n",
-										i,guidstr(estreamproppos+0),
-										extensionsystemdatasize,
-										extensionsysteminfolength);
+										i,gui_data_string(stream_prop_position+0),
+										ext_system_data_size,
+										ext_system_info_length);
 
 								// For DVR-MS presentation timestamp
-								if( !memcmp(estreamproppos, DVRMS_PTS, 16 ) )
+								if( !memcmp(stream_prop_position, DVRMS_PTS, 16 ) )
 								{
 									dbg_print(CCX_DMT_PARSE, "Found DVRMS_PTS\n");
-									asf_data_container.PayloadExtPTSEntry[StreamNumber] = i;
+									asf_data_container.PayloadExtPTSEntry[stream_number] = i;
 								}
 
-								estreamproppos+=22+extensionsysteminfolength;
+								stream_prop_position+=22+ext_system_info_length;
 							}
 
 							// Now, there can be a Stream Properties Object.  The only way to
 							// find out is to check if there are bytes left in the current
 							// object.
-							if ( (estreamproppos - hecurpos) < heobjectsize )
+							if ( (stream_prop_position - header_current_position) < header_object_size )
 							{
-								int64_t spobjectsize = *((int64_t*)(estreamproppos+16)); // Local
-								if( memcmp(estreamproppos, ASF_STREAM_PROPERTIES, 16 ) )
+								int64_t stream_prop_object_size = *((int64_t*)(stream_prop_position+16)); // Local
+								if( memcmp(stream_prop_position, ASF_STREAM_PROPERTIES, 16 ) )
 									fatal(EXIT_NOT_CLASSIFIED, "Stream Properties Object expected\n");
 
-								if( !memcmp(estreamproppos+24, ASF_VIDEO_MEDIA, 16 ) )
+								if( !memcmp(stream_prop_position+24, ASF_VIDEO_MEDIA, 16 ) )
 								{
 									dbg_print(CCX_DMT_PARSE, "Stream Type: ASF_Video_Media (size: %lld)\n",
-											spobjectsize);
-									asf_data_container.StreamProperties.VideoStreamNumber = StreamNumber;
+											stream_prop_object_size);
+									asf_data_container.StreamProperties.VideoStreamNumber = stream_number;
 								}
-								else if( !memcmp(estreamproppos+24, ASF_AUDIO_MEDIA, 16 ) )
+								else if( !memcmp(stream_prop_position+24, ASF_AUDIO_MEDIA, 16 ) )
 								{
 									dbg_print(CCX_DMT_PARSE, "Stream Type: ASF_Audio_Media (size: %lld)\n",
-											spobjectsize);
-									asf_data_container.StreamProperties.AudioStreamNumber = StreamNumber;
+											stream_prop_object_size);
+									asf_data_container.StreamProperties.AudioStreamNumber = stream_number;
 								}
-								else if( !memcmp(estreamproppos+24, ASF_BINARY_MEDIA, 16 ) )
+								else if( !memcmp(stream_prop_position+24, ASF_BINARY_MEDIA, 16 ) )
 								{
 									// dvr-ms files identify audio streams as binary streams
 									// but use the "major media type" accordingly to identify
 									// the steam.  (There might be other audio identifiers.)
-									if( !memcmp(estreamproppos+78, DVRMS_AUDIO, 16 ) ) {
+									if( !memcmp(stream_prop_position+78, DVRMS_AUDIO, 16 ) ) {
 										dbg_print(CCX_DMT_PARSE, "Binary media: DVR-MS Audio Stream (size: %lld)\n",
-												spobjectsize);
+												stream_prop_object_size);
 									}
-									else if( !memcmp(estreamproppos+78, DVRMS_NTSC, 16 ) )
+									else if( !memcmp(stream_prop_position+78, DVRMS_NTSC, 16 ) )
 									{
 										dbg_print(CCX_DMT_PARSE, "Binary media: NTSC captions (size: %lld)\n",
-												spobjectsize);
-										asf_data_container.StreamProperties.CaptionStreamNumber = StreamNumber;
+												stream_prop_object_size);
+										asf_data_container.StreamProperties.CaptionStreamNumber = stream_number;
 										asf_data_container.StreamProperties.CaptionStreamStyle = 1;
 
 									}
-									else if( !memcmp(estreamproppos+78, DVRMS_ATSC, 16 ) )
+									else if( !memcmp(stream_prop_position+78, DVRMS_ATSC, 16 ) )
 									{
 										dbg_print(CCX_DMT_PARSE, "Binary media: ATSC captions (size: %lld)\n",
-												spobjectsize);
-										asf_data_container.StreamProperties.CaptionStreamNumber = StreamNumber;
+												stream_prop_object_size);
+										asf_data_container.StreamProperties.CaptionStreamNumber = stream_number;
 										asf_data_container.StreamProperties.CaptionStreamStyle = 2;
 									}
 									else
 									{
 										dbg_print(CCX_DMT_PARSE, "Binary media: Major Media Type GUID: %s (size: %lld)\n",
-												guidstr(estreamproppos+78), spobjectsize);
+												gui_data_string(stream_prop_position+78), stream_prop_object_size);
 									}
 								}
 								else
 								{
 									dbg_print(CCX_DMT_PARSE, "Unknown Type GUID: %s (size: %lld)\n",
-											guidstr(estreamproppos+24), spobjectsize);
+											gui_data_string(stream_prop_position+24), stream_prop_object_size);
 								}
 							}
 							else
@@ -384,122 +384,122 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 							}
 
 						}
-						else if( !memcmp(hecurpos,ASF_METADATA, 16 ) )
+						else if( !memcmp(header_current_position,ASF_METADATA, 16 ) )
 						{
-							dbg_print(CCX_DMT_PARSE, "\nMetadata Object     (size: %lld)\n", heobjectsize);
+							dbg_print(CCX_DMT_PARSE, "\nMetadata Object     (size: %lld)\n", header_object_size);
 						}
-						else if( !memcmp(hecurpos,ASF_METADATA_LIBRARY, 16 ) )
+						else if( !memcmp(header_current_position,ASF_METADATA_LIBRARY, 16 ) )
 						{
-							dbg_print(CCX_DMT_PARSE, "\nMetadata Library Object     (size: %lld)\n", heobjectsize);
+							dbg_print(CCX_DMT_PARSE, "\nMetadata Library Object     (size: %lld)\n", header_object_size);
 						}
-						else if( !memcmp(hecurpos,ASF_COMPATIBILITY2, 16 ) )
+						else if( !memcmp(header_current_position,ASF_COMPATIBILITY2, 16 ) )
 						{
-							dbg_print(CCX_DMT_PARSE, "\nCompatibility Object 2     (size: %lld)\n", heobjectsize);
+							dbg_print(CCX_DMT_PARSE, "\nCompatibility Object 2     (size: %lld)\n", header_object_size);
 						}
-						else if( !memcmp(hecurpos,ASF_PADDING, 16 ) )
+						else if( !memcmp(header_current_position,ASF_PADDING, 16 ) )
 						{
-							dbg_print(CCX_DMT_PARSE, "\nPadding Object     (size: %lld)\n", heobjectsize);
+							dbg_print(CCX_DMT_PARSE, "\nPadding Object     (size: %lld)\n", header_object_size);
 						}
 						else
 						{
 							dbg_print(CCX_DMT_PARSE, "\nGUID: %s  size: %lld\n",
-									guidstr(hecurpos), heobjectsize);
-							dump(CCX_DMT_PARSE, hecurpos, 16, 0, 0);
+									gui_data_string(header_current_position), header_object_size);
+							dump(CCX_DMT_PARSE, header_current_position, 16, 0, 0);
 						}
 
-						hecurpos += heobjectsize;
+						header_current_position += header_object_size;
 					}
-					if (hecurpos - (curpos+46) != HeaderExtensionDataSize)
+					if (header_current_position - (current_position+46) != header_extension_data_size)
 						fatal(EXIT_NOT_CLASSIFIED, "HE Parsing problem: read bytes %ld != header length %lld\nAbort!\n",
-								(long)(hecurpos - (curpos+46)), HeaderExtensionDataSize);
+								(long)(header_current_position - (current_position+46)), header_extension_data_size);
 				}
 				dbg_print(CCX_DMT_PARSE, "\nHeader Extension Object  -  End\n");
 
 			}
-			else if( !memcmp(curpos,ASF_CONTENT_DESCRIPTION, 16 ) )
+			else if( !memcmp(current_position,ASF_CONTENT_DESCRIPTION, 16 ) )
 			{
 				dbg_print(CCX_DMT_PARSE, "\nContend Description Object     (size: %lld)\n", hpobjectsize);
 			}
-			else if( !memcmp(curpos,ASF_EXTENDED_CONTENT_DESCRIPTION, 16 ) )
+			else if( !memcmp(current_position,ASF_EXTENDED_CONTENT_DESCRIPTION, 16 ) )
 			{
-				dbg_print(CCX_DMT_PARSE, "\nExtended Contend Description Object     (size: %lld)\n", hpobjectsize);
+				dbg_print(CCX_DMT_PARSE, "\nExtended Content Description Object     (size: %lld)\n", hpobjectsize);
 
-				int ContentDescriptorsCount = *((uint16_t*)(curpos+24));
-				unsigned char *econtentpos=curpos+26;
-				int DescriptorNameLength;
-				int DescriptorValueDataType;
-				int DescriptorValueLength;
-				unsigned char *edescval;
+				int content_descriptor_count = *((uint16_t*)(current_position+24));
+				unsigned char *ext_content_position=current_position+26;
+				int descriptor_name_length;
+				int descriptor_value_data_type;
+				int descriptor_value_length;
+				unsigned char *extended_description_value;
 
-				for(int i=0; i<ContentDescriptorsCount; i++)
+				for(int i=0; i<content_descriptor_count; i++)
 				{
-					DescriptorNameLength = *((uint16_t*)(econtentpos));
-					DescriptorValueDataType = *((uint16_t*)(econtentpos+2+DescriptorNameLength));
-					DescriptorValueLength = *((uint16_t*)(econtentpos+4+DescriptorNameLength));
-					edescval = econtentpos+6+DescriptorNameLength;
+					descriptor_name_length = *((uint16_t*)(ext_content_position));
+					descriptor_value_data_type = *((uint16_t*)(ext_content_position+2+descriptor_name_length));
+					descriptor_value_length = *((uint16_t*)(ext_content_position+4+descriptor_name_length));
+					extended_description_value = ext_content_position+6+descriptor_name_length;
 
-					dbg_print(CCX_DMT_PARSE, "%3d. %ls = ",i,(wchar_t*)(econtentpos+2));
-					switch(DescriptorValueDataType)
+					dbg_print(CCX_DMT_PARSE, "%3d. %ls = ",i,(wchar_t*)(ext_content_position+2));
+					switch(descriptor_value_data_type)
 					{
 						case 0: // Unicode string
-							dbg_print(CCX_DMT_PARSE, "%ls (Unicode)\n",(wchar_t*)edescval);
+							dbg_print(CCX_DMT_PARSE, "%ls (Unicode)\n",(wchar_t*)extended_description_value);
 							break;
 						case 1: // byte string
 							dbg_print(CCX_DMT_PARSE, ":");
-							for(int ii=0; ii<DescriptorValueLength && ii<9; ii++)
+							for(int ii=0; ii<descriptor_value_length && ii<9; ii++)
 							{
-								dbg_print(CCX_DMT_PARSE, "%02X:",*((unsigned char*)(edescval+ii)));
+								dbg_print(CCX_DMT_PARSE, "%02X:",*((unsigned char*)(extended_description_value+ii)));
 							}
-							if (DescriptorValueLength>8)
-								dbg_print(CCX_DMT_PARSE, "skipped %d more",DescriptorValueLength-8);
+							if (descriptor_value_length>8)
+								dbg_print(CCX_DMT_PARSE, "skipped %d more",descriptor_value_length-8);
 							dbg_print(CCX_DMT_PARSE, " (BYTES)\n");
 							break;
 						case 2: // BOOL
-							dbg_print(CCX_DMT_PARSE, "%d (BOOL)\n",*((int32_t*)edescval));
+							dbg_print(CCX_DMT_PARSE, "%d (BOOL)\n",*((int32_t*)extended_description_value));
 							break;
 						case 3: // DWORD
-							dbg_print(CCX_DMT_PARSE, "%u (DWORD)\n",*((uint32_t*)edescval));
+							dbg_print(CCX_DMT_PARSE, "%u (DWORD)\n",*((uint32_t*)extended_description_value));
 							break;
 						case 4: // QWORD
-							dbg_print(CCX_DMT_PARSE, "%llu (QWORD)\n",*((uint64_t*)edescval));
+							dbg_print(CCX_DMT_PARSE, "%llu (QWORD)\n",*((uint64_t*)extended_description_value));
 							break;
 						case 5: // WORD
-							dbg_print(CCX_DMT_PARSE, "%u (WORD)\n",(int)*((uint16_t*)edescval));
+							dbg_print(CCX_DMT_PARSE, "%u (WORD)\n",(int)*((uint16_t*)extended_description_value));
 							break;
 						default:
 							fatal(CCX_COMMON_EXIT_BUG_BUG, "Wrong type ...\n");
 							break;
 					}
 
-					if(!memcmp(econtentpos+2, L"WM/VideoClosedCaptioning"
-								,DescriptorNameLength))
+					if(!memcmp(ext_content_position+2, L"WM/VideoClosedCaptioning"
+								,descriptor_name_length))
 					{
 						// This flag would be really usefull if it would be
 						// reliable - it isn't.
-						asf_data_container.VideoClosedCaptioningFlag = *((int32_t*)edescval);
+						asf_data_container.VideoClosedCaptioningFlag = *((int32_t*)extended_description_value);
 						dbg_print(CCX_DMT_PARSE, "Found WM/VideoClosedCaptioning flag: %d\n",
 								asf_data_container.VideoClosedCaptioningFlag);
 					}
 
-					econtentpos+=6+DescriptorNameLength+DescriptorValueLength;
+					ext_content_position+=6+descriptor_name_length+descriptor_value_length;
 				}
 			}
-			else if( !memcmp(curpos,ASF_STREAM_BITRATE_PROPERTIES, 16 ) )
+			else if( !memcmp(current_position,ASF_STREAM_BITRATE_PROPERTIES, 16 ) )
 			{
 				dbg_print(CCX_DMT_PARSE, "\nStream Bitrate Properties Object     (size: %lld)\n", hpobjectsize);
 			}
 			else
 			{
 				dbg_print(CCX_DMT_PARSE, "\nGUID: %s  size: %lld\n",
-						guidstr(curpos), hpobjectsize);
-				dump(CCX_DMT_PARSE, curpos, 16, 0, 0);
+						gui_data_string(current_position), hpobjectsize);
+				dump(CCX_DMT_PARSE, current_position, 16, 0, 0);
 			}
 
-			curpos += hpobjectsize;
+			current_position += hpobjectsize;
 		}
-		if (curpos - asf_data_container.parsebuf != asf_data_container.HeaderObjectSize)
+		if (current_position - asf_data_container.parsebuf != asf_data_container.HeaderObjectSize)
 			fatal(EXIT_NOT_CLASSIFIED, "Parsing problem: read bytes %ld != header length %lld\nAbort!\n",
-					(long)(curpos - asf_data_container.parsebuf), asf_data_container.HeaderObjectSize);
+					(long)(current_position - asf_data_container.parsebuf), asf_data_container.HeaderObjectSize);
 
 		if (asf_data_container.StreamProperties.VideoStreamNumber == 0)
 			fatal(EXIT_NOT_CLASSIFIED, "No Video Stream Properties Object found.  Unable to continue ...\n");
@@ -541,9 +541,9 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 
 		// When reading "Payload parsing information" it occured that "Packet Lenght"
 		// was not set (Packet Length Type 00) and for "Single Payloads" this means
-		// the Payload Data Length cannot be infered.  Use MinPacketSize, MaxPacketSize instead.
-		if ((MinPacketSize > 0) && (MinPacketSize == MaxPacketSize))
-			asf_data_container.PacketSize = MinPacketSize;
+		// the Payload Data Length cannot be infered.  Use min_packet_size, max_packet_size instead.
+		if ((min_packet_size > 0) && (min_packet_size == max_packet_size))
+			asf_data_container.PacketSize = min_packet_size;
 
 		// Now the Data Object, except for the packages
 		result = buffered_read(ctx->demux_ctx, asf_data_container.parsebuf, 50); // No realloc needed.
@@ -583,7 +583,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 		{
 			int ecinfo = 0;
 
-			datapacketlength = 0;
+			data_packet_length = 0;
 
 			dbg_print(CCX_DMT_PARSE, "\nReading packet %d/%d\n", asf_data_container.datapacketcur + 1, asf_data_container.TotalDataPackets);
 
@@ -597,7 +597,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 				end_of_file=1;
 				return payload_read;
 			}
-			datapacketlength+=1;
+			data_packet_length+=1;
 			if (*asf_data_container.parsebuf & 0x80)
 			{
 				int ecdatalength = *asf_data_container.parsebuf & 0x0F; // Small, no realloc needed
@@ -614,7 +614,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 					end_of_file=1;
 					return payload_read;
 				}
-				datapacketlength+=ecdatalength;
+				data_packet_length+=ecdatalength;
 				if (asf_data_container.parsebuf[1] & 0x0F)
 					fatal(EXIT_NOT_CLASSIFIED, "Error correction present.  Unable to continue ...\n");
 			}
@@ -635,15 +635,15 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 				end_of_file=1;
 				return payload_read;
 			}
-			datapacketlength+=2;
+			data_packet_length+=2;
 
 			asf_data_container.MultiplePayloads = *asf_data_container.parsebuf & 0x01;
 
-			SequenceType = (*asf_data_container.parsebuf >> 1) & 0x03;
-			SequenceType = ASF_TypeLength(SequenceType);
+			sequence_type = (*asf_data_container.parsebuf >> 1) & 0x03;
+			sequence_type = ASF_TypeLength(sequence_type);
 
-			PaddingLType = (*asf_data_container.parsebuf >> 3) & 0x03;
-			PaddingLType = ASF_TypeLength(PaddingLType);
+			padding_l_type = (*asf_data_container.parsebuf >> 3) & 0x03;
+			padding_l_type = ASF_TypeLength(padding_l_type);
 
 			asf_data_container.PacketLType = (*asf_data_container.parsebuf >> 5) & 0x03;
 			asf_data_container.PacketLType = ASF_TypeLength(asf_data_container.PacketLType);
@@ -660,24 +660,24 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 			asf_data_container.StreamNumberLType = (asf_data_container.parsebuf[1] >> 6) & 0x03;
 			asf_data_container.StreamNumberLType = ASF_TypeLength(asf_data_container.StreamNumberLType);
 
-			payloadparsersize = asf_data_container.PacketLType + SequenceType + PaddingLType + 6;
+			payload_parser_size = asf_data_container.PacketLType + sequence_type + padding_l_type + 6;
 
-			result = buffered_read(ctx->demux_ctx, asf_data_container.parsebuf + 2, payloadparsersize); // No realloc needed
+			result = buffered_read(ctx->demux_ctx, asf_data_container.parsebuf + 2, payload_parser_size); // No realloc needed
 			ctx->demux_ctx->past += result;
 			asf_data_container.dobjectread += result;
-			if (result!=payloadparsersize)
+			if (result!=payload_parser_size)
 			{
 				mprint("Premature end of file!\n");
 				end_of_file=1;
 				return payload_read;
 			}
-			datapacketlength+=payloadparsersize;
+			data_packet_length+=payload_parser_size;
 
 			asf_data_container.PacketLength = asf_readval(asf_data_container.parsebuf + 2, asf_data_container.PacketLType);
-			Sequence = asf_readval(asf_data_container.parsebuf + 2 + asf_data_container.PacketLType, SequenceType);
-			asf_data_container.PaddingLength = asf_readval(asf_data_container.parsebuf + 2 + asf_data_container.PacketLType + SequenceType, PaddingLType);
+			sequence = asf_readval(asf_data_container.parsebuf + 2 + asf_data_container.PacketLType, sequence_type);
+			asf_data_container.PaddingLength = asf_readval(asf_data_container.parsebuf + 2 + asf_data_container.PacketLType + sequence_type, padding_l_type);
 			// Data Packet ms time stamp
-			SendTime = *((uint32_t*)(asf_data_container.parsebuf + 2 + asf_data_container.PacketLType + SequenceType + PaddingLType));
+			send_time = *((uint32_t*)(asf_data_container.parsebuf + 2 + asf_data_container.PacketLType + sequence_type + padding_l_type));
 
 			// If Packet Length is not set use global setting if possible
 			if (asf_data_container.PacketLength == 0)
@@ -689,8 +689,8 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 					fatal(EXIT_NOT_CLASSIFIED, "No idea how long the data packet will be. Abort.\n");
 			}
 
-			dbg_print(CCX_DMT_PARSE, "Lengths - Packet: %d / Sequence %d / Padding %d\n",
-					asf_data_container.PacketLength, Sequence, asf_data_container.PaddingLength);
+			dbg_print(CCX_DMT_PARSE, "Lengths - Packet: %d / sequence %d / Padding %d\n",
+					asf_data_container.PacketLength, sequence, asf_data_container.PaddingLength);
 
 			asf_data_container.PayloadLType = 0; // Payload Length Type. <>0 for multiple payloads
 			asf_data_container.PayloadLength = 0; // Payload Length (for multiple payloads)
@@ -709,7 +709,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 					end_of_file=1;
 					return payload_read;
 				}
-				datapacketlength+=1;
+				data_packet_length+=1;
 				asf_data_container.PayloadLType = (*plheader >> 6) & 0x03;
 				asf_data_container.PayloadLType = ASF_TypeLength(asf_data_container.PayloadLType);
 
@@ -737,49 +737,49 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 				else
 					dbg_print(CCX_DMT_PARSE, "\nMultiple payloads %d/%d\n", asf_data_container.payloadcur + 1, asf_data_container.NumberOfPayloads);
 
-				int payloadheadersize = 1 + asf_data_container.MediaNumberLType + asf_data_container.OffsetMediaLType + asf_data_container.ReplicatedLType;
+				int payload_header_size = 1 + asf_data_container.MediaNumberLType + asf_data_container.OffsetMediaLType + asf_data_container.ReplicatedLType;
 
-				result = buffered_read(ctx->demux_ctx, asf_data_container.parsebuf, payloadheadersize); // No realloc needed
+				result = buffered_read(ctx->demux_ctx, asf_data_container.parsebuf, payload_header_size); // No realloc needed
 				ctx->demux_ctx->past += result;
 				asf_data_container.dobjectread += result;
-				if (result!=payloadheadersize)
+				if (result!=payload_header_size)
 				{
 					mprint("Premature end of file!\n");
 					end_of_file=1;
 					return payload_read;
 				}
-				datapacketlength+=payloadheadersize;
+				data_packet_length+=payload_header_size;
 
 				asf_data_container.PayloadStreamNumber = *asf_data_container.parsebuf & 0x7F;
 				asf_data_container.KeyFrame = (*asf_data_container.parsebuf & 0x80) && 1;
 
 				asf_data_container.PayloadMediaNumber = asf_readval(asf_data_container.parsebuf + 1, asf_data_container.MediaNumberLType);
-				OffsetMediaLength = asf_readval(asf_data_container.parsebuf + 1 + asf_data_container.MediaNumberLType, asf_data_container.OffsetMediaLType);
-				ReplicatedLength = asf_readval(asf_data_container.parsebuf + 1 + asf_data_container.MediaNumberLType + asf_data_container.OffsetMediaLType, asf_data_container.ReplicatedLType);
+				offset_media_length = asf_readval(asf_data_container.parsebuf + 1 + asf_data_container.MediaNumberLType, asf_data_container.OffsetMediaLType);
+				replicated_length = asf_readval(asf_data_container.parsebuf + 1 + asf_data_container.MediaNumberLType + asf_data_container.OffsetMediaLType, asf_data_container.ReplicatedLType);
 
-				if (ReplicatedLength == 1)
+				if (replicated_length == 1)
 					fatal(EXIT_NOT_CLASSIFIED, "Cannot handle compressed data...\n");
 
-				if ((long)ReplicatedLength > asf_data_container.parsebufsize)
+				if ((long)replicated_length > asf_data_container.parsebufsize)
 				{
-					asf_data_container.parsebuf = (unsigned char*)realloc(asf_data_container.parsebuf, ReplicatedLength);
+					asf_data_container.parsebuf = (unsigned char*)realloc(asf_data_container.parsebuf, replicated_length);
 					if (!asf_data_container.parsebuf)
 						fatal(EXIT_NOT_ENOUGH_MEMORY, "Out of memory");
-					asf_data_container.parsebufsize = ReplicatedLength;
+					asf_data_container.parsebufsize = replicated_length;
 				}
-				result = buffered_read(ctx->demux_ctx, asf_data_container.parsebuf, (long)ReplicatedLength);
+				result = buffered_read(ctx->demux_ctx, asf_data_container.parsebuf, (long)replicated_length);
 				ctx->demux_ctx->past += result;
 				asf_data_container.dobjectread += result;
-				if (result!=ReplicatedLength)
+				if (result!=replicated_length)
 				{
 					mprint("Premature end of file!\n");
 					end_of_file=1;
 					return payload_read;
 				}
 				// Parse Replicated data
-				unsigned char *reppos = asf_data_container.parsebuf;
-				int MediaObjectSize = 0;
-				int PresentationTimems = 0; //Payload ms time stamp
+				unsigned char *replicate_position = asf_data_container.parsebuf;
+				int media_object_size = 0;
+				int presentation_time_millis = 0; //Payload ms time stamp
 				int extsize = 0;
 				// int32_t dwVersion = 0;
 				// int32_t unknown = 0;
@@ -787,35 +787,35 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 				int64_t rtEnd = 0; // dvr-ms 100ns time stamp end
 
 				// Always at least 8 bytes long, see 7.3.1
-				MediaObjectSize = *((uint16_t*)(asf_data_container.parsebuf));
-				PresentationTimems = *((uint16_t*)(asf_data_container.parsebuf + 4));
-				reppos += 8;
+				media_object_size = *((uint16_t*)(asf_data_container.parsebuf));
+				presentation_time_millis = *((uint16_t*)(asf_data_container.parsebuf + 4));
+				replicate_position += 8;
 
 				dbg_print(CCX_DMT_PARSE, "Stream# %d[%d] Media# %d Offset/Size: %d/%d\n",
 						asf_data_container.PayloadStreamNumber, asf_data_container.KeyFrame, asf_data_container.PayloadMediaNumber,
-						OffsetMediaLength, MediaObjectSize);
+						offset_media_length, media_object_size);
 
 				// Loop over Payload Extension Systems
 				for (int i = 0; i<asf_data_container.PayloadExtPTSEntry[asf_data_container.PayloadStreamNumber]; i++)
 				{
 					if (asf_data_container.PayloadExtSize[asf_data_container.PayloadStreamNumber][i] == 0xffff)
 					{
-						extsize = *((uint16_t*)(reppos+0));
-						reppos += 2;
+						extsize = *((uint16_t*)(replicate_position+0));
+						replicate_position += 2;
 					}
 					else
 					{
 						extsize = asf_data_container.PayloadExtSize[asf_data_container.PayloadStreamNumber][i];
 					}
-					reppos += extsize;
+					replicate_position += extsize;
 					//printf("%2d. Ext. System - size: %d\n", i, extsize);
 				}
 				if (asf_data_container.PayloadExtPTSEntry[asf_data_container.PayloadStreamNumber] > 0)
 				{
-					// dwVersion = *((uint32_t*)(reppos+0));
-					// unknown = *((uint32_t*)(reppos+4));
-					rtStart = *((int64_t*)(reppos+8));
-					rtEnd = *((int64_t*)(reppos+16));
+					// dwVersion = *((uint32_t*)(replicate_position+0));
+					// unknown = *((uint32_t*)(replicate_position+4));
+					rtStart = *((int64_t*)(replicate_position+8));
+					rtEnd = *((int64_t*)(replicate_position+16));
 
 					//printf("dwVersion: %d    unknown: 0x%04X\n", dwVersion, unknown);
 				}
@@ -830,13 +830,13 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 
 				// print_mstime uses a static buffer
 				dbg_print(CCX_DMT_PARSE, "Stream #%d PacketTime: %s",
-						asf_data_container.PayloadStreamNumber, print_mstime_static(SendTime));
+						asf_data_container.PayloadStreamNumber, print_mstime_static(send_time));
 				dbg_print(CCX_DMT_PARSE,"   PayloadTime: %s",
-						print_mstime_static(PresentationTimems));
+						print_mstime_static(presentation_time_millis));
 				dbg_print(CCX_DMT_PARSE,"   dvr-ms PTS: %s+%lld\n",
 						print_mstime_static(rtStart/10000), (rtEnd-rtStart)/10000);
 
-				datapacketlength+=ReplicatedLength;
+				data_packet_length+=replicated_length;
 
 				// Only multiple payload packages have this value
 				if (asf_data_container.MultiplePayloads != 0)
@@ -856,21 +856,21 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 				}
 				else
 				{
-					asf_data_container.PayloadLength = asf_data_container.PacketLength - datapacketlength - asf_data_container.PaddingLength;
+					asf_data_container.PayloadLength = asf_data_container.PacketLength - data_packet_length - asf_data_container.PaddingLength;
 				}
 				dbg_print(CCX_DMT_PARSE, "Size - Replicated %d + Payload %d = %d\n",
-						ReplicatedLength, asf_data_container.PayloadLength, ReplicatedLength + asf_data_container.PayloadLength);
+						replicated_length, asf_data_container.PayloadLength, replicated_length + asf_data_container.PayloadLength);
 
 				// Remember the last video time stamp - only when captions are separate
 				// from video stream.
 				if (asf_data_container.PayloadStreamNumber == asf_data_container.StreamProperties.VideoStreamNumber
 						&& asf_data_container.StreamProperties.DecodeStreamNumber != asf_data_container.StreamProperties.VideoStreamNumber
-						&& OffsetMediaLength == 0)
+						&& offset_media_length == 0)
 				{
 					asf_data_container.StreamProperties.prevVideoStreamMS = asf_data_container.StreamProperties.currVideoStreamMS;
 					asf_data_container.StreamProperties.currVideoStreamMS = asf_data_container.StreamProperties.VideoStreamMS;
 
-					// Use PresentationTimems (SendTime might also work) when the
+					// Use presentation_time_millis (send_time might also work) when the
 					// dvr-ms time stamp is not present.
 					if (asf_data_container.PayloadExtPTSEntry[asf_data_container.PayloadStreamNumber] > 0)
 					{
@@ -881,7 +881,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 					else
 					{
 						// Add 1ms to avoid 0ms start times getting rejected
-						asf_data_container.StreamProperties.VideoStreamMS = PresentationTimems + 1;
+						asf_data_container.StreamProperties.VideoStreamMS = presentation_time_millis + 1;
 					}
 					// This checks if there is a video time jump in the timeline
 					// between caption information.
@@ -896,12 +896,12 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 
 				// Remember the PTS values
 				if (asf_data_container.PayloadStreamNumber == asf_data_container.StreamProperties.DecodeStreamNumber
-						&& OffsetMediaLength == 0)
+						&& offset_media_length == 0)
 				{
 					asf_data_container.StreamProperties.prevDecodeStreamPTS = asf_data_container.StreamProperties.currDecodeStreamPTS;
 					asf_data_container.StreamProperties.currDecodeStreamPTS = asf_data_container.StreamProperties.DecodeStreamPTS;
 
-					// Use PresentationTimems (SendTime might also work) when the
+					// Use presentation_time_millis (send_time might also work) when the
 					// dvr-ms time stamp is not present.
 					if (asf_data_container.PayloadExtPTSEntry[asf_data_container.PayloadStreamNumber] > 0)
 					{
@@ -912,7 +912,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 					else
 					{
 						// Add 1ms to avoid 0ms start times getting rejected
-						asf_data_container.StreamProperties.DecodeStreamPTS = PresentationTimems + 1;
+						asf_data_container.StreamProperties.DecodeStreamPTS = presentation_time_millis + 1;
 					}
 
 					// Check the caption stream for jumps in the timeline. This
@@ -955,9 +955,9 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 
 			// Video streams need several packages to complete a PES.  Leave
 			// the loop when the next package starts a new Media Object.
-			if ( curmedianumber != 0xFFFFFFFF  // Is initialized
+			if ( current_media_number != 0xFFFFFFFF  // Is initialized
 					&& asf_data_container.PayloadStreamNumber == asf_data_container.StreamProperties.DecodeStreamNumber
-					&& asf_data_container.PayloadMediaNumber != curmedianumber)
+					&& asf_data_container.PayloadMediaNumber != current_media_number)
 			{
 				if (asf_data_container.StreamProperties.DecodeStreamNumber == asf_data_container.StreamProperties.CaptionStreamNumber)
 					dbg_print(CCX_DMT_PARSE, "\nCaption stream object");
@@ -975,7 +975,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 			// Read it!!
 			if (asf_data_container.PayloadStreamNumber == asf_data_container.StreamProperties.DecodeStreamNumber)
 			{
-				curmedianumber = asf_data_container.PayloadMediaNumber; // Remember current value
+				current_media_number = asf_data_container.PayloadMediaNumber; // Remember current value
 
 				// Read the data
 				dbg_print(CCX_DMT_PARSE, "Reading Stream #%d data ...\n", asf_data_container.PayloadStreamNumber);

--- a/src/lib_ccx/asf_functions.c
+++ b/src/lib_ccx/asf_functions.c
@@ -830,11 +830,11 @@ int asf_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 
 				// print_mstime uses a static buffer
 				dbg_print(CCX_DMT_PARSE, "Stream #%d PacketTime: %s",
-						asf_data_container.PayloadStreamNumber, print_mstime(SendTime));
+						asf_data_container.PayloadStreamNumber, print_mstime_static(SendTime));
 				dbg_print(CCX_DMT_PARSE,"   PayloadTime: %s",
-						print_mstime(PresentationTimems));
+						print_mstime_static(PresentationTimems));
 				dbg_print(CCX_DMT_PARSE,"   dvr-ms PTS: %s+%lld\n",
-						print_mstime(rtStart/10000), (rtEnd-rtStart)/10000);
+						print_mstime_static(rtStart/10000), (rtEnd-rtStart)/10000);
 
 				datapacketlength+=ReplicatedLength;
 
@@ -964,7 +964,7 @@ int asf_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 				else
 					dbg_print(CCX_DMT_PARSE, "\nVideo stream object");
 				dbg_print(CCX_DMT_PARSE, " read with PTS: %s\n",
-						print_mstime(asf_data_container.StreamProperties.currDecodeStreamPTS));
+						print_mstime_static(asf_data_container.StreamProperties.currDecodeStreamPTS));
 
 
 				// Enough for now

--- a/src/lib_ccx/asf_functions.c
+++ b/src/lib_ccx/asf_functions.c
@@ -39,7 +39,7 @@ uint32_t asf_readval(void *val, int ltype)
 	return rval;
 }
 
-char *guidstr(void *val)
+char *gui_data_string(void *val)
 {
 	static char sbuf[40];
 
@@ -248,7 +248,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 				else
 				{
 					dbg_print(CCX_DMT_PARSE, "Stream Type: %s\n",
-							guidstr(curpos+24));
+							gui_data_string(curpos+24));
 					dbg_print(CCX_DMT_PARSE, "Stream Number: %d\n", *(curpos+72) & 0x7F );
 				}
 			}
@@ -307,7 +307,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 								asf_data_container.PayloadExtSize[StreamNumber][i] = extensionsystemdatasize;
 
 								dbg_print(CCX_DMT_PARSE,"%2d. Payload Extension GUID: %s Size %d Info Length %d\n",
-										i,guidstr(estreamproppos+0),
+										i,gui_data_string(estreamproppos+0),
 										extensionsystemdatasize,
 										extensionsysteminfolength);
 
@@ -369,13 +369,13 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 									else
 									{
 										dbg_print(CCX_DMT_PARSE, "Binary media: Major Media Type GUID: %s (size: %lld)\n",
-												guidstr(estreamproppos+78), spobjectsize);
+												gui_data_string(estreamproppos+78), spobjectsize);
 									}
 								}
 								else
 								{
 									dbg_print(CCX_DMT_PARSE, "Unknown Type GUID: %s (size: %lld)\n",
-											guidstr(estreamproppos+24), spobjectsize);
+											gui_data_string(estreamproppos+24), spobjectsize);
 								}
 							}
 							else
@@ -403,7 +403,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 						else
 						{
 							dbg_print(CCX_DMT_PARSE, "\nGUID: %s  size: %lld\n",
-									guidstr(hecurpos), heobjectsize);
+									gui_data_string(hecurpos), heobjectsize);
 							dump(CCX_DMT_PARSE, hecurpos, 16, 0, 0);
 						}
 
@@ -491,7 +491,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 			else
 			{
 				dbg_print(CCX_DMT_PARSE, "\nGUID: %s  size: %lld\n",
-						guidstr(curpos), hpobjectsize);
+						gui_data_string(curpos), hpobjectsize);
 				dump(CCX_DMT_PARSE, curpos, 16, 0, 0);
 			}
 

--- a/src/lib_ccx/asf_functions.c
+++ b/src/lib_ccx/asf_functions.c
@@ -4,7 +4,7 @@
 #include "activity.h"
 #include "file_buffer.h"
 
-// Indicate first / subsequent calls to asf_getmoredata()
+// Indicate first / subsequent calls to asf_get_more_data()
 int firstcall;
 
 asf_data asf_data_container;
@@ -63,7 +63,7 @@ char *guidstr(void *val)
  * When the function is called the next time it continues to read
  * where it stopped before, static variables make sure that parameters
  * are remembered between calls. */
-int asf_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
+int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 {
 	int enough = 0;
 	int payload_read = 0;
@@ -723,7 +723,7 @@ int asf_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 			// NumberOfPayloads, payloadcur, PayloadLength, PaddingLength
 			// and related variables being kept as static variables to be
 			// able to reenter the loop here.
-			dbg_print(CCX_DMT_PARSE, "\nReentry into asf_getmoredata()\n");
+			dbg_print(CCX_DMT_PARSE, "\nReentry into asf_get_more_data()\n");
 		}
 
 		// The following repeats NumberOfPayloads times

--- a/src/lib_ccx/asf_functions.c
+++ b/src/lib_ccx/asf_functions.c
@@ -422,7 +422,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 			}
 			else if( !memcmp(curpos,ASF_EXTENDED_CONTENT_DESCRIPTION, 16 ) )
 			{
-				dbg_print(CCX_DMT_PARSE, "\nExtended Contend Description Object     (size: %lld)\n", hpobjectsize);
+				dbg_print(CCX_DMT_PARSE, "\nExtended Content Description Object     (size: %lld)\n", hpobjectsize);
 
 				int ContentDescriptorsCount = *((uint16_t*)(curpos+24));
 				unsigned char *econtentpos=curpos+26;

--- a/src/lib_ccx/asf_functions.c
+++ b/src/lib_ccx/asf_functions.c
@@ -39,7 +39,7 @@ uint32_t asf_readval(void *val, int ltype)
 	return rval;
 }
 
-char *gui_data_string(void *val)
+char *guidstr(void *val)
 {
 	static char sbuf[40];
 
@@ -248,7 +248,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 				else
 				{
 					dbg_print(CCX_DMT_PARSE, "Stream Type: %s\n",
-							gui_data_string(curpos+24));
+							guidstr(curpos+24));
 					dbg_print(CCX_DMT_PARSE, "Stream Number: %d\n", *(curpos+72) & 0x7F );
 				}
 			}
@@ -307,7 +307,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 								asf_data_container.PayloadExtSize[StreamNumber][i] = extensionsystemdatasize;
 
 								dbg_print(CCX_DMT_PARSE,"%2d. Payload Extension GUID: %s Size %d Info Length %d\n",
-										i,gui_data_string(estreamproppos+0),
+										i,guidstr(estreamproppos+0),
 										extensionsystemdatasize,
 										extensionsysteminfolength);
 
@@ -369,13 +369,13 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 									else
 									{
 										dbg_print(CCX_DMT_PARSE, "Binary media: Major Media Type GUID: %s (size: %lld)\n",
-												gui_data_string(estreamproppos+78), spobjectsize);
+												guidstr(estreamproppos+78), spobjectsize);
 									}
 								}
 								else
 								{
 									dbg_print(CCX_DMT_PARSE, "Unknown Type GUID: %s (size: %lld)\n",
-											gui_data_string(estreamproppos+24), spobjectsize);
+											guidstr(estreamproppos+24), spobjectsize);
 								}
 							}
 							else
@@ -403,7 +403,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 						else
 						{
 							dbg_print(CCX_DMT_PARSE, "\nGUID: %s  size: %lld\n",
-									gui_data_string(hecurpos), heobjectsize);
+									guidstr(hecurpos), heobjectsize);
 							dump(CCX_DMT_PARSE, hecurpos, 16, 0, 0);
 						}
 
@@ -491,7 +491,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 			else
 			{
 				dbg_print(CCX_DMT_PARSE, "\nGUID: %s  size: %lld\n",
-						gui_data_string(curpos), hpobjectsize);
+						guidstr(curpos), hpobjectsize);
 				dump(CCX_DMT_PARSE, curpos, 16, 0, 0);
 			}
 

--- a/src/lib_ccx/asf_functions.c
+++ b/src/lib_ccx/asf_functions.c
@@ -75,31 +75,31 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 	int reentry = 1;
 
 	// Variables for Header Object
-	int64_t DataPacketsCount = 0;
-	int BroadcastFlag = 0;
-	int SeekableFlag = 0;
-	uint32_t MinPacketSize = 0;
-	uint32_t MaxPacketSize = 0;
+	int64_t data_packets_count = 0;
+	int broadcast_flag = 0;
+	int seekable_flag = 0;
+	uint32_t min_packet_size = 0;
+	uint32_t max_packet_size = 0;
 
 	// Data Object Loop
-	int datapacketlength = 0; // Collect the read header bytes
+	int data_packet_length = 0; // Collect the read header bytes
 
 	// Payload parsing information
-	int SequenceType = 0; // ASF
-	int PaddingLType = 0; // ASF
-	uint32_t Sequence = 0;
-	uint32_t SendTime = 0;
+	int sequence_type = 0; // ASF
+	int padding_l_type = 0; // ASF
+	uint32_t sequence = 0;
+	uint32_t send_time = 0;
 
-	int payloadparsersize = 0; // Infered (PacketLType + SequenceType + PaddingLType + 6);
+	int payload_parser_size = 0; // Infered (PacketLType + sequence_type + padding_l_type + 6);
 
-	uint32_t OffsetMediaLength = 0; // ASF
-	uint32_t ReplicatedLength = 0; // ASF
+	uint32_t offset_media_length = 0; // ASF
+	uint32_t replicated_length = 0; // ASF
 
 	// Last media number. Used to determine a new PES, mark uninitialized.
-	uint32_t curmedianumber = 0xFFFFFFFF;
+	uint32_t current_media_number = 0xFFFFFFFF;
 
-	unsigned char *curpos;
-	int64_t getbytes;
+	unsigned char *current_position;
+	int64_t get_bytes;
 	size_t result = 0;
 	struct demuxer_data *data;
 
@@ -194,12 +194,12 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 			asf_data_container.parsebufsize = (long)asf_data_container.HeaderObjectSize;
 		}
 
-		curpos = asf_data_container.parsebuf + 30;
-		getbytes = asf_data_container.HeaderObjectSize - 30;
+		current_position = asf_data_container.parsebuf + 30;
+		get_bytes = asf_data_container.HeaderObjectSize - 30;
 
-		result = buffered_read(ctx->demux_ctx, curpos, (int) getbytes);
+		result = buffered_read(ctx->demux_ctx, current_position, (int) get_bytes);
 		ctx->demux_ctx->past += result;
-		if (result!=getbytes)
+		if (result!=get_bytes)
 		{
 			mprint("Premature end of file!\n");
 			end_of_file=1;
@@ -208,174 +208,174 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 
 		dbg_print(CCX_DMT_PARSE, "Reading header objects\n");
 
-		while (curpos < asf_data_container.parsebuf + asf_data_container.HeaderObjectSize)
+		while (current_position < asf_data_container.parsebuf + asf_data_container.HeaderObjectSize)
 		{
-			int64_t hpobjectsize = *((int64_t*)(curpos+16)); // Local
+			int64_t hpobjectsize = *((int64_t*)(current_position+16)); // Local
 
-			if( !memcmp(curpos, ASF_FILE_PROPERTIES, 16 ) )
+			if( !memcmp(current_position, ASF_FILE_PROPERTIES, 16 ) )
 			{
 				// Mandatory Object, only one.
 				dbg_print(CCX_DMT_PARSE, "\nFile Properties Object     (size: %lld)\n", hpobjectsize);
 
-				asf_data_container.FileSize = *((int64_t*)(curpos + 40));
-				DataPacketsCount = *((int64_t*)(curpos+56));
-				BroadcastFlag = 0x1 & curpos[88];
-				SeekableFlag = 0x2 & curpos[88];
-				MinPacketSize = *((uint32_t*)(curpos+92));
-				MaxPacketSize = *((uint32_t*)(curpos+96));
+				asf_data_container.FileSize = *((int64_t*)(current_position + 40));
+				data_packets_count = *((int64_t*)(current_position+56));
+				broadcast_flag = 0x1 & current_position[88];
+				seekable_flag = 0x2 & current_position[88];
+				min_packet_size = *((uint32_t*)(current_position+92));
+				max_packet_size = *((uint32_t*)(current_position+96));
 
-				dbg_print(CCX_DMT_PARSE, "FileSize: %lld   Packet count: %lld\n", asf_data_container.FileSize, DataPacketsCount);
-				dbg_print(CCX_DMT_PARSE, "Broadcast: %d - Seekable: %d\n", BroadcastFlag, SeekableFlag);
-				dbg_print(CCX_DMT_PARSE, "MiDPS: %d   MaDPS: %d\n", MinPacketSize, MaxPacketSize);
+				dbg_print(CCX_DMT_PARSE, "FileSize: %lld   Packet count: %lld\n", asf_data_container.FileSize, data_packets_count);
+				dbg_print(CCX_DMT_PARSE, "Broadcast: %d - Seekable: %d\n", broadcast_flag, seekable_flag);
+				dbg_print(CCX_DMT_PARSE, "MiDPS: %d   MaDPS: %d\n", min_packet_size, max_packet_size);
 
 			}
-			else if( !memcmp(curpos,ASF_STREAM_PROPERTIES, 16 ) )
+			else if( !memcmp(current_position,ASF_STREAM_PROPERTIES, 16 ) )
 			{
 				dbg_print(CCX_DMT_PARSE, "\nStream Properties Object     (size: %lld)\n", hpobjectsize);
-				if( !memcmp(curpos+24, ASF_VIDEO_MEDIA, 16 ) )
+				if( !memcmp(current_position+24, ASF_VIDEO_MEDIA, 16 ) )
 				{
-					asf_data_container.StreamProperties.VideoStreamNumber = *(curpos + 72) & 0x7F;
+					asf_data_container.StreamProperties.VideoStreamNumber = *(current_position + 72) & 0x7F;
 					dbg_print(CCX_DMT_PARSE, "Stream Type: ASF_Video_Media\n");
 					dbg_print(CCX_DMT_PARSE, "Video Stream Number: %d\n", asf_data_container.StreamProperties.VideoStreamNumber);
 
 				}
-				else if( !memcmp(curpos+24, ASF_AUDIO_MEDIA, 16 ) )
+				else if( !memcmp(current_position+24, ASF_AUDIO_MEDIA, 16 ) )
 				{
-					asf_data_container.StreamProperties.AudioStreamNumber = *(curpos + 72) & 0x7F;
+					asf_data_container.StreamProperties.AudioStreamNumber = *(current_position + 72) & 0x7F;
 					dbg_print(CCX_DMT_PARSE, "Stream Type: ASF_Audio_Media\n");
 					dbg_print(CCX_DMT_PARSE, "Audio Stream Number: %d\n", asf_data_container.StreamProperties.AudioStreamNumber);
 				}
 				else
 				{
 					dbg_print(CCX_DMT_PARSE, "Stream Type: %s\n",
-							gui_data_string(curpos+24));
-					dbg_print(CCX_DMT_PARSE, "Stream Number: %d\n", *(curpos+72) & 0x7F );
+							gui_data_string(current_position+24));
+					dbg_print(CCX_DMT_PARSE, "Stream Number: %d\n", *(current_position+72) & 0x7F );
 				}
 			}
-			else if( !memcmp(curpos,ASF_HEADER_EXTENSION, 16 ) )
+			else if( !memcmp(current_position,ASF_HEADER_EXTENSION, 16 ) )
 			{
 				dbg_print(CCX_DMT_PARSE, "\nHeader Extension Object     (size: %lld)\n", hpobjectsize);
 
-				int32_t HeaderExtensionDataSize = *((uint32_t*)(curpos+42));
+				int32_t header_extension_data_size = *((uint32_t*)(current_position+42));
 				// Process Header Extension Data
-				if ( HeaderExtensionDataSize )
+				if ( header_extension_data_size )
 				{
-					unsigned char *hecurpos=curpos+46;
+					unsigned char *header_current_position=current_position+46;
 
-					if ( HeaderExtensionDataSize != hpobjectsize - 46 )
-						fatal(EXIT_NOT_CLASSIFIED, "HeaderExtensionDataSize size wrong");
+					if ( header_extension_data_size != hpobjectsize - 46 )
+						fatal(EXIT_NOT_CLASSIFIED, "header_extension_data_size size wrong");
 
 					dbg_print(CCX_DMT_PARSE, "\nReading Header Extension Sub-Objects\n");
-					while( hecurpos < curpos+46 + HeaderExtensionDataSize )
+					while( header_current_position < current_position+46 + header_extension_data_size )
 					{
-						int64_t heobjectsize = *((int64_t*)(hecurpos+16)); // Local
+						int64_t header_object_size = *((int64_t*)(header_current_position+16)); // Local
 
-						if( !memcmp(hecurpos,ASF_EXTENDED_STREAM_PROPERTIES, 16 ) )
+						if( !memcmp(header_current_position,ASF_EXTENDED_STREAM_PROPERTIES, 16 ) )
 						{
-							dbg_print(CCX_DMT_PARSE, "\nExtended Stream Properties Object     (size: %lld)\n", heobjectsize);
-							int StreamNumber = *((uint16_t*)(hecurpos+72));
-							int StreamNameCount = *((uint16_t*)(hecurpos+84));
-							int PayloadExtensionSystemCount = *((uint16_t*)(hecurpos+86));
+							dbg_print(CCX_DMT_PARSE, "\nExtended Stream Properties Object     (size: %lld)\n", header_object_size);
+							int stream_number = *((uint16_t*)(header_current_position+72));
+							int stream_name_count = *((uint16_t*)(header_current_position+84));
+							int payload_ext_system_count = *((uint16_t*)(header_current_position+86));
 
-							unsigned char *estreamproppos=hecurpos+88;
+							unsigned char *stream_prop_position=header_current_position+88;
 
-							int streamnamelength;
+							int stream_name_length;
 
 							dbg_print(CCX_DMT_PARSE, "Stream Number: %d NameCount: %d  ESCount: %d\n",
-									StreamNumber, StreamNameCount, PayloadExtensionSystemCount);
+									stream_number, stream_name_count, payload_ext_system_count);
 
-							if ( StreamNumber >= STREAMNUM )
+							if ( stream_number >= STREAMNUM )
 								fatal(CCX_COMMON_EXIT_BUG_BUG, "STREAMNUM too small. Send bug report!/n");
 
-							for(int i=0; i<StreamNameCount; i++)
+							for(int i=0; i<stream_name_count; i++)
 							{
 								dbg_print(CCX_DMT_PARSE,"%2d. Stream Name Field\n",i);
-								streamnamelength=*((uint16_t*)(estreamproppos+2));
-								estreamproppos+=4+streamnamelength;
+								stream_name_length=*((uint16_t*)(stream_prop_position+2));
+								stream_prop_position+=4+stream_name_length;
 							}
-							int extensionsystemdatasize;
-							int extensionsysteminfolength;
+							int ext_system_data_size;
+							int ext_system_info_length;
 
-							if ( PayloadExtensionSystemCount > PAYEXTNUM )
+							if ( payload_ext_system_count > PAYEXTNUM )
 								fatal(CCX_COMMON_EXIT_BUG_BUG, "PAYEXTNUM too small. Send bug report!/n");
 
-							for(int i=0; i<PayloadExtensionSystemCount; i++)
+							for(int i=0; i<payload_ext_system_count; i++)
 							{
-								extensionsystemdatasize = *((uint16_t*)(estreamproppos+16));
-								extensionsysteminfolength = *((uint32_t*)(estreamproppos+18));
+								ext_system_data_size = *((uint16_t*)(stream_prop_position+16));
+								ext_system_info_length = *((uint32_t*)(stream_prop_position+18));
 
-								asf_data_container.PayloadExtSize[StreamNumber][i] = extensionsystemdatasize;
+								asf_data_container.PayloadExtSize[stream_number][i] = ext_system_data_size;
 
 								dbg_print(CCX_DMT_PARSE,"%2d. Payload Extension GUID: %s Size %d Info Length %d\n",
-										i,gui_data_string(estreamproppos+0),
-										extensionsystemdatasize,
-										extensionsysteminfolength);
+										i,gui_data_string(stream_prop_position+0),
+										ext_system_data_size,
+										ext_system_info_length);
 
 								// For DVR-MS presentation timestamp
-								if( !memcmp(estreamproppos, DVRMS_PTS, 16 ) )
+								if( !memcmp(stream_prop_position, DVRMS_PTS, 16 ) )
 								{
 									dbg_print(CCX_DMT_PARSE, "Found DVRMS_PTS\n");
-									asf_data_container.PayloadExtPTSEntry[StreamNumber] = i;
+									asf_data_container.PayloadExtPTSEntry[stream_number] = i;
 								}
 
-								estreamproppos+=22+extensionsysteminfolength;
+								stream_prop_position+=22+ext_system_info_length;
 							}
 
 							// Now, there can be a Stream Properties Object.  The only way to
 							// find out is to check if there are bytes left in the current
 							// object.
-							if ( (estreamproppos - hecurpos) < heobjectsize )
+							if ( (stream_prop_position - header_current_position) < header_object_size )
 							{
-								int64_t spobjectsize = *((int64_t*)(estreamproppos+16)); // Local
-								if( memcmp(estreamproppos, ASF_STREAM_PROPERTIES, 16 ) )
+								int64_t stream_prop_object_size = *((int64_t*)(stream_prop_position+16)); // Local
+								if( memcmp(stream_prop_position, ASF_STREAM_PROPERTIES, 16 ) )
 									fatal(EXIT_NOT_CLASSIFIED, "Stream Properties Object expected\n");
 
-								if( !memcmp(estreamproppos+24, ASF_VIDEO_MEDIA, 16 ) )
+								if( !memcmp(stream_prop_position+24, ASF_VIDEO_MEDIA, 16 ) )
 								{
 									dbg_print(CCX_DMT_PARSE, "Stream Type: ASF_Video_Media (size: %lld)\n",
-											spobjectsize);
-									asf_data_container.StreamProperties.VideoStreamNumber = StreamNumber;
+											stream_prop_object_size);
+									asf_data_container.StreamProperties.VideoStreamNumber = stream_number;
 								}
-								else if( !memcmp(estreamproppos+24, ASF_AUDIO_MEDIA, 16 ) )
+								else if( !memcmp(stream_prop_position+24, ASF_AUDIO_MEDIA, 16 ) )
 								{
 									dbg_print(CCX_DMT_PARSE, "Stream Type: ASF_Audio_Media (size: %lld)\n",
-											spobjectsize);
-									asf_data_container.StreamProperties.AudioStreamNumber = StreamNumber;
+											stream_prop_object_size);
+									asf_data_container.StreamProperties.AudioStreamNumber = stream_number;
 								}
-								else if( !memcmp(estreamproppos+24, ASF_BINARY_MEDIA, 16 ) )
+								else if( !memcmp(stream_prop_position+24, ASF_BINARY_MEDIA, 16 ) )
 								{
 									// dvr-ms files identify audio streams as binary streams
 									// but use the "major media type" accordingly to identify
 									// the steam.  (There might be other audio identifiers.)
-									if( !memcmp(estreamproppos+78, DVRMS_AUDIO, 16 ) ) {
+									if( !memcmp(stream_prop_position+78, DVRMS_AUDIO, 16 ) ) {
 										dbg_print(CCX_DMT_PARSE, "Binary media: DVR-MS Audio Stream (size: %lld)\n",
-												spobjectsize);
+												stream_prop_object_size);
 									}
-									else if( !memcmp(estreamproppos+78, DVRMS_NTSC, 16 ) )
+									else if( !memcmp(stream_prop_position+78, DVRMS_NTSC, 16 ) )
 									{
 										dbg_print(CCX_DMT_PARSE, "Binary media: NTSC captions (size: %lld)\n",
-												spobjectsize);
-										asf_data_container.StreamProperties.CaptionStreamNumber = StreamNumber;
+												stream_prop_object_size);
+										asf_data_container.StreamProperties.CaptionStreamNumber = stream_number;
 										asf_data_container.StreamProperties.CaptionStreamStyle = 1;
 
 									}
-									else if( !memcmp(estreamproppos+78, DVRMS_ATSC, 16 ) )
+									else if( !memcmp(stream_prop_position+78, DVRMS_ATSC, 16 ) )
 									{
 										dbg_print(CCX_DMT_PARSE, "Binary media: ATSC captions (size: %lld)\n",
-												spobjectsize);
-										asf_data_container.StreamProperties.CaptionStreamNumber = StreamNumber;
+												stream_prop_object_size);
+										asf_data_container.StreamProperties.CaptionStreamNumber = stream_number;
 										asf_data_container.StreamProperties.CaptionStreamStyle = 2;
 									}
 									else
 									{
 										dbg_print(CCX_DMT_PARSE, "Binary media: Major Media Type GUID: %s (size: %lld)\n",
-												gui_data_string(estreamproppos+78), spobjectsize);
+												gui_data_string(stream_prop_position+78), stream_prop_object_size);
 									}
 								}
 								else
 								{
 									dbg_print(CCX_DMT_PARSE, "Unknown Type GUID: %s (size: %lld)\n",
-											gui_data_string(estreamproppos+24), spobjectsize);
+											gui_data_string(stream_prop_position+24), stream_prop_object_size);
 								}
 							}
 							else
@@ -384,122 +384,122 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 							}
 
 						}
-						else if( !memcmp(hecurpos,ASF_METADATA, 16 ) )
+						else if( !memcmp(header_current_position,ASF_METADATA, 16 ) )
 						{
-							dbg_print(CCX_DMT_PARSE, "\nMetadata Object     (size: %lld)\n", heobjectsize);
+							dbg_print(CCX_DMT_PARSE, "\nMetadata Object     (size: %lld)\n", header_object_size);
 						}
-						else if( !memcmp(hecurpos,ASF_METADATA_LIBRARY, 16 ) )
+						else if( !memcmp(header_current_position,ASF_METADATA_LIBRARY, 16 ) )
 						{
-							dbg_print(CCX_DMT_PARSE, "\nMetadata Library Object     (size: %lld)\n", heobjectsize);
+							dbg_print(CCX_DMT_PARSE, "\nMetadata Library Object     (size: %lld)\n", header_object_size);
 						}
-						else if( !memcmp(hecurpos,ASF_COMPATIBILITY2, 16 ) )
+						else if( !memcmp(header_current_position,ASF_COMPATIBILITY2, 16 ) )
 						{
-							dbg_print(CCX_DMT_PARSE, "\nCompatibility Object 2     (size: %lld)\n", heobjectsize);
+							dbg_print(CCX_DMT_PARSE, "\nCompatibility Object 2     (size: %lld)\n", header_object_size);
 						}
-						else if( !memcmp(hecurpos,ASF_PADDING, 16 ) )
+						else if( !memcmp(header_current_position,ASF_PADDING, 16 ) )
 						{
-							dbg_print(CCX_DMT_PARSE, "\nPadding Object     (size: %lld)\n", heobjectsize);
+							dbg_print(CCX_DMT_PARSE, "\nPadding Object     (size: %lld)\n", header_object_size);
 						}
 						else
 						{
 							dbg_print(CCX_DMT_PARSE, "\nGUID: %s  size: %lld\n",
-									gui_data_string(hecurpos), heobjectsize);
-							dump(CCX_DMT_PARSE, hecurpos, 16, 0, 0);
+									gui_data_string(header_current_position), header_object_size);
+							dump(CCX_DMT_PARSE, header_current_position, 16, 0, 0);
 						}
 
-						hecurpos += heobjectsize;
+						header_current_position += header_object_size;
 					}
-					if (hecurpos - (curpos+46) != HeaderExtensionDataSize)
+					if (header_current_position - (current_position+46) != header_extension_data_size)
 						fatal(EXIT_NOT_CLASSIFIED, "HE Parsing problem: read bytes %ld != header length %lld\nAbort!\n",
-								(long)(hecurpos - (curpos+46)), HeaderExtensionDataSize);
+								(long)(header_current_position - (current_position+46)), header_extension_data_size);
 				}
 				dbg_print(CCX_DMT_PARSE, "\nHeader Extension Object  -  End\n");
 
 			}
-			else if( !memcmp(curpos,ASF_CONTENT_DESCRIPTION, 16 ) )
+			else if( !memcmp(current_position,ASF_CONTENT_DESCRIPTION, 16 ) )
 			{
 				dbg_print(CCX_DMT_PARSE, "\nContend Description Object     (size: %lld)\n", hpobjectsize);
 			}
-			else if( !memcmp(curpos,ASF_EXTENDED_CONTENT_DESCRIPTION, 16 ) )
+			else if( !memcmp(current_position,ASF_EXTENDED_CONTENT_DESCRIPTION, 16 ) )
 			{
 				dbg_print(CCX_DMT_PARSE, "\nExtended Content Description Object     (size: %lld)\n", hpobjectsize);
 
-				int ContentDescriptorsCount = *((uint16_t*)(curpos+24));
-				unsigned char *econtentpos=curpos+26;
-				int DescriptorNameLength;
-				int DescriptorValueDataType;
-				int DescriptorValueLength;
-				unsigned char *edescval;
+				int content_descriptor_count = *((uint16_t*)(current_position+24));
+				unsigned char *ext_content_position=current_position+26;
+				int descriptor_name_length;
+				int descriptor_value_data_type;
+				int descriptor_value_length;
+				unsigned char *extended_description_value;
 
-				for(int i=0; i<ContentDescriptorsCount; i++)
+				for(int i=0; i<content_descriptor_count; i++)
 				{
-					DescriptorNameLength = *((uint16_t*)(econtentpos));
-					DescriptorValueDataType = *((uint16_t*)(econtentpos+2+DescriptorNameLength));
-					DescriptorValueLength = *((uint16_t*)(econtentpos+4+DescriptorNameLength));
-					edescval = econtentpos+6+DescriptorNameLength;
+					descriptor_name_length = *((uint16_t*)(ext_content_position));
+					descriptor_value_data_type = *((uint16_t*)(ext_content_position+2+descriptor_name_length));
+					descriptor_value_length = *((uint16_t*)(ext_content_position+4+descriptor_name_length));
+					extended_description_value = ext_content_position+6+descriptor_name_length;
 
-					dbg_print(CCX_DMT_PARSE, "%3d. %ls = ",i,(wchar_t*)(econtentpos+2));
-					switch(DescriptorValueDataType)
+					dbg_print(CCX_DMT_PARSE, "%3d. %ls = ",i,(wchar_t*)(ext_content_position+2));
+					switch(descriptor_value_data_type)
 					{
 						case 0: // Unicode string
-							dbg_print(CCX_DMT_PARSE, "%ls (Unicode)\n",(wchar_t*)edescval);
+							dbg_print(CCX_DMT_PARSE, "%ls (Unicode)\n",(wchar_t*)extended_description_value);
 							break;
 						case 1: // byte string
 							dbg_print(CCX_DMT_PARSE, ":");
-							for(int ii=0; ii<DescriptorValueLength && ii<9; ii++)
+							for(int ii=0; ii<descriptor_value_length && ii<9; ii++)
 							{
-								dbg_print(CCX_DMT_PARSE, "%02X:",*((unsigned char*)(edescval+ii)));
+								dbg_print(CCX_DMT_PARSE, "%02X:",*((unsigned char*)(extended_description_value+ii)));
 							}
-							if (DescriptorValueLength>8)
-								dbg_print(CCX_DMT_PARSE, "skipped %d more",DescriptorValueLength-8);
+							if (descriptor_value_length>8)
+								dbg_print(CCX_DMT_PARSE, "skipped %d more",descriptor_value_length-8);
 							dbg_print(CCX_DMT_PARSE, " (BYTES)\n");
 							break;
 						case 2: // BOOL
-							dbg_print(CCX_DMT_PARSE, "%d (BOOL)\n",*((int32_t*)edescval));
+							dbg_print(CCX_DMT_PARSE, "%d (BOOL)\n",*((int32_t*)extended_description_value));
 							break;
 						case 3: // DWORD
-							dbg_print(CCX_DMT_PARSE, "%u (DWORD)\n",*((uint32_t*)edescval));
+							dbg_print(CCX_DMT_PARSE, "%u (DWORD)\n",*((uint32_t*)extended_description_value));
 							break;
 						case 4: // QWORD
-							dbg_print(CCX_DMT_PARSE, "%llu (QWORD)\n",*((uint64_t*)edescval));
+							dbg_print(CCX_DMT_PARSE, "%llu (QWORD)\n",*((uint64_t*)extended_description_value));
 							break;
 						case 5: // WORD
-							dbg_print(CCX_DMT_PARSE, "%u (WORD)\n",(int)*((uint16_t*)edescval));
+							dbg_print(CCX_DMT_PARSE, "%u (WORD)\n",(int)*((uint16_t*)extended_description_value));
 							break;
 						default:
 							fatal(CCX_COMMON_EXIT_BUG_BUG, "Wrong type ...\n");
 							break;
 					}
 
-					if(!memcmp(econtentpos+2, L"WM/VideoClosedCaptioning"
-								,DescriptorNameLength))
+					if(!memcmp(ext_content_position+2, L"WM/VideoClosedCaptioning"
+								,descriptor_name_length))
 					{
 						// This flag would be really usefull if it would be
 						// reliable - it isn't.
-						asf_data_container.VideoClosedCaptioningFlag = *((int32_t*)edescval);
+						asf_data_container.VideoClosedCaptioningFlag = *((int32_t*)extended_description_value);
 						dbg_print(CCX_DMT_PARSE, "Found WM/VideoClosedCaptioning flag: %d\n",
 								asf_data_container.VideoClosedCaptioningFlag);
 					}
 
-					econtentpos+=6+DescriptorNameLength+DescriptorValueLength;
+					ext_content_position+=6+descriptor_name_length+descriptor_value_length;
 				}
 			}
-			else if( !memcmp(curpos,ASF_STREAM_BITRATE_PROPERTIES, 16 ) )
+			else if( !memcmp(current_position,ASF_STREAM_BITRATE_PROPERTIES, 16 ) )
 			{
 				dbg_print(CCX_DMT_PARSE, "\nStream Bitrate Properties Object     (size: %lld)\n", hpobjectsize);
 			}
 			else
 			{
 				dbg_print(CCX_DMT_PARSE, "\nGUID: %s  size: %lld\n",
-						gui_data_string(curpos), hpobjectsize);
-				dump(CCX_DMT_PARSE, curpos, 16, 0, 0);
+						gui_data_string(current_position), hpobjectsize);
+				dump(CCX_DMT_PARSE, current_position, 16, 0, 0);
 			}
 
-			curpos += hpobjectsize;
+			current_position += hpobjectsize;
 		}
-		if (curpos - asf_data_container.parsebuf != asf_data_container.HeaderObjectSize)
+		if (current_position - asf_data_container.parsebuf != asf_data_container.HeaderObjectSize)
 			fatal(EXIT_NOT_CLASSIFIED, "Parsing problem: read bytes %ld != header length %lld\nAbort!\n",
-					(long)(curpos - asf_data_container.parsebuf), asf_data_container.HeaderObjectSize);
+					(long)(current_position - asf_data_container.parsebuf), asf_data_container.HeaderObjectSize);
 
 		if (asf_data_container.StreamProperties.VideoStreamNumber == 0)
 			fatal(EXIT_NOT_CLASSIFIED, "No Video Stream Properties Object found.  Unable to continue ...\n");
@@ -541,9 +541,9 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 
 		// When reading "Payload parsing information" it occured that "Packet Lenght"
 		// was not set (Packet Length Type 00) and for "Single Payloads" this means
-		// the Payload Data Length cannot be infered.  Use MinPacketSize, MaxPacketSize instead.
-		if ((MinPacketSize > 0) && (MinPacketSize == MaxPacketSize))
-			asf_data_container.PacketSize = MinPacketSize;
+		// the Payload Data Length cannot be infered.  Use min_packet_size, max_packet_size instead.
+		if ((min_packet_size > 0) && (min_packet_size == max_packet_size))
+			asf_data_container.PacketSize = min_packet_size;
 
 		// Now the Data Object, except for the packages
 		result = buffered_read(ctx->demux_ctx, asf_data_container.parsebuf, 50); // No realloc needed.
@@ -583,7 +583,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 		{
 			int ecinfo = 0;
 
-			datapacketlength = 0;
+			data_packet_length = 0;
 
 			dbg_print(CCX_DMT_PARSE, "\nReading packet %d/%d\n", asf_data_container.datapacketcur + 1, asf_data_container.TotalDataPackets);
 
@@ -597,7 +597,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 				end_of_file=1;
 				return payload_read;
 			}
-			datapacketlength+=1;
+			data_packet_length+=1;
 			if (*asf_data_container.parsebuf & 0x80)
 			{
 				int ecdatalength = *asf_data_container.parsebuf & 0x0F; // Small, no realloc needed
@@ -614,7 +614,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 					end_of_file=1;
 					return payload_read;
 				}
-				datapacketlength+=ecdatalength;
+				data_packet_length+=ecdatalength;
 				if (asf_data_container.parsebuf[1] & 0x0F)
 					fatal(EXIT_NOT_CLASSIFIED, "Error correction present.  Unable to continue ...\n");
 			}
@@ -635,15 +635,15 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 				end_of_file=1;
 				return payload_read;
 			}
-			datapacketlength+=2;
+			data_packet_length+=2;
 
 			asf_data_container.MultiplePayloads = *asf_data_container.parsebuf & 0x01;
 
-			SequenceType = (*asf_data_container.parsebuf >> 1) & 0x03;
-			SequenceType = ASF_TypeLength(SequenceType);
+			sequence_type = (*asf_data_container.parsebuf >> 1) & 0x03;
+			sequence_type = ASF_TypeLength(sequence_type);
 
-			PaddingLType = (*asf_data_container.parsebuf >> 3) & 0x03;
-			PaddingLType = ASF_TypeLength(PaddingLType);
+			padding_l_type = (*asf_data_container.parsebuf >> 3) & 0x03;
+			padding_l_type = ASF_TypeLength(padding_l_type);
 
 			asf_data_container.PacketLType = (*asf_data_container.parsebuf >> 5) & 0x03;
 			asf_data_container.PacketLType = ASF_TypeLength(asf_data_container.PacketLType);
@@ -660,24 +660,24 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 			asf_data_container.StreamNumberLType = (asf_data_container.parsebuf[1] >> 6) & 0x03;
 			asf_data_container.StreamNumberLType = ASF_TypeLength(asf_data_container.StreamNumberLType);
 
-			payloadparsersize = asf_data_container.PacketLType + SequenceType + PaddingLType + 6;
+			payload_parser_size = asf_data_container.PacketLType + sequence_type + padding_l_type + 6;
 
-			result = buffered_read(ctx->demux_ctx, asf_data_container.parsebuf + 2, payloadparsersize); // No realloc needed
+			result = buffered_read(ctx->demux_ctx, asf_data_container.parsebuf + 2, payload_parser_size); // No realloc needed
 			ctx->demux_ctx->past += result;
 			asf_data_container.dobjectread += result;
-			if (result!=payloadparsersize)
+			if (result!=payload_parser_size)
 			{
 				mprint("Premature end of file!\n");
 				end_of_file=1;
 				return payload_read;
 			}
-			datapacketlength+=payloadparsersize;
+			data_packet_length+=payload_parser_size;
 
 			asf_data_container.PacketLength = asf_readval(asf_data_container.parsebuf + 2, asf_data_container.PacketLType);
-			Sequence = asf_readval(asf_data_container.parsebuf + 2 + asf_data_container.PacketLType, SequenceType);
-			asf_data_container.PaddingLength = asf_readval(asf_data_container.parsebuf + 2 + asf_data_container.PacketLType + SequenceType, PaddingLType);
+			sequence = asf_readval(asf_data_container.parsebuf + 2 + asf_data_container.PacketLType, sequence_type);
+			asf_data_container.PaddingLength = asf_readval(asf_data_container.parsebuf + 2 + asf_data_container.PacketLType + sequence_type, padding_l_type);
 			// Data Packet ms time stamp
-			SendTime = *((uint32_t*)(asf_data_container.parsebuf + 2 + asf_data_container.PacketLType + SequenceType + PaddingLType));
+			send_time = *((uint32_t*)(asf_data_container.parsebuf + 2 + asf_data_container.PacketLType + sequence_type + padding_l_type));
 
 			// If Packet Length is not set use global setting if possible
 			if (asf_data_container.PacketLength == 0)
@@ -689,8 +689,8 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 					fatal(EXIT_NOT_CLASSIFIED, "No idea how long the data packet will be. Abort.\n");
 			}
 
-			dbg_print(CCX_DMT_PARSE, "Lengths - Packet: %d / Sequence %d / Padding %d\n",
-					asf_data_container.PacketLength, Sequence, asf_data_container.PaddingLength);
+			dbg_print(CCX_DMT_PARSE, "Lengths - Packet: %d / sequence %d / Padding %d\n",
+					asf_data_container.PacketLength, sequence, asf_data_container.PaddingLength);
 
 			asf_data_container.PayloadLType = 0; // Payload Length Type. <>0 for multiple payloads
 			asf_data_container.PayloadLength = 0; // Payload Length (for multiple payloads)
@@ -709,7 +709,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 					end_of_file=1;
 					return payload_read;
 				}
-				datapacketlength+=1;
+				data_packet_length+=1;
 				asf_data_container.PayloadLType = (*plheader >> 6) & 0x03;
 				asf_data_container.PayloadLType = ASF_TypeLength(asf_data_container.PayloadLType);
 
@@ -737,49 +737,49 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 				else
 					dbg_print(CCX_DMT_PARSE, "\nMultiple payloads %d/%d\n", asf_data_container.payloadcur + 1, asf_data_container.NumberOfPayloads);
 
-				int payloadheadersize = 1 + asf_data_container.MediaNumberLType + asf_data_container.OffsetMediaLType + asf_data_container.ReplicatedLType;
+				int payload_header_size = 1 + asf_data_container.MediaNumberLType + asf_data_container.OffsetMediaLType + asf_data_container.ReplicatedLType;
 
-				result = buffered_read(ctx->demux_ctx, asf_data_container.parsebuf, payloadheadersize); // No realloc needed
+				result = buffered_read(ctx->demux_ctx, asf_data_container.parsebuf, payload_header_size); // No realloc needed
 				ctx->demux_ctx->past += result;
 				asf_data_container.dobjectread += result;
-				if (result!=payloadheadersize)
+				if (result!=payload_header_size)
 				{
 					mprint("Premature end of file!\n");
 					end_of_file=1;
 					return payload_read;
 				}
-				datapacketlength+=payloadheadersize;
+				data_packet_length+=payload_header_size;
 
 				asf_data_container.PayloadStreamNumber = *asf_data_container.parsebuf & 0x7F;
 				asf_data_container.KeyFrame = (*asf_data_container.parsebuf & 0x80) && 1;
 
 				asf_data_container.PayloadMediaNumber = asf_readval(asf_data_container.parsebuf + 1, asf_data_container.MediaNumberLType);
-				OffsetMediaLength = asf_readval(asf_data_container.parsebuf + 1 + asf_data_container.MediaNumberLType, asf_data_container.OffsetMediaLType);
-				ReplicatedLength = asf_readval(asf_data_container.parsebuf + 1 + asf_data_container.MediaNumberLType + asf_data_container.OffsetMediaLType, asf_data_container.ReplicatedLType);
+				offset_media_length = asf_readval(asf_data_container.parsebuf + 1 + asf_data_container.MediaNumberLType, asf_data_container.OffsetMediaLType);
+				replicated_length = asf_readval(asf_data_container.parsebuf + 1 + asf_data_container.MediaNumberLType + asf_data_container.OffsetMediaLType, asf_data_container.ReplicatedLType);
 
-				if (ReplicatedLength == 1)
+				if (replicated_length == 1)
 					fatal(EXIT_NOT_CLASSIFIED, "Cannot handle compressed data...\n");
 
-				if ((long)ReplicatedLength > asf_data_container.parsebufsize)
+				if ((long)replicated_length > asf_data_container.parsebufsize)
 				{
-					asf_data_container.parsebuf = (unsigned char*)realloc(asf_data_container.parsebuf, ReplicatedLength);
+					asf_data_container.parsebuf = (unsigned char*)realloc(asf_data_container.parsebuf, replicated_length);
 					if (!asf_data_container.parsebuf)
 						fatal(EXIT_NOT_ENOUGH_MEMORY, "Out of memory");
-					asf_data_container.parsebufsize = ReplicatedLength;
+					asf_data_container.parsebufsize = replicated_length;
 				}
-				result = buffered_read(ctx->demux_ctx, asf_data_container.parsebuf, (long)ReplicatedLength);
+				result = buffered_read(ctx->demux_ctx, asf_data_container.parsebuf, (long)replicated_length);
 				ctx->demux_ctx->past += result;
 				asf_data_container.dobjectread += result;
-				if (result!=ReplicatedLength)
+				if (result!=replicated_length)
 				{
 					mprint("Premature end of file!\n");
 					end_of_file=1;
 					return payload_read;
 				}
 				// Parse Replicated data
-				unsigned char *reppos = asf_data_container.parsebuf;
-				int MediaObjectSize = 0;
-				int PresentationTimems = 0; //Payload ms time stamp
+				unsigned char *replicate_position = asf_data_container.parsebuf;
+				int media_object_size = 0;
+				int presentation_time_millis = 0; //Payload ms time stamp
 				int extsize = 0;
 				// int32_t dwVersion = 0;
 				// int32_t unknown = 0;
@@ -787,35 +787,35 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 				int64_t rtEnd = 0; // dvr-ms 100ns time stamp end
 
 				// Always at least 8 bytes long, see 7.3.1
-				MediaObjectSize = *((uint16_t*)(asf_data_container.parsebuf));
-				PresentationTimems = *((uint16_t*)(asf_data_container.parsebuf + 4));
-				reppos += 8;
+				media_object_size = *((uint16_t*)(asf_data_container.parsebuf));
+				presentation_time_millis = *((uint16_t*)(asf_data_container.parsebuf + 4));
+				replicate_position += 8;
 
 				dbg_print(CCX_DMT_PARSE, "Stream# %d[%d] Media# %d Offset/Size: %d/%d\n",
 						asf_data_container.PayloadStreamNumber, asf_data_container.KeyFrame, asf_data_container.PayloadMediaNumber,
-						OffsetMediaLength, MediaObjectSize);
+						offset_media_length, media_object_size);
 
 				// Loop over Payload Extension Systems
 				for (int i = 0; i<asf_data_container.PayloadExtPTSEntry[asf_data_container.PayloadStreamNumber]; i++)
 				{
 					if (asf_data_container.PayloadExtSize[asf_data_container.PayloadStreamNumber][i] == 0xffff)
 					{
-						extsize = *((uint16_t*)(reppos+0));
-						reppos += 2;
+						extsize = *((uint16_t*)(replicate_position+0));
+						replicate_position += 2;
 					}
 					else
 					{
 						extsize = asf_data_container.PayloadExtSize[asf_data_container.PayloadStreamNumber][i];
 					}
-					reppos += extsize;
+					replicate_position += extsize;
 					//printf("%2d. Ext. System - size: %d\n", i, extsize);
 				}
 				if (asf_data_container.PayloadExtPTSEntry[asf_data_container.PayloadStreamNumber] > 0)
 				{
-					// dwVersion = *((uint32_t*)(reppos+0));
-					// unknown = *((uint32_t*)(reppos+4));
-					rtStart = *((int64_t*)(reppos+8));
-					rtEnd = *((int64_t*)(reppos+16));
+					// dwVersion = *((uint32_t*)(replicate_position+0));
+					// unknown = *((uint32_t*)(replicate_position+4));
+					rtStart = *((int64_t*)(replicate_position+8));
+					rtEnd = *((int64_t*)(replicate_position+16));
 
 					//printf("dwVersion: %d    unknown: 0x%04X\n", dwVersion, unknown);
 				}
@@ -830,13 +830,13 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 
 				// print_mstime uses a static buffer
 				dbg_print(CCX_DMT_PARSE, "Stream #%d PacketTime: %s",
-						asf_data_container.PayloadStreamNumber, print_mstime_static(SendTime));
+						asf_data_container.PayloadStreamNumber, print_mstime_static(send_time));
 				dbg_print(CCX_DMT_PARSE,"   PayloadTime: %s",
-						print_mstime_static(PresentationTimems));
+						print_mstime_static(presentation_time_millis));
 				dbg_print(CCX_DMT_PARSE,"   dvr-ms PTS: %s+%lld\n",
 						print_mstime_static(rtStart/10000), (rtEnd-rtStart)/10000);
 
-				datapacketlength+=ReplicatedLength;
+				data_packet_length+=replicated_length;
 
 				// Only multiple payload packages have this value
 				if (asf_data_container.MultiplePayloads != 0)
@@ -856,21 +856,21 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 				}
 				else
 				{
-					asf_data_container.PayloadLength = asf_data_container.PacketLength - datapacketlength - asf_data_container.PaddingLength;
+					asf_data_container.PayloadLength = asf_data_container.PacketLength - data_packet_length - asf_data_container.PaddingLength;
 				}
 				dbg_print(CCX_DMT_PARSE, "Size - Replicated %d + Payload %d = %d\n",
-						ReplicatedLength, asf_data_container.PayloadLength, ReplicatedLength + asf_data_container.PayloadLength);
+						replicated_length, asf_data_container.PayloadLength, replicated_length + asf_data_container.PayloadLength);
 
 				// Remember the last video time stamp - only when captions are separate
 				// from video stream.
 				if (asf_data_container.PayloadStreamNumber == asf_data_container.StreamProperties.VideoStreamNumber
 						&& asf_data_container.StreamProperties.DecodeStreamNumber != asf_data_container.StreamProperties.VideoStreamNumber
-						&& OffsetMediaLength == 0)
+						&& offset_media_length == 0)
 				{
 					asf_data_container.StreamProperties.prevVideoStreamMS = asf_data_container.StreamProperties.currVideoStreamMS;
 					asf_data_container.StreamProperties.currVideoStreamMS = asf_data_container.StreamProperties.VideoStreamMS;
 
-					// Use PresentationTimems (SendTime might also work) when the
+					// Use presentation_time_millis (send_time might also work) when the
 					// dvr-ms time stamp is not present.
 					if (asf_data_container.PayloadExtPTSEntry[asf_data_container.PayloadStreamNumber] > 0)
 					{
@@ -881,7 +881,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 					else
 					{
 						// Add 1ms to avoid 0ms start times getting rejected
-						asf_data_container.StreamProperties.VideoStreamMS = PresentationTimems + 1;
+						asf_data_container.StreamProperties.VideoStreamMS = presentation_time_millis + 1;
 					}
 					// This checks if there is a video time jump in the timeline
 					// between caption information.
@@ -896,12 +896,12 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 
 				// Remember the PTS values
 				if (asf_data_container.PayloadStreamNumber == asf_data_container.StreamProperties.DecodeStreamNumber
-						&& OffsetMediaLength == 0)
+						&& offset_media_length == 0)
 				{
 					asf_data_container.StreamProperties.prevDecodeStreamPTS = asf_data_container.StreamProperties.currDecodeStreamPTS;
 					asf_data_container.StreamProperties.currDecodeStreamPTS = asf_data_container.StreamProperties.DecodeStreamPTS;
 
-					// Use PresentationTimems (SendTime might also work) when the
+					// Use presentation_time_millis (send_time might also work) when the
 					// dvr-ms time stamp is not present.
 					if (asf_data_container.PayloadExtPTSEntry[asf_data_container.PayloadStreamNumber] > 0)
 					{
@@ -912,7 +912,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 					else
 					{
 						// Add 1ms to avoid 0ms start times getting rejected
-						asf_data_container.StreamProperties.DecodeStreamPTS = PresentationTimems + 1;
+						asf_data_container.StreamProperties.DecodeStreamPTS = presentation_time_millis + 1;
 					}
 
 					// Check the caption stream for jumps in the timeline. This
@@ -955,9 +955,9 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 
 			// Video streams need several packages to complete a PES.  Leave
 			// the loop when the next package starts a new Media Object.
-			if ( curmedianumber != 0xFFFFFFFF  // Is initialized
+			if ( current_media_number != 0xFFFFFFFF  // Is initialized
 					&& asf_data_container.PayloadStreamNumber == asf_data_container.StreamProperties.DecodeStreamNumber
-					&& asf_data_container.PayloadMediaNumber != curmedianumber)
+					&& asf_data_container.PayloadMediaNumber != current_media_number)
 			{
 				if (asf_data_container.StreamProperties.DecodeStreamNumber == asf_data_container.StreamProperties.CaptionStreamNumber)
 					dbg_print(CCX_DMT_PARSE, "\nCaption stream object");
@@ -975,7 +975,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 			// Read it!!
 			if (asf_data_container.PayloadStreamNumber == asf_data_container.StreamProperties.DecodeStreamNumber)
 			{
-				curmedianumber = asf_data_container.PayloadMediaNumber; // Remember current value
+				current_media_number = asf_data_container.PayloadMediaNumber; // Remember current value
 
 				// Read the data
 				dbg_print(CCX_DMT_PARSE, "Reading Stream #%d data ...\n", asf_data_container.PayloadStreamNumber);

--- a/src/lib_ccx/avc_functions.c
+++ b/src/lib_ccx/avc_functions.c
@@ -1156,7 +1156,7 @@ void slice_header (struct lib_cc_decode *ctx, unsigned char *heabuf, unsigned ch
 			pic_order_cnt_lsb, ctx->timing->current_tref,
 			curridx, ctx->avc_ctx->currref, ctx->avc_ctx->lastmaxidx, ctx->avc_ctx->maxtref);
 	dbg_print(CCX_DMT_TIME, "  sync_pts:%s (%8u)",
-			print_mstime(ctx->timing->sync_pts/(MPEG_CLOCK_FREQ/1000)),
+			print_mstime_static(ctx->timing->sync_pts/(MPEG_CLOCK_FREQ/1000)),
 			(unsigned) (ctx->timing->sync_pts));
 	dbg_print(CCX_DMT_TIME, " - %s since GOP: %2u",
 			slice_types[slice_type],

--- a/src/lib_ccx/avc_functions.c
+++ b/src/lib_ccx/avc_functions.c
@@ -87,18 +87,18 @@ struct avc_ctx *init_avc(void)
 	return ctx;
 }
 
-void do_NAL (struct lib_cc_decode *ctx, unsigned char *NALstart, LLONG NAL_length, struct cc_subtitle *sub)
+void do_NAL (struct lib_cc_decode *ctx, unsigned char *NAL_start, LLONG NAL_length, struct cc_subtitle *sub)
 {
-	unsigned char *NALstop;
-	enum ccx_avc_nal_types nal_unit_type = *NALstart & 0x1F;
+	unsigned char *NAL_stop;
+	enum ccx_avc_nal_types nal_unit_type = *NAL_start & 0x1F;
 
-	NALstop = NAL_length+NALstart;
-	NALstop = remove_03emu(NALstart+1, NALstop); // Add +1 to NALstop for TS, without it for MP4. Still don't know why
+	NAL_stop = NAL_length+NAL_start;
+	NAL_stop = remove_03emu(NAL_start+1, NAL_stop); // Add +1 to NAL_stop for TS, without it for MP4. Still don't know why
 
 	dvprint("BEGIN NAL unit type: %d length %d ref_idc: %d - Buffered captions before: %d\n",
-				nal_unit_type,  NALstop-NALstart-1, ctx->avc_ctx->nal_ref_idc, !ctx->avc_ctx->cc_buffer_saved);
+				nal_unit_type,  NAL_stop-NAL_start-1, ctx->avc_ctx->nal_ref_idc, !ctx->avc_ctx->cc_buffer_saved);
 
-	if (NALstop==NULL) // remove_03emu failed.
+	if (NAL_stop==NULL) // remove_03emu failed.
 	{
 		mprint ("\rNotice: NAL of type %u had to be skipped because remove_03emu failed.\n", nal_unit_type);
 		return;
@@ -113,7 +113,7 @@ void do_NAL (struct lib_cc_decode *ctx, unsigned char *NALstart, LLONG NAL_lengt
 		// Found sequence parameter set
 		// We need this to parse NAL type 1 (CCX_NAL_TYPE_CODED_SLICE_NON_IDR_PICTURE_1)
 		ctx->avc_ctx->num_nal_unit_type_7++;
-		seq_parameter_set_rbsp(ctx->avc_ctx, NALstart+1, NALstop);
+		seq_parameter_set_rbsp(ctx->avc_ctx, NAL_start+1, NAL_stop);
 		ctx->avc_ctx->got_seq_para = 1;
 	}
 	else if ( ctx->avc_ctx->got_seq_para && (nal_unit_type == CCX_NAL_TYPE_CODED_SLICE_NON_IDR_PICTURE_1 ||
@@ -122,13 +122,13 @@ void do_NAL (struct lib_cc_decode *ctx, unsigned char *NALstart, LLONG NAL_lengt
 		// Found coded slice of a non-IDR picture
 		// We only need the slice header data, no need to implement
 		// slice_layer_without_partitioning_rbsp( );
-		slice_header(ctx, NALstart+1, NALstop, nal_unit_type, sub);
+		slice_header(ctx, NAL_start+1, NAL_stop, nal_unit_type, sub);
 	}
 	else if ( ctx->avc_ctx->got_seq_para && nal_unit_type == CCX_NAL_TYPE_SEI )
 	{
 		// Found SEI (used for subtitles)
 		//set_fts(ctx->timing); // FIXME - check this!!!
-		sei_rbsp(ctx->avc_ctx, NALstart+1, NALstop);
+		sei_rbsp(ctx->avc_ctx, NAL_start+1, NAL_stop);
 	}
 	else if ( ctx->avc_ctx->got_seq_para && nal_unit_type == CCX_NAL_TYPE_PICTURE_PARAMETER_SET )
 	{
@@ -137,126 +137,126 @@ void do_NAL (struct lib_cc_decode *ctx, unsigned char *NALstart, LLONG NAL_lengt
 	if (temp_debug)
 	{
 		mprint ("NAL process failed.\n");
-		mprint ("\n After decoding, the actual thing was (length =%d)\n", NALstop-(NALstart+1));
-		dump (CCX_DMT_GENERIC_NOTICES,NALstart+1, NALstop-(NALstart+1),0, 0);
+		mprint ("\n After decoding, the actual thing was (length =%d)\n", NAL_stop-(NAL_start+1));
+		dump (CCX_DMT_GENERIC_NOTICES,NAL_start+1, NAL_stop-(NAL_start+1),0, 0);
 	}
 
 	dvprint("END   NAL unit type: %d length %d ref_idc: %d - Buffered captions after: %d\n",
-			nal_unit_type,  NALstop-NALstart-1, ctx->avc_ctx->nal_ref_idc, !ctx->avc_ctx->cc_buffer_saved);
+			nal_unit_type,  NAL_stop-NAL_start-1, ctx->avc_ctx->nal_ref_idc, !ctx->avc_ctx->cc_buffer_saved);
 
 }
 
 // Process inbuf bytes in buffer holding and AVC (H.264) video stream.
 // The number of processed bytes is returned.
-size_t process_avc ( struct lib_cc_decode *ctx, unsigned char *avcbuf, size_t avcbuflen ,struct cc_subtitle *sub)
+size_t process_avc ( struct lib_cc_decode *ctx, unsigned char *avc_buffer, size_t avc_buffer_length ,struct cc_subtitle *sub)
 {
-	unsigned char *bpos = avcbuf;
-	unsigned char *NALstart;
-	unsigned char *NALstop;
+	unsigned char *buffer_position = avc_buffer;
+	unsigned char *NAL_start;
+	unsigned char *NAL_stop;
 
 	// At least 5 bytes are needed for a NAL unit
-	if(avcbuflen <= 5)
+	if(avc_buffer_length <= 5)
 	{
 		fatal(CCX_COMMON_EXIT_BUG_BUG,
 				"NAL unit need at last 5 bytes ...");
 	}
 
 	// Warning there should be only leading zeros, nothing else
-	if( !(bpos[0]==0x00 && bpos[1]==0x00) )
+	if( !(buffer_position[0]==0x00 && buffer_position[1]==0x00) )
 	{
 		fatal(CCX_COMMON_EXIT_BUG_BUG,
 				"Broken AVC stream - no 0x0000 ...");
 	}
-	bpos = bpos+2;
+	buffer_position = buffer_position+2;
 
-	int firstloop=1; // Check for valid start code at buffer start
+	int first_loop=1; // Check for valid start code at buffer start
 
 	// Loop over NAL units
-	while(bpos < avcbuf + avcbuflen - 2) // bpos points to 0x01 plus at least two bytes
+	while(buffer_position < avc_buffer + avc_buffer_length - 2) // buffer_position points to 0x01 plus at least two bytes
 	{
 		int zeropad=0; // Count leading zeros
 
-		// Find next NALstart
-		while (bpos < avcbuf + avcbuflen)
+		// Find next NAL_start
+		while (buffer_position < avc_buffer + avc_buffer_length)
 		{
-			if(*bpos == 0x01)
+			if(*buffer_position == 0x01)
 			{
 				// OK, found a start code
 				break;
 			}
-			else if(firstloop && *bpos != 0x00)
+			else if(first_loop && *buffer_position != 0x00)
 			{
 				// Not 0x00 or 0x01
 				fatal(CCX_COMMON_EXIT_BUG_BUG,
 						"Broken AVC stream - no 0x00 ...");
 			}
-			bpos++;
+			buffer_position++;
 			zeropad++;
 		}
-		firstloop=0;
-		if (bpos >= avcbuf + avcbuflen)
+		first_loop=0;
+		if (buffer_position >= avc_buffer + avc_buffer_length)
 		{
 			// No new start sequence
 			break;
 		}
-		NALstart = bpos+1;
+		NAL_start = buffer_position+1;
 
 		// Find next start code or buffer end
 		LLONG restlen;
 		do
 		{
 			// Search for next 000000 or 000001
-			bpos++;
-			restlen = avcbuf - bpos + avcbuflen - 2; // leave room for two more bytes
+			buffer_position++;
+			restlen = avc_buffer - buffer_position + avc_buffer_length - 2; // leave room for two more bytes
 
 			// Find the next zero
 			if (restlen > 0)
 			{
-				bpos = (unsigned char *) memchr (bpos, 0x00, (size_t) restlen);
+				buffer_position = (unsigned char *) memchr (buffer_position, 0x00, (size_t) restlen);
 
-				if(!bpos)
+				if(!buffer_position)
 				{
 					// No 0x00 till the end of the buffer
-					NALstop = avcbuf + avcbuflen;
-					bpos = NALstop;
+					NAL_stop = avc_buffer + avc_buffer_length;
+					buffer_position = NAL_stop;
 					break;
 				}
 
-				if(bpos[1]==0x00 && (bpos[2]|0x01)==0x01)
+				if(buffer_position[1]==0x00 && (buffer_position[2]|0x01)==0x01)
 				{
 					// Found new start code
-					NALstop = bpos;
-					bpos = bpos + 2; // Move after the two leading 0x00
+					NAL_stop = buffer_position;
+					buffer_position = buffer_position + 2; // Move after the two leading 0x00
 					break;
 				}
 			}
 			else
 			{
-				NALstop = avcbuf + avcbuflen;
-				bpos = NALstop;
+				NAL_stop = avc_buffer + avc_buffer_length;
+				buffer_position = NAL_stop;
 				break;
 			}
 		} while(restlen); // Should never be true - loop is exited via break
 
-		if(*NALstart & 0x80)
+		if(*NAL_start & 0x80)
 		{
-			dump(CCX_DMT_GENERIC_NOTICES, NALstart-4,10, 0, 0);
+			dump(CCX_DMT_GENERIC_NOTICES, NAL_start-4,10, 0, 0);
 			fatal(CCX_COMMON_EXIT_BUG_BUG,
 					"Broken AVC stream - forbidden_zero_bit not zero ...");
 		}
 
-		ctx->avc_ctx->nal_ref_idc = *NALstart >> 5;
+		ctx->avc_ctx->nal_ref_idc = *NAL_start >> 5;
                 dvprint("process_avc: zeropad %d\n", zeropad);
-		do_NAL (ctx, NALstart, NALstop-NALstart, sub);
+		do_NAL (ctx, NAL_start, NAL_stop-NAL_start, sub);
 	}
 
-	return avcbuflen;
+	return avc_buffer_length;
 }
 
 #define ZEROBYTES_SHORTSTARTCODE 2
 
 // Copied for reference decoder, see if it behaves different that Volker's code
-int EBSPtoRBSP(unsigned char *streamBuffer, int end_bytepos, int begin_bytepos)
+int EBSP_to_RBSP(unsigned char *streamBuffer, int end_bytepos, int begin_bytepos)
 {
 	int i, j, count;
 	count = 0;
@@ -303,7 +303,7 @@ u32 avc_remove_emulation_bytes(const unsigned char *buffer_src, unsigned char *b
 unsigned char *remove_03emu(unsigned char *from, unsigned char *to)
 {
 	int num=to-from;
-	int newsize = EBSPtoRBSP (from,num,0); //TODO: Do something if newsize == -1 (broken NAL)
+	int newsize = EBSP_to_RBSP (from,num,0); //TODO: Do something if newsize == -1 (broken NAL)
 	if (newsize==-1)
 		return NULL;
 	return from+newsize;
@@ -342,35 +342,35 @@ void sei_rbsp (struct avc_ctx *ctx, unsigned char *seibuf, unsigned char *seiend
 // This combines sei_message() and sei_payload().
 unsigned char *sei_message (struct avc_ctx *ctx, unsigned char *seibuf, unsigned char *seiend)
 {
-	int payloadType = 0;
+	int payload_type = 0;
 	while (*seibuf==0xff)
 	{
-		payloadType+=255;
+		payload_type+=255;
 		seibuf++;
 	}
-	payloadType += *seibuf;
+	payload_type += *seibuf;
 	seibuf++;
 
 
-	int payloadSize = 0;
+	int payload_size = 0;
 	while (*seibuf==0xff)
 	{
-		payloadSize+=255;
+		payload_size+=255;
 		seibuf++;
 	}
-	payloadSize += *seibuf;
+	payload_size += *seibuf;
 	seibuf++;
 
 	int broken=0;
-	unsigned char *paystart = seibuf;
-	seibuf+=payloadSize;
+	unsigned char *payload_start = seibuf;
+	seibuf+=payload_size;
 
-	dvprint("Payload type: %d size: %d - ", payloadType, payloadSize);
+	dvprint("Payload type: %d size: %d - ", payload_type, payload_size);
 	if(seibuf > seiend )
 	{
 		// TODO: What do we do here?
 		broken=1;
-		if (payloadType==4)
+		if (payload_type==4)
 		{
 			dbg_print(CCX_DMT_VERBOSE, "Warning: Subtitles payload seems incorrect (too long), continuing but it doesn't look good..");
 		}
@@ -381,8 +381,8 @@ unsigned char *sei_message (struct avc_ctx *ctx, unsigned char *seibuf, unsigned
 	}
 	dbg_print(CCX_DMT_VERBOSE, "\n");
 	// Ignore all except user_data_registered_itu_t_t35() payload
-	if(!broken && payloadType == 4)
-		user_data_registered_itu_t_t35(ctx, paystart, paystart+payloadSize);
+	if(!broken && payload_type == 4)
+		user_data_registered_itu_t_t35(ctx, payload_start, payload_start+payload_size);
 
 	return seibuf;
 }
@@ -404,7 +404,7 @@ void copy_ccdata_to_buffer (struct avc_ctx *ctx, char *source, int new_cc_count)
 void user_data_registered_itu_t_t35 (struct avc_ctx *ctx, unsigned char *userbuf, unsigned char *userend)
 {
 	unsigned char *tbuf = userbuf;
-	unsigned char *cc_tmpdata;
+	unsigned char *cc_tmp_data;
 	unsigned char process_cc_data_flag;
 	int user_data_type_code;
 	int user_data_len;
@@ -489,7 +489,7 @@ void user_data_registered_itu_t_t35 (struct avc_ctx *ctx, unsigned char *userbuf
 						   } */
 						// OK, all checks passed!
 						tbuf++;
-						cc_tmpdata = tbuf;
+						cc_tmp_data = tbuf;
 
 						/* TODO: I don't think we have user_data_len here
 						   if (cc_count*3+3 != user_data_len)
@@ -497,10 +497,10 @@ void user_data_registered_itu_t_t35 (struct avc_ctx *ctx, unsigned char *userbuf
 						   "Syntax problem: user_data_len != cc_count*3+3."); */
 
 						// Enough room for CC captions?
-						if (cc_tmpdata+local_cc_count*3 >= userend)
+						if (cc_tmp_data+local_cc_count*3 >= userend)
 							fatal(CCX_COMMON_EXIT_BUG_BUG,
 									"Syntax problem: Too many caption blocks.");
-						if (cc_tmpdata[local_cc_count*3]!=0xFF)
+						if (cc_tmp_data[local_cc_count*3]!=0xFF)
 							fatal(CCX_COMMON_EXIT_BUG_BUG,
 									"Syntax problem: Final 0xFF marker missing.");
 
@@ -513,7 +513,7 @@ void user_data_registered_itu_t_t35 (struct avc_ctx *ctx, unsigned char *userbuf
 							ctx->cc_databufsize = (long) ( (ctx->cc_count + local_cc_count) * 6) + 1;
 						}
 						// Copy new cc data into cc_data
-						copy_ccdata_to_buffer (ctx, (char *) cc_tmpdata, local_cc_count);
+						copy_ccdata_to_buffer (ctx, (char *) cc_tmp_data, local_cc_count);
 						break;
 					case 0x06:
 						dbg_print(CCX_DMT_VERBOSE, "bar_data (unsupported for now)\n");
@@ -562,17 +562,17 @@ void user_data_registered_itu_t_t35 (struct avc_ctx *ctx, unsigned char *userbuf
 				mprint ("process_cc_data_flag == 0, skipping this caption block.\n");
 				break;
 			}
-			cc_tmpdata = tbuf+2;
+			cc_tmp_data = tbuf+2;
 
 			if (local_cc_count*3+3 != user_data_len)
 				fatal(CCX_COMMON_EXIT_BUG_BUG,
 						"Syntax problem: user_data_len != cc_count*3+3.");
 
 			// Enough room for CC captions?
-			if (cc_tmpdata+local_cc_count*3 >= userend)
+			if (cc_tmp_data+local_cc_count*3 >= userend)
 				fatal(CCX_COMMON_EXIT_BUG_BUG,
 						"Syntax problem: Too many caption blocks.");
-			if (cc_tmpdata[local_cc_count*3]!=0xFF)
+			if (cc_tmp_data[local_cc_count*3]!=0xFF)
 				fatal(CCX_COMMON_EXIT_BUG_BUG,
 						"Syntax problem: Final 0xFF marker missing.");
 
@@ -585,7 +585,7 @@ void user_data_registered_itu_t_t35 (struct avc_ctx *ctx, unsigned char *userbuf
 				ctx->cc_databufsize = (long) (((local_cc_count + ctx->cc_count) * 6) + 1);
 			}
 			// Copy new cc data into cc_data - replace command below.
-			copy_ccdata_to_buffer (ctx, (char *) cc_tmpdata, local_cc_count);
+			copy_ccdata_to_buffer (ctx, (char *) cc_tmp_data, local_cc_count);
 
 			//dump(tbuf,user_data_len-1,0);
 			break;
@@ -880,10 +880,10 @@ void slice_header (struct lib_cc_decode *ctx, unsigned char *heabuf, unsigned ch
 {
 	LLONG tmp;
 	struct bitstream q1;
-	int maxframe_num;
+	int max_frame_num;
 	LLONG slice_type, bottom_field_flag=0, pic_order_cnt_lsb=-1;
-	int curridx;
-	int IdrPicFlag;
+	int current_index;
+	int ird_pic_flag;
 	LLONG field_pic_flag = 0; // Moved here because it's needed for ctx->avc_ctx->pic_order_cnt_type==2
 
 	if (init_bitstream(&q1, heabuf, heaend))
@@ -892,7 +892,7 @@ void slice_header (struct lib_cc_decode *ctx, unsigned char *heabuf, unsigned ch
 		return;
 	}
 
-	IdrPicFlag = ((nal_unit_type == 5 )?1:0);
+	ird_pic_flag = ((nal_unit_type == 5 )?1:0);
 
 
 	dvprint("\nSLICE HEADER\n");
@@ -904,7 +904,7 @@ void slice_header (struct lib_cc_decode *ctx, unsigned char *heabuf, unsigned ch
 	dvprint("pic_parameter_set_id=  % 4lld (%#llX)\n",tmp,tmp);
 
 	ctx->avc_ctx->lastframe_num = ctx->avc_ctx->frame_num;
-	maxframe_num = (int) ((1<<ctx->avc_ctx->log2_max_frame_num) - 1);
+	max_frame_num = (int) ((1<<ctx->avc_ctx->log2_max_frame_num) - 1);
 
 	// Needs log2_max_frame_num_minus4 + 4 bits
 	ctx->avc_ctx->frame_num = read_int_unsigned(&q1,ctx->avc_ctx->log2_max_frame_num);
@@ -927,7 +927,7 @@ void slice_header (struct lib_cc_decode *ctx, unsigned char *heabuf, unsigned ch
 		}
 	}
 
-	dvprint("IdrPicFlag=            % 4d\n", IdrPicFlag	);
+	dvprint("ird_pic_flag=            % 4d\n", ird_pic_flag	);
 
 	if( nal_unit_type == 5 )
 	{
@@ -963,15 +963,15 @@ void slice_header (struct lib_cc_decode *ctx, unsigned char *heabuf, unsigned ch
 	{
 		/* CFS: Warning!!: Untested stuff, copied from specs (8.2.1.3) */
 		LLONG FrameNumOffset = 0;
-		if (IdrPicFlag == 1)
+		if (ird_pic_flag == 1)
 			FrameNumOffset=0;
 		else if (lastframe_num > frame_num)
-			FrameNumOffset = lastframe_num + maxframe_num;
+			FrameNumOffset = lastframe_num + max_frame_num;
 		else
 			FrameNumOffset = lastframe_num;
 
 		LLONG tempPicOrderCnt=0;
-		if (IdrPicFlag == 1)
+		if (ird_pic_flag == 1)
 			tempPicOrderCnt=0;
 		else if (ctx->avc_ctx->nal_ref_idc == 0)
 			tempPicOrderCnt = 2*(FrameNumOffset + frame_num) -1 ;
@@ -1017,7 +1017,7 @@ void slice_header (struct lib_cc_decode *ctx, unsigned char *heabuf, unsigned ch
 
 	// If we saw a jump set maxidx, lastmaxidx to -1
 	LLONG dif = ctx->avc_ctx->frame_num - ctx->avc_ctx->lastframe_num;
-	if (dif == -maxframe_num)
+	if (dif == -max_frame_num)
 		dif = 0;
 	if ( ctx->avc_ctx->lastframe_num > -1 && (dif < 0 || dif > 1) )
 	{
@@ -1063,7 +1063,7 @@ void slice_header (struct lib_cc_decode *ctx, unsigned char *heabuf, unsigned ch
 		if ( ccx_options.usepicorder ) {
 			// Use pic_order_cnt_lsb
 
-			// Make sure that curridx never wraps for curidx values that
+			// Make sure that current_index never wraps for curidx values that
 			// are smaller than currref
 			ctx->avc_ctx->currref = (int)pic_order_cnt_lsb;
 			if (ctx->avc_ctx->currref < maxrefcnt/3)
@@ -1086,19 +1086,19 @@ void slice_header (struct lib_cc_decode *ctx, unsigned char *heabuf, unsigned ch
 
 	if ( ccx_options.usepicorder ) {
 		// Use pic_order_cnt_lsb
-		// Wrap (add max index value) curridx if needed.
+		// Wrap (add max index value) current_index if needed.
 		if( ctx->avc_ctx->currref - pic_order_cnt_lsb > maxrefcnt/2 )
-			curridx = (int)pic_order_cnt_lsb + maxrefcnt+1;
+			current_index = (int)pic_order_cnt_lsb + maxrefcnt+1;
 		else
-			curridx = (int)pic_order_cnt_lsb;
+			current_index = (int)pic_order_cnt_lsb;
 
 		// Track maximum index for this GOP
-		if ( curridx > ctx->avc_ctx->maxidx )
-			ctx->avc_ctx->maxidx = curridx;
+		if ( current_index > ctx->avc_ctx->maxidx )
+			ctx->avc_ctx->maxidx = current_index;
 
 		// Calculate tref
 		if ( ctx->avc_ctx->lastmaxidx > 0 ) {
-			ctx->timing->current_tref = curridx - ctx->avc_ctx->lastmaxidx -1;
+			ctx->timing->current_tref = current_index - ctx->avc_ctx->lastmaxidx -1;
 			// Set maxtref
 			if( ctx->timing->current_tref > ctx->avc_ctx->maxtref ) {
 				ctx->avc_ctx->maxtref = ctx->timing->current_tref;
@@ -1121,24 +1121,24 @@ void slice_header (struct lib_cc_decode *ctx, unsigned char *heabuf, unsigned ch
 		// frame rate
 		// The 2* accounts for a discrepancy between current and actual FPS
 		// seen in some files (CCSample2.mpg)
-		curridx = (int)roundportable(2*(ctx->timing->current_pts - ctx->avc_ctx->currefpts)/(MPEG_CLOCK_FREQ/current_fps));
+		current_index = (int)roundportable(2*(ctx->timing->current_pts - ctx->avc_ctx->currefpts)/(MPEG_CLOCK_FREQ/current_fps));
 
-		if (abs(curridx) >= MAXBFRAMES) {
+		if (abs(current_index) >= MAXBFRAMES) {
 			// Probably a jump in the timeline. Warn and handle gracefully.
-			mprint("\nFound large gap(%d) in PTS! Trying to recover ...\n", curridx);
-			curridx = 0;
+			mprint("\nFound large gap(%d) in PTS! Trying to recover ...\n", current_index);
+			current_index = 0;
 		}
 
 		// Track maximum index for this GOP
-		if ( curridx > ctx->avc_ctx->maxidx )
-			ctx->avc_ctx->maxidx = curridx;
+		if ( current_index > ctx->avc_ctx->maxidx )
+			ctx->avc_ctx->maxidx = current_index;
 
 		// Track minimum index for this GOP
-		if ( curridx < ctx->avc_ctx->minidx )
-			ctx->avc_ctx->minidx = curridx;
+		if ( current_index < ctx->avc_ctx->minidx )
+			ctx->avc_ctx->minidx = current_index;
 
 		ctx->timing->current_tref = 1;
-		if ( curridx == ctx->avc_ctx->lastminidx ) {
+		if ( current_index == ctx->avc_ctx->lastminidx ) {
 			// This implies that the minimal index (assuming its number is
 			// fairly constant) sets the temporal reference to zero - needed to set sync_pts.
 			ctx->timing->current_tref = 0;
@@ -1154,7 +1154,7 @@ void slice_header (struct lib_cc_decode *ctx, unsigned char *heabuf, unsigned ch
 
 	dbg_print(CCX_DMT_TIME, "  picordercnt:%3lld tref:%3d idx:%3d refidx:%3d lmaxidx:%3d maxtref:%3d\n",
 			pic_order_cnt_lsb, ctx->timing->current_tref,
-			curridx, ctx->avc_ctx->currref, ctx->avc_ctx->lastmaxidx, ctx->avc_ctx->maxtref);
+			current_index, ctx->avc_ctx->currref, ctx->avc_ctx->lastmaxidx, ctx->avc_ctx->maxtref);
 	dbg_print(CCX_DMT_TIME, "  sync_pts:%s (%8u)",
 			print_mstime_static(ctx->timing->sync_pts/(MPEG_CLOCK_FREQ/1000)),
 			(unsigned) (ctx->timing->sync_pts));
@@ -1176,7 +1176,7 @@ void slice_header (struct lib_cc_decode *ctx, unsigned char *heabuf, unsigned ch
 	total_frames_count++;
 	ctx->frames_since_last_gop++;
 
-	store_hdcc(ctx, ctx->avc_ctx->cc_data, ctx->avc_ctx->cc_count, curridx, ctx->timing->fts_now, sub);
+	store_hdcc(ctx, ctx->avc_ctx->cc_data, ctx->avc_ctx->cc_count, current_index, ctx->timing->fts_now, sub);
 	ctx->avc_ctx->cc_buffer_saved = CCX_TRUE; // CFS: store_hdcc supposedly saves the CC buffer to a sequence buffer
 	ctx->avc_ctx->cc_count = 0;
 }

--- a/src/lib_ccx/avc_functions.h
+++ b/src/lib_ccx/avc_functions.h
@@ -50,6 +50,6 @@ struct avc_ctx
 
 struct avc_ctx *init_avc(void);
 void dinit_avc(struct avc_ctx **ctx);
-void do_NAL (struct lib_cc_decode *ctx, unsigned char *NALstart, LLONG NAL_length, struct cc_subtitle *sub);
-size_t process_avc(struct lib_cc_decode *ctx, unsigned char *avcbuf, size_t avcbuflen, struct cc_subtitle *sub);
+void do_NAL (struct lib_cc_decode *ctx, unsigned char *NAL_start, LLONG NAL_length, struct cc_subtitle *sub);
+size_t process_avc(struct lib_cc_decode *ctx, unsigned char *avc_buffer, size_t avc_buffer_length, struct cc_subtitle *sub);
 #endif

--- a/src/lib_ccx/avc_functions.h
+++ b/src/lib_ccx/avc_functions.h
@@ -50,6 +50,6 @@ struct avc_ctx
 
 struct avc_ctx *init_avc(void);
 void dinit_avc(struct avc_ctx **ctx);
-void do_NAL (struct lib_cc_decode *ctx, unsigned char *NALstart, LLONG NAL_length, struct cc_subtitle *sub);
+void do_NAL (struct lib_cc_decode *ctx, unsigned char *NAL_start, LLONG NAL_length, struct cc_subtitle *sub);
 size_t process_avc(struct lib_cc_decode *ctx, unsigned char *avcbuf, size_t avcbuflen, struct cc_subtitle *sub);
 #endif

--- a/src/lib_ccx/avc_functions.h
+++ b/src/lib_ccx/avc_functions.h
@@ -50,6 +50,6 @@ struct avc_ctx
 
 struct avc_ctx *init_avc(void);
 void dinit_avc(struct avc_ctx **ctx);
-void do_NAL (struct lib_cc_decode *ctx, unsigned char *NAL_start, LLONG NAL_length, struct cc_subtitle *sub);
-size_t process_avc(struct lib_cc_decode *ctx, unsigned char *avc_buffer, size_t avc_buffer_length, struct cc_subtitle *sub);
+void do_NAL (struct lib_cc_decode *ctx, unsigned char *NALstart, LLONG NAL_length, struct cc_subtitle *sub);
+size_t process_avc(struct lib_cc_decode *ctx, unsigned char *avcbuf, size_t avcbuflen, struct cc_subtitle *sub);
 #endif

--- a/src/lib_ccx/avc_functions.h
+++ b/src/lib_ccx/avc_functions.h
@@ -51,5 +51,5 @@ struct avc_ctx
 struct avc_ctx *init_avc(void);
 void dinit_avc(struct avc_ctx **ctx);
 void do_NAL (struct lib_cc_decode *ctx, unsigned char *NAL_start, LLONG NAL_length, struct cc_subtitle *sub);
-size_t process_avc(struct lib_cc_decode *ctx, unsigned char *avcbuf, size_t avcbuflen, struct cc_subtitle *sub);
+size_t process_avc(struct lib_cc_decode *ctx, unsigned char *avc_buffer, size_t avc_buffer_length, struct cc_subtitle *sub);
 #endif

--- a/src/lib_ccx/bitstream.h
+++ b/src/lib_ccx/bitstream.h
@@ -57,10 +57,10 @@ void make_byte_aligned(struct bitstream *bstr);
 unsigned char *next_bytes(struct bitstream *bstr, unsigned bynum);
 unsigned char *read_bytes(struct bitstream *bstr, unsigned bynum);
 uint64_t bitstream_get_num(struct bitstream *bstr, unsigned bytes, int advance);
-uint64_t ue(struct bitstream *bstr);
-int64_t se(struct bitstream *bstr);
-uint64_t u(struct bitstream *bstr, unsigned bnum);
-int64_t i(struct bitstream *bstr, unsigned bnum);
+uint64_t read_exp_golomb_unsigned(struct bitstream *bstr);
+int64_t read_exp_golomb(struct bitstream *bstr);
+uint64_t read_int_unsigned(struct bitstream *bstr, unsigned bnum);
+int64_t read_int(struct bitstream *bstr, unsigned bnum);
 uint8_t reverse8(uint8_t data);
 
 #endif

--- a/src/lib_ccx/cc_bitstream.c
+++ b/src/lib_ccx/cc_bitstream.c
@@ -309,7 +309,7 @@ uint64_t bitstream_get_num(struct bitstream *bstr, unsigned bytes, int advance)
 
 
 // Read unsigned Exp-Golomb code from bitstream
-uint64_t ue(struct bitstream *bstr)
+uint64_t read_exp_golomb_unsigned(struct bitstream *bstr)
 {
 	uint64_t res = 0;
 	int zeros=0;
@@ -324,11 +324,11 @@ uint64_t ue(struct bitstream *bstr)
 
 
 // Read signed Exp-Golomb code from bitstream
-int64_t se(struct bitstream *bstr)
+int64_t read_exp_golomb(struct bitstream *bstr)
 {
 	int64_t res = 0;
 
-	res = ue(bstr);
+	res = read_exp_golomb_unsigned(bstr);
 
 	// The following function might truncate when res+1 overflows
 	//res = (res+1)/2 * (res % 2 ? 1 : -1);
@@ -341,14 +341,14 @@ int64_t se(struct bitstream *bstr)
 
 // Read unsigned integer with bnum bits length.  Basically an
 // alias for read_bits().
-uint64_t u(struct bitstream *bstr, unsigned bnum)
+uint64_t read_int_unsigned(struct bitstream *bstr, unsigned bnum)
 {
 	return read_bits(bstr, bnum);
 }
 
 
 // Read signed integer with bnum bits length.
-int64_t i(struct bitstream *bstr, unsigned bnum)
+int64_t read_int(struct bitstream *bstr, unsigned bnum)
 {
 	uint64_t res = read_bits(bstr, bnum);
 

--- a/src/lib_ccx/ccx_common_common.c
+++ b/src/lib_ccx/ccx_common_common.c
@@ -38,14 +38,14 @@ void fdprintf(int fd, const char *fmt, ...)
 			free(p);
 			return;
 		}
-		else 
+		else
 		{
 			p = np;
 		}
 	}
 }
 /* Converts the given milli to separate hours,minutes,seconds and ms variables */
-void mstotime(LLONG milli, unsigned *hours, unsigned *minutes,
+void millis_to_time(LLONG milli, unsigned *hours, unsigned *minutes,
 	unsigned *seconds, unsigned *ms)
 {
 	// LLONG milli = (LLONG) ((ccblock*1000)/29.97);

--- a/src/lib_ccx/ccx_common_common.h
+++ b/src/lib_ccx/ccx_common_common.h
@@ -43,7 +43,7 @@ void fdprintf(int fd, const char *fmt, ...);
 void millis_to_time(LLONG milli, unsigned *hours, unsigned *minutes,unsigned *seconds, unsigned *ms);
 void freep(void *arg);
 void dbg_print(LLONG mask, const char *fmt, ...);
-unsigned char *debug_608toASC(unsigned char *ccdata, int channel);
+unsigned char *debug_608_to_ASC(unsigned char *ccdata, int channel);
 int add_cc_sub_text(struct cc_subtitle *sub, char *str, LLONG start_time,
 		LLONG end_time, char *info, char *mode, enum ccx_encoding_type);
 

--- a/src/lib_ccx/ccx_common_common.h
+++ b/src/lib_ccx/ccx_common_common.h
@@ -40,7 +40,7 @@
 
 // Declarations
 void fdprintf(int fd, const char *fmt, ...);
-void mstotime(LLONG milli, unsigned *hours, unsigned *minutes,unsigned *seconds, unsigned *ms);
+void millis_to_time(LLONG milli, unsigned *hours, unsigned *minutes,unsigned *seconds, unsigned *ms);
 void freep(void *arg);
 void dbg_print(LLONG mask, const char *fmt, ...);
 unsigned char *debug_608toASC(unsigned char *ccdata, int channel);

--- a/src/lib_ccx/ccx_common_timing.h
+++ b/src/lib_ccx/ccx_common_timing.h
@@ -47,7 +47,7 @@ struct ccx_common_timing_ctx
 	LLONG fts_max; // Remember the maximum fts that we saw in current file
 	LLONG fts_global; // Duration of previous files (-ve mode)
 	int sync_pts2fts_set; //0 = No, 1 = Yes
-	LLONG sync_pts2fts_fts; 
+	LLONG sync_pts2fts_fts;
 	LLONG sync_pts2fts_pts;
 };
 // Count 608 (per field) and 708 blocks since last set_fts() call
@@ -78,9 +78,8 @@ void add_current_pts(struct ccx_common_timing_ctx *ctx, LLONG pts);
 int set_fts(struct ccx_common_timing_ctx *ctx);
 LLONG get_fts(struct ccx_common_timing_ctx *ctx, int current_field);
 LLONG get_fts_max(struct ccx_common_timing_ctx *ctx);
-char *print_mstime(LLONG mstime);
-char *print_mstime2buf(LLONG mstime, char *buf);
-size_t mstime_sprintf(LLONG mstime, char *fmt, char *buf);
+char *print_mstime_static(LLONG mstime);
+size_t print_mstime_buff(LLONG mstime, char *fmt, char *buf);
 void print_debug_timing(struct ccx_common_timing_ctx *ctx);
 int gop_accepted(struct gop_time_code* g);
 void calculate_ms_gop_time(struct gop_time_code *g);

--- a/src/lib_ccx/ccx_decoders_608.c
+++ b/src/lib_ccx/ccx_decoders_608.c
@@ -1234,7 +1234,7 @@ int process608(const unsigned char *data, int length, void *private_data, struct
 
 /* Return a pointer to a string that holds the printable characters
  * of the caption data block. FOR DEBUG PURPOSES ONLY! */
-unsigned char *debug_608toASC (unsigned char *cc_data, int channel)
+unsigned char *debug_608_to_ASC (unsigned char *cc_data, int channel)
 {
 	static unsigned char output[3];
 

--- a/src/lib_ccx/ccx_decoders_608.c
+++ b/src/lib_ccx/ccx_decoders_608.c
@@ -1207,7 +1207,7 @@ int process608(const unsigned char *data, int length, void *private_data, struct
 
 			if (!context->textprinted && context->channel == context->my_channel)
 			{   // Current FTS information after the characters are shown
-				ccx_common_logging.debug_ftn(CCX_DMT_DECODER_608, "Current FTS: %s\n", print_mstime(get_fts(dec_ctx->timing, context->my_field)));
+				ccx_common_logging.debug_ftn(CCX_DMT_DECODER_608, "Current FTS: %s\n", print_mstime_static(get_fts(dec_ctx->timing, context->my_field)));
 				//printf("  N:%u", unsigned(fts_now) );
 				//printf("  G:%u", unsigned(fts_global) );
 				//printf("  F:%d %d %d %d\n",

--- a/src/lib_ccx/ccx_decoders_708.c
+++ b/src/lib_ccx/ccx_decoders_708.c
@@ -105,7 +105,7 @@ ccx_dtvcc_pen_attribs ccx_dtvcc_default_pen_attribs =
 };
 
 ccx_dtvcc_window_attribs ccx_dtvcc_predefined_window_styles[] =
-{	
+{
 	{0,0,0,0,0,0,0,0,0,0, 0}, // Dummy, unused (position 0 doesn't use the table)
 	{//1 - NTSC Style PopUp Captions
 		CCX_DTVCC_WINDOW_JUSTIFY_LEFT,
@@ -296,8 +296,8 @@ void _dtvcc_window_dump(ccx_dtvcc_service_decoder *decoder, ccx_dtvcc_window *wi
 	char tbuf1[SUBLINESIZE],
 			tbuf2[SUBLINESIZE];
 
-	print_mstime2buf(window->time_ms_show, tbuf1);
-	print_mstime2buf(window->time_ms_hide, tbuf2);
+	print_mstime_buff(window->time_ms_show, "%02u:%02u:%02u:%03u", tbuf1);
+	print_mstime_buff(window->time_ms_hide, "%02u:%02u:%02u:%03u", tbuf2);
 
 	ccx_common_logging.debug_ftn(CCX_DMT_GENERIC_NOTICES, "\r%s --> %s\n", tbuf1, tbuf2);
 	for (int i = 0; i < CCX_DTVCC_MAX_ROWS; i++)
@@ -366,7 +366,7 @@ void _dtvcc_window_update_time_show(ccx_dtvcc_window *window, struct ccx_common_
 {
 	char buf[128];
 	window->time_ms_show = get_visible_start(timing, 3);
-	print_mstime2buf(window->time_ms_show, buf);
+	print_mstime_buff(window->time_ms_show, "%02u:%02u:%02u:%03u", buf);
 	ccx_common_logging.debug_ftn(CCX_DMT_708, "[CEA-708] "
 			"[W-%d] show time updated to %s\n", window->number, buf);
 }
@@ -375,7 +375,7 @@ void _dtvcc_window_update_time_hide(ccx_dtvcc_window *window, struct ccx_common_
 {
 	char buf[128];
 	window->time_ms_hide = get_visible_end(timing, 3);
-	print_mstime2buf(window->time_ms_hide, buf);
+	print_mstime_buff(window->time_ms_hide, "%02u:%02u:%02u:%03u", buf);
 	ccx_common_logging.debug_ftn(CCX_DMT_708, "[CEA-708] "
 			"[W-%d] hide time updated to %s\n", window->number, buf);
 }
@@ -383,8 +383,8 @@ void _dtvcc_window_update_time_hide(ccx_dtvcc_window *window, struct ccx_common_
 void _dtvcc_screen_update_time_show(dtvcc_tv_screen *tv, LLONG time)
 {
 	char buf1[128], buf2[128];
-	print_mstime2buf(tv->time_ms_show, buf1);
-	print_mstime2buf(time, buf2);
+	print_mstime_buff(tv->time_ms_show, "%02u:%02u:%02u:%03u", buf1);
+	print_mstime_buff(time, "%02u:%02u:%02u:%03u", buf2);
 	ccx_common_logging.debug_ftn(CCX_DMT_708, "[CEA-708] "
 			"Screen show time: %s -> %s\n", buf1, buf2);
 
@@ -397,8 +397,8 @@ void _dtvcc_screen_update_time_show(dtvcc_tv_screen *tv, LLONG time)
 void _dtvcc_screen_update_time_hide(dtvcc_tv_screen *tv, LLONG time)
 {
 	char buf1[128], buf2[128];
-	print_mstime2buf(tv->time_ms_hide, buf1);
-	print_mstime2buf(time, buf2);
+	print_mstime_buff(tv->time_ms_hide, "%02u:%02u:%02u:%03u", buf1);
+	print_mstime_buff(time, "%02u:%02u:%02u:%03u", buf2);
 	ccx_common_logging.debug_ftn(CCX_DMT_708, "[CEA-708] "
 			"Screen hide time: %s -> %s\n", buf1, buf2);
 
@@ -897,9 +897,9 @@ void dtvcc_handle_DFx_DefineWindow(ccx_dtvcc_service_decoder *decoder, int windo
 		pen_style = 1;
 	}
 
-	//Apply windows attribute presets 
+	//Apply windows attribute presets
 	if (win_style > 0 && win_style < 8)
-	
+
 		window->win_style = win_style; {
 		window->attribs.border_color = ccx_dtvcc_predefined_window_styles[win_style].border_color;
 		window->attribs.border_type = ccx_dtvcc_predefined_window_styles[win_style].border_type;
@@ -913,7 +913,7 @@ void dtvcc_handle_DFx_DefineWindow(ccx_dtvcc_service_decoder *decoder, int windo
 		window->attribs.scroll_direction = ccx_dtvcc_predefined_window_styles[win_style].scroll_direction;
 		window->attribs.word_wrap = ccx_dtvcc_predefined_window_styles[win_style].word_wrap;
 	}
-		
+
 	if (pen_style > 0)
 	{
 		//TODO apply static pen_style preset
@@ -955,7 +955,7 @@ void dtvcc_handle_DFx_DefineWindow(ccx_dtvcc_service_decoder *decoder, int windo
 			_dtvcc_window_apply_style(window, &ccx_dtvcc_predefined_window_styles[0]);
 		}
 	}
-	else	
+	else
 	{
 		if (do_clear_window)
 			_dtvcc_window_clear_text(window);
@@ -1312,7 +1312,7 @@ int _dtvcc_handle_C1(ccx_dtvcc_ctx *dtvcc,
 {
 	struct CCX_DTVCC_S_COMMANDS_C1 com = DTVCC_COMMANDS_C1[data[0] - 0x80];
 	ccx_common_logging.debug_ftn(CCX_DMT_708, "[CEA-708] C1: %s | [%02X]  [%s] [%s] (%d)\n",
-			print_mstime(get_fts(dtvcc->timing, 3)),
+			print_mstime_static(get_fts(dtvcc->timing, 3)),
 			data[0], com.name, com.description, com.length);
 
 	if (com.length > data_length)

--- a/src/lib_ccx/ccx_decoders_708_output.c
+++ b/src/lib_ccx/ccx_decoders_708_output.c
@@ -144,10 +144,10 @@ void ccx_dtvcc_write_srt(ccx_dtvcc_writer_ctx *writer, dtvcc_tv_screen *tv, stru
 	memset(buf, 0, INITIAL_ENC_BUFFER_CAPACITY);
 
 	sprintf(buf, "%u%s", tv->cc_count, encoder->encoded_crlf);
-	mstime_sprintf(tv->time_ms_show + encoder->subs_delay,
+	print_mstime_buff(tv->time_ms_show + encoder->subs_delay,
 				   "%02u:%02u:%02u,%03u", buf + strlen(buf));
 	sprintf(buf + strlen(buf), " --> ");
-	mstime_sprintf(tv->time_ms_hide + encoder->subs_delay,
+	print_mstime_buff(tv->time_ms_hide + encoder->subs_delay,
 				   "%02u:%02u:%02u,%03u", buf + strlen(buf));
 	sprintf(buf + strlen(buf),"%s", (char *) encoder->encoded_crlf);
 
@@ -173,8 +173,8 @@ void ccx_dtvcc_write_debug(dtvcc_tv_screen *tv)
 	char tbuf1[SUBLINESIZE],
 			tbuf2[SUBLINESIZE];
 
-	print_mstime2buf(tv->time_ms_show, tbuf1);
-	print_mstime2buf(tv->time_ms_hide, tbuf2);
+	print_mstime_buff(tv->time_ms_show, "%02u:%02u:%02u:%03u", tbuf1);
+	print_mstime_buff(tv->time_ms_hide, "%02u:%02u:%02u:%03u", tbuf2);
 
 	ccx_common_logging.debug_ftn(CCX_DMT_GENERIC_NOTICES, "\r%s --> %s\n", tbuf1, tbuf2);
 	for (int i = 0; i < CCX_DTVCC_SCREENGRID_ROWS; i++)
@@ -207,11 +207,11 @@ void ccx_dtvcc_write_transcript(ccx_dtvcc_writer_ctx *writer, dtvcc_tv_screen *t
 			buf[0] = 0;
 
 			if (encoder->transcript_settings->showStartTime)
-				mstime_sprintf(tv->time_ms_show + encoder->subs_delay,
+				print_mstime_buff(tv->time_ms_show + encoder->subs_delay,
 							   "%02u:%02u:%02u,%03u|", buf + strlen(buf));
 
 			if (encoder->transcript_settings->showEndTime)
-				mstime_sprintf(tv->time_ms_hide + encoder->subs_delay,
+				print_mstime_buff(tv->time_ms_hide + encoder->subs_delay,
 							   "%02u:%02u:%02u,%03u|", buf + strlen(buf));
 
 			if (encoder->transcript_settings->showCC)

--- a/src/lib_ccx/ccx_decoders_common.c
+++ b/src/lib_ccx/ccx_decoders_common.c
@@ -118,7 +118,7 @@ int do_cb (struct lib_cc_decode *ctx, unsigned char *cc_block, struct cc_subtitl
 		switch (cc_type)
 		{
 			case 0:
-				dbg_print(CCX_DMT_CBRAW, "    %s   ..   ..\n",  debug_608toASC( cc_block, 0));
+				dbg_print(CCX_DMT_CBRAW, "    %s   ..   ..\n",  debug_608_to_ASC( cc_block, 0));
 
 				ctx->current_field = 1;
 				ctx->saw_caption_block = 1;
@@ -142,7 +142,7 @@ int do_cb (struct lib_cc_decode *ctx, unsigned char *cc_block, struct cc_subtitl
 				cb_field1++;
 				break;
 			case 1:
-				dbg_print(CCX_DMT_CBRAW, "    ..   %s   ..\n",  debug_608toASC( cc_block, 1));
+				dbg_print(CCX_DMT_CBRAW, "    ..   %s   ..\n",  debug_608_to_ASC( cc_block, 1));
 
 				ctx->current_field = 2;
 				ctx->saw_caption_block = 1;
@@ -349,7 +349,7 @@ struct lib_cc_decode* init_cc_decode (struct ccx_decoders_common_settings_t *set
 	ctx->pulldownfields = 0;
         //es parser related variable ends here
 
-	memset(ctx->cc_stats, 0, 4 * sizeof(int)); 
+	memset(ctx->cc_stats, 0, 4 * sizeof(int));
 
 	ctx->anchor_seq_number = -1;
 	// Init XDS buffers
@@ -369,7 +369,7 @@ void flush_cc_decode(struct lib_cc_decode *ctx, struct cc_subtitle *sub)
 	{
 		if (ctx->extract != 2)
 		{
-			if (ctx->write_format==CCX_OF_SMPTETT || ctx->write_format==CCX_OF_SAMI || 
+			if (ctx->write_format==CCX_OF_SMPTETT || ctx->write_format==CCX_OF_SAMI ||
 					ctx->write_format==CCX_OF_SRT || ctx->write_format==CCX_OF_TRANSCRIPT ||
 					ctx->write_format == CCX_OF_WEBVTT || ctx->write_format == CCX_OF_SPUPNG)
 			{

--- a/src/lib_ccx/ccx_decoders_common.c
+++ b/src/lib_ccx/ccx_decoders_common.c
@@ -25,7 +25,7 @@ LLONG get_visible_start (struct ccx_common_timing_ctx *ctx, int current_field)
 	LLONG fts = get_fts(ctx, current_field);
 	if (fts <= ctx->minimum_fts)
 		fts = ctx->minimum_fts + 1;
-	ccx_common_logging.debug_ftn(CCX_DMT_DECODER_608, "Visible Start time=%s\n", print_mstime(fts));
+	ccx_common_logging.debug_ftn(CCX_DMT_DECODER_608, "Visible Start time=%s\n", print_mstime_static(fts));
 	return fts;
 }
 
@@ -35,7 +35,7 @@ LLONG get_visible_end (struct ccx_common_timing_ctx *ctx, int current_field)
 	LLONG fts = get_fts(ctx, current_field);
 	if (fts > ctx->minimum_fts)
 		ctx->minimum_fts = fts;
-	ccx_common_logging.debug_ftn(CCX_DMT_DECODER_608, "Visible End time=%s\n", print_mstime(fts));
+	ccx_common_logging.debug_ftn(CCX_DMT_DECODER_608, "Visible End time=%s\n", print_mstime_static(fts));
 	return fts;
 }
 
@@ -102,7 +102,7 @@ int do_cb (struct lib_cc_decode *ctx, unsigned char *cc_block, struct cc_subtitl
 		return 1;
 
 	// Print raw data with FTS.
-	dbg_print(CCX_DMT_CBRAW, "%s   %d   %02X:%c%c:%02X", print_mstime(ctx->timing->fts_now + ctx->timing->fts_global),in_xds_mode,
+	dbg_print(CCX_DMT_CBRAW, "%s   %d   %02X:%c%c:%02X", print_mstime_static(ctx->timing->fts_now + ctx->timing->fts_global),in_xds_mode,
 			cc_block[0], cc_block[1]&0x7f,cc_block[2]&0x7f, cc_block[2]);
 
 	/* In theory the writercwtdata() function could return early and not

--- a/src/lib_ccx/ccx_decoders_common.c
+++ b/src/lib_ccx/ccx_decoders_common.c
@@ -108,7 +108,7 @@ int do_cb (struct lib_cc_decode *ctx, unsigned char *cc_block, struct cc_subtitl
 	/* In theory the writercwtdata() function could return early and not
 	 * go through the 608/708 cases below.  We do that to get accurate
 	 * counts for cb_field1, cb_field2 and cb_708.
-	 * Note that printdata() and dtvcc_process_data() must not be called for
+	 * Note that print_data() and dtvcc_process_data() must not be called for
 	 * the CCX_OF_RCWT case. */
 
 	if (cc_valid || cc_type==3)
@@ -135,7 +135,7 @@ int do_cb (struct lib_cc_decode *ctx, unsigned char *cc_block, struct cc_subtitl
 				if (timeok)
 				{
 					if(ctx->write_format!=CCX_OF_RCWT)
-						printdata (ctx, cc_block+1,2,0,0, sub);
+						print_data (ctx, cc_block+1,2,0,0, sub);
 					else
 						writercwtdata(ctx, cc_block, sub);
 				}
@@ -159,7 +159,7 @@ int do_cb (struct lib_cc_decode *ctx, unsigned char *cc_block, struct cc_subtitl
 				if (timeok)
 				{
 					if(ctx->write_format!=CCX_OF_RCWT)
-						printdata (ctx, 0,0,cc_block+1,2, sub);
+						print_data (ctx, 0,0,cc_block+1,2, sub);
 					else
 						writercwtdata(ctx, cc_block, sub);
 				}

--- a/src/lib_ccx/ccx_decoders_common.h
+++ b/src/lib_ccx/ccx_decoders_common.h
@@ -20,7 +20,7 @@ void ccx_decoders_common_settings_init(LLONG subs_delay, enum ccx_output_format 
 int validate_cc_data_pair (unsigned char *cc_data_pair);
 int process_cc_data (struct lib_cc_decode *ctx, unsigned char *cc_data, int cc_count, struct cc_subtitle *sub);
 int do_cb (struct lib_cc_decode *ctx, unsigned char *cc_block, struct cc_subtitle *sub);
-void printdata (struct lib_cc_decode *ctx, const unsigned char *data1, int length1,
+void print_data (struct lib_cc_decode *ctx, const unsigned char *data1, int length1,
                 const unsigned char *data2, int length2, struct cc_subtitle *sub);
 struct lib_cc_decode* init_cc_decode (struct ccx_decoders_common_settings_t *setting);
 void dinit_cc_decode(struct lib_cc_decode **ctx);

--- a/src/lib_ccx/ccx_demuxer.c
+++ b/src/lib_ccx/ccx_demuxer.c
@@ -182,7 +182,7 @@ static int ccx_demuxer_open(struct ccx_demuxer *ctx, const char *file)
 
 	return 0;
 }
-LLONG ccx_demuxer_getfilesize (struct ccx_demuxer *ctx)
+LLONG ccx_demuxer_get_file_size (struct ccx_demuxer *ctx)
 {
 	LLONG ret = 0;
 	int in = ctx->infd;
@@ -332,7 +332,7 @@ struct ccx_demuxer *init_demuxer(void *parent, struct demuxer_cfg *cfg)
 	ctx->close = ccx_demuxer_close;
 	ctx->open = ccx_demuxer_open;
 	ctx->is_open = ccx_demuxer_isopen;
-	ctx->get_filesize = ccx_demuxer_getfilesize;
+	ctx->get_filesize = ccx_demuxer_get_file_size;
 	ctx->get_stream_mode = ccx_demuxer_get_stream_mode;
 	ctx->print_cfg = ccx_demuxer_print_cfg;
 	ctx->write_es = ccx_demuxer_write_es;

--- a/src/lib_ccx/ccx_demuxer.h
+++ b/src/lib_ccx/ccx_demuxer.h
@@ -42,7 +42,7 @@ struct cap_info
 {
 	int pid;
 	int program_number;
-	enum ccx_stream_type stream; 
+	enum ccx_stream_type stream;
 	enum ccx_code_type codec;
 	long capbufsize;
 	unsigned char *capbuf;
@@ -52,17 +52,17 @@ struct cap_info
 	void *codec_private_data;
 	int ignore;
 
-	/** 
-	  List joining all stream in TS 
+	/**
+	  List joining all stream in TS
 	*/
 	struct list_head all_stream;
-	/** 
-	  List joining all sibling Stream in Program 
+	/**
+	  List joining all sibling Stream in Program
 	*/
 	struct list_head sib_head;
 	struct list_head sib_stream;
-	/** 
-	  List joining all sibling Stream in Program 
+	/**
+	  List joining all sibling Stream in Program
 	*/
 	struct list_head pg_stream;
 
@@ -169,8 +169,8 @@ struct demuxer_data* alloc_demuxer_data(void);
 void delete_demuxer_data(struct demuxer_data *data);
 int update_capinfo(struct ccx_demuxer *ctx, int pid, enum ccx_stream_type stream, enum ccx_code_type codec, int pn, void *private_data);
 struct cap_info * get_cinfo(struct ccx_demuxer *ctx, int pid);
-int need_capInfo(struct ccx_demuxer *ctx, int program_number);
-int need_capInfo_for_pid(struct ccx_demuxer *ctx, int pid);
+int need_cap_info(struct ccx_demuxer *ctx, int program_number);
+int need_cap_info_for_pid(struct ccx_demuxer *ctx, int pid);
 struct demuxer_data *get_best_data(struct demuxer_data *data);
 struct demuxer_data *get_data_stream(struct demuxer_data *data, int pid);
 int get_best_stream(struct ccx_demuxer *ctx);

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -372,7 +372,7 @@ static int write_bom(struct encoder_ctx *ctx, struct ccx_s_write *out)
 				mprint("WARNING: Unable tp write UTF BOM\n");
 				return -1;
 			}
-				
+
 		}
 		if (ctx->encoding == CCX_ENC_UNICODE){ // Write BOM
 			ret = write(out->fh, LITTLE_ENDIAN_BOM, sizeof(LITTLE_ENDIAN_BOM));
@@ -914,7 +914,7 @@ struct encoder_ctx *init_encoder(struct encoder_cfg *opt)
 
 	ctx->transcript_settings = &opt->transcript_settings;
 	ctx->no_bom = opt->no_bom;
-	ctx->sentence_cap = opt->sentence_cap;	
+	ctx->sentence_cap = opt->sentence_cap;
 	ctx->trim_subs = opt->trim_subs;
 	ctx->autodash = opt->autodash;
 	ctx->no_font_color = opt->no_font_color;
@@ -1231,8 +1231,8 @@ void write_cc_buffer_to_gui(struct eia608_screen *data, struct encoder_ctx *cont
 			if (!time_reported)
 			{
 				LLONG ms_end = data->end_time;
-				mstotime(ms_start, &h1, &m1, &s1, &ms1);
-				mstotime(ms_end - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
+				millis_to_time(ms_start, &h1, &m1, &s1, &ms1);
+				millis_to_time(ms_end - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
 				// Note, only MM:SS here as we need to save space in the preview window
 				fprintf(stderr, "%02u:%02u#%02u:%02u#",
 					h1 * 60 + m1, s1, h2 * 60 + m2, s2);

--- a/src/lib_ccx/ccx_encoders_curl.c
+++ b/src/lib_ccx/ccx_encoders_curl.c
@@ -56,8 +56,8 @@ int write_cc_bitmap_as_libcurl(struct cc_subtitle *sub, struct encoder_ctx *cont
 	{
 		if (context->prev_start != -1 || !(sub->flags & SUB_EOD_MARKER))
 		{
-			mstotime(ms_start, &h1, &m1, &s1, &ms1);
-			mstotime(ms_end - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
+			millis_to_time(ms_start, &h1, &m1, &s1, &ms1);
+			millis_to_time(ms_end - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
 			context->srt_counter++;
 			sprintf(timeline, "group_id=ccextractordev&start_time=%" PRIu64 "&end_time=%" PRIu64 "&lang=en", ms_start, ms_end);
 			char *curlline = NULL;

--- a/src/lib_ccx/ccx_encoders_g608.c
+++ b/src/lib_ccx/ccx_encoders_g608.c
@@ -76,8 +76,8 @@ int write_cc_buffer_as_g608(struct eia608_screen *data, struct encoder_ctx *cont
 
 	ms_end = data->end_time;
 
-	mstotime (ms_start,&h1,&m1,&s1,&ms1);
-	mstotime (ms_end-1,&h2,&m2,&s2,&ms2); // -1 To prevent overlapping with next line.
+	millis_to_time (ms_start,&h1,&m1,&s1,&ms1);
+	millis_to_time (ms_end-1,&h2,&m2,&s2,&ms2); // -1 To prevent overlapping with next line.
 	char timeline[128];
 	context->srt_counter++;
 	sprintf(timeline, "%u%s", context->srt_counter, context->encoded_crlf);

--- a/src/lib_ccx/ccx_encoders_helpers.c
+++ b/src/lib_ccx/ccx_encoders_helpers.c
@@ -31,13 +31,13 @@ static const char *spell_builtin[] =
 	NULL
 };
 
-int string_cmp2(const void *p1, const void *p2, void *arg)
+int string_cmp_function(const void *p1, const void *p2, void *arg)
 {
 	return strcasecmp(*(char**)p1, *(char**)p2);
 }
 int string_cmp(const void *p1, const void *p2)
 {
-	return string_cmp2(p1, p2, NULL);
+	return string_cmp_function(p1, p2, NULL);
 }
 
 void correct_case_with_dictionary(int line_num, struct eia608_screen *data)
@@ -459,7 +459,6 @@ void shell_sort(void *base, int nb, size_t size, int(*compar)(const void*p1, con
 
 void ccx_encoders_helpers_perform_shellsort_words(void)
 {
-	shell_sort(spell_lower, spell_words, sizeof(*spell_lower), string_cmp2, NULL);
-	shell_sort(spell_correct, spell_words, sizeof(*spell_correct), string_cmp2, NULL);
+	shell_sort(spell_lower, spell_words, sizeof(*spell_lower), string_cmp_function, NULL);
+	shell_sort(spell_correct, spell_words, sizeof(*spell_correct), string_cmp_function, NULL);
 }
-

--- a/src/lib_ccx/ccx_encoders_helpers.h
+++ b/src/lib_ccx/ccx_encoders_helpers.h
@@ -30,7 +30,7 @@ unsigned get_decoder_line_encoded_for_gui(unsigned char *buffer, int line_num, s
 unsigned get_decoder_line_encoded(struct encoder_ctx *ctx, unsigned char *buffer, int line_num, struct eia608_screen *data);
 
 int string_cmp(const void *p1, const void *p2);
-int string_cmp2(const void *p1, const void *p2, void *arg);
+int string_cmp_function(const void *p1, const void *p2, void *arg);
 int add_built_in_words(void);
 int add_word(const char *word);
 unsigned encode_line (struct encoder_ctx *ctx, unsigned char *buffer, unsigned char *text);

--- a/src/lib_ccx/ccx_encoders_smptett.c
+++ b/src/lib_ccx/ccx_encoders_smptett.c
@@ -46,8 +46,8 @@ void write_stringz_as_smptett(char *string, struct encoder_ctx *context, LLONG m
 	if (el == NULL || unescaped == NULL)
 		fatal (EXIT_NOT_ENOUGH_MEMORY, "In write_stringz_as_sami() - not enough memory.\n");
 
-	mstotime (ms_start, &h1, &m1, &s1, &ms1);
-	mstotime (ms_end-1, &h2, &m2, &s2, &ms2);
+	millis_to_time (ms_start, &h1, &m1, &s1, &ms1);
+	millis_to_time (ms_end-1, &h2, &m2, &s2, &ms2);
 
 	sprintf ((char *) str, "<p begin=\"%02u:%02u:%02u.%03u\" end=\"%02u:%02u:%02u.%03u\">\r\n", h1, m1, s1, ms1, h2, m2, s2, ms2);
 	if (context->encoding!=CCX_ENC_UNICODE)
@@ -149,8 +149,8 @@ int write_cc_bitmap_as_smptett(struct cc_subtitle *sub, struct encoder_ctx *cont
 			char *buf = (char *) context->buffer;
 			unsigned h1, m1, s1, ms1;
 			unsigned h2, m2, s2, ms2;
-			mstotime (ms_start,&h1,&m1,&s1,&ms1);
-			mstotime (ms_end-1,&h2,&m2,&s2,&ms2); // -1 To prevent overlapping with next line.
+			millis_to_time (ms_start,&h1,&m1,&s1,&ms1);
+			millis_to_time (ms_end-1,&h2,&m2,&s2,&ms2); // -1 To prevent overlapping with next line.
 			sprintf ((char *) context->buffer,"<p begin=\"%02u:%02u:%02u.%03u\" end=\"%02u:%02u:%02u.%03u\">\n",h1,m1,s1,ms1, h2,m2,s2,ms2);
 			write (context->out->fh, buf,strlen(buf) );
 			len = strlen(rect[0].ocr_text);
@@ -212,8 +212,8 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
 
 	endms  = data->end_time;
 	endms--; // To prevent overlapping with next line.
-	mstotime (startms,&h1,&m1,&s1,&ms1);
-	mstotime (endms-1,&h2,&m2,&s2,&ms2);
+	millis_to_time (startms,&h1,&m1,&s1,&ms1);
+	millis_to_time (endms-1,&h2,&m2,&s2,&ms2);
 
 	sprintf ((char *) str,"<p begin=\"%02u:%02u:%02u.%03u\" end=\"%02u:%02u:%02u.%03u\">\n",h1,m1,s1,ms1, h2,m2,s2,ms2);
 

--- a/src/lib_ccx/ccx_encoders_srt.c
+++ b/src/lib_ccx/ccx_encoders_srt.c
@@ -17,8 +17,8 @@ int write_stringz_as_srt(char *string, struct encoder_ctx *context, LLONG ms_sta
 	if(!string || !string[0])
 		return 0;
 
-	mstotime (ms_start,&h1,&m1,&s1,&ms1);
-	mstotime (ms_end-1,&h2,&m2,&s2,&ms2); // -1 To prevent overlapping with next line.
+	millis_to_time (ms_start,&h1,&m1,&s1,&ms1);
+	millis_to_time (ms_end-1,&h2,&m2,&s2,&ms2); // -1 To prevent overlapping with next line.
 	context->srt_counter++;
 	sprintf(timeline, "%u%s", context->srt_counter, context->encoded_crlf);
 	used = encode_line(context, context->buffer,(unsigned char *) timeline);
@@ -118,8 +118,8 @@ int write_cc_bitmap_as_srt(struct cc_subtitle *sub, struct encoder_ctx *context)
 	{
 		if (context->prev_start != -1 || !(sub->flags & SUB_EOD_MARKER))
 		{
-			mstotime (ms_start,&h1,&m1,&s1,&ms1);
-			mstotime (ms_end-1,&h2,&m2,&s2,&ms2); // -1 To prevent overlapping with next line.
+			millis_to_time (ms_start,&h1,&m1,&s1,&ms1);
+			millis_to_time (ms_end-1,&h2,&m2,&s2,&ms2); // -1 To prevent overlapping with next line.
 			context->srt_counter++;
 			sprintf(timeline, "%u\r\n", context->srt_counter);
 			used = encode_line(context, context->buffer,(unsigned char *) timeline);
@@ -202,8 +202,8 @@ int write_cc_buffer_as_srt(struct eia608_screen *data, struct encoder_ctx *conte
 
 	ms_end = data->end_time;
 
-	mstotime (ms_start,&h1,&m1,&s1,&ms1);
-	mstotime (ms_end-1,&h2,&m2,&s2,&ms2); // -1 To prevent overlapping with next line.
+	millis_to_time (ms_start,&h1,&m1,&s1,&ms1);
+	millis_to_time (ms_end-1,&h2,&m2,&s2,&ms2); // -1 To prevent overlapping with next line.
 	char timeline[128];
 	context->srt_counter++;
 	sprintf(timeline, "%u%s", context->srt_counter, context->encoded_crlf);

--- a/src/lib_ccx/ccx_encoders_transcript.c
+++ b/src/lib_ccx/ccx_encoders_transcript.c
@@ -59,7 +59,7 @@ int write_cc_bitmap_as_transcript(struct cc_subtitle *sub, struct encoder_ctx *c
 				}
 				else
 				{
-					mstotime(start_time + context->subs_delay, &h1, &m1, &s1, &ms1);
+					millis_to_time(start_time + context->subs_delay, &h1, &m1, &s1, &ms1);
 					time_t start_time_int = (start_time + context->subs_delay) / 1000;
 					int start_time_dec = (start_time + context->subs_delay) % 1000;
 					struct tm *start_time_struct = gmtime(&start_time_int);
@@ -375,4 +375,3 @@ int write_cc_buffer_as_transcript2(struct eia608_screen *data, struct encoder_ct
 	dbg_print(CCX_DMT_DECODER_608, "- - - - - - - - - - - -\r\n");
 	return wrote_something;
 }
-

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -16,8 +16,8 @@ int write_stringz_as_webvtt(char *string, struct encoder_ctx *context, LLONG ms_
 	int written;
 	char timeline[128];
 
-	mstotime(ms_start, &h1, &m1, &s1, &ms1);
-	mstotime(ms_end - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
+	millis_to_time(ms_start, &h1, &m1, &s1, &ms1);
+	millis_to_time(ms_end - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
 
 	sprintf(timeline, "%02u:%02u:%02u.%03u --> %02u:%02u:%02u.%03u%s",
 		h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
@@ -98,9 +98,9 @@ int write_xtimestamp_header(struct encoder_ctx *context)
 		char header_string[200];
 		int used;
 		unsigned h1, m1, s1, ms1;
-		mstotime(context->timing->sync_pts2fts_fts, &h1, &m1, &s1, &ms1);
+		millis_to_time(context->timing->sync_pts2fts_fts, &h1, &m1, &s1, &ms1);
 		sprintf(header_string, "X-TIMESTAMP-MAP=MPEGTS:%ld, LOCAL %02u:%02u:%02u.%03u\r\n",
-			context->timing->sync_pts2fts_pts, 
+			context->timing->sync_pts2fts_pts,
 			h1, m1, s1, ms1);
 		used = encode_line(context, context->buffer, (unsigned char *)header_string);
 		write(context->out->fh, context->buffer, used);
@@ -155,8 +155,8 @@ int write_cc_bitmap_as_webvtt(struct cc_subtitle *sub, struct encoder_ctx *conte
 	{
 		if (context->prev_start != -1 || !(sub->flags & SUB_EOD_MARKER))
 		{
-			mstotime(ms_start, &h1, &m1, &s1, &ms1);
-			mstotime(ms_end - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
+			millis_to_time(ms_start, &h1, &m1, &s1, &ms1);
+			millis_to_time(ms_end - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
 			context->srt_counter++; // Not needed for WebVTT but let's keep it around for now
 			sprintf(timeline, "%02u:%02u:%02u.%03u --> %02u:%02u:%02u.%03u%s",
 				h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
@@ -239,8 +239,8 @@ int write_cc_buffer_as_webvtt(struct eia608_screen *data, struct encoder_ctx *co
 
 	ms_end = data->end_time;
 
-	mstotime(ms_start, &h1, &m1, &s1, &ms1);
-	mstotime(ms_end - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
+	millis_to_time(ms_start, &h1, &m1, &s1, &ms1);
+	millis_to_time(ms_end - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
 
 	sprintf(timeline, "%02u:%02u:%02u.%03u --> %02u:%02u:%02u.%03u%s",
 		h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
@@ -332,7 +332,7 @@ int write_cc_buffer_as_webvtt(struct eia608_screen *data, struct encoder_ctx *co
 			written = write(context->out->fh, context->subline, length);
 			if (written != length)
 				return -1;
-			written = write(context->out->fh, 
+			written = write(context->out->fh,
 				context->encoded_crlf, context->encoded_crlf_length);
 			if (written != context->encoded_crlf_length)
 				return -1;

--- a/src/lib_ccx/ccx_encoders_xds.c
+++ b/src/lib_ccx/ccx_encoders_xds.c
@@ -35,7 +35,7 @@ void xds_write_transcript_line_prefix (struct encoder_ctx *context, struct ccx_s
 		{
 			if (utc_refvalue == UINT64_MAX)
 			{
-				mstotime(start_time + context->subs_delay, &h1, &m1, &s1, &ms1);
+				millis_to_time(start_time + context->subs_delay, &h1, &m1, &s1, &ms1);
 				fdprintf(wb->fh, "%02u:%02u:%02u%c%03u|", h1, m1, s1, context->millis_separator, ms1);
 			}
 			else
@@ -46,7 +46,7 @@ void xds_write_transcript_line_prefix (struct encoder_ctx *context, struct ccx_s
 		}
 		else
 		{
-			mstotime(start_time + context->subs_delay, &h1, &m1, &s1, &ms1);
+			millis_to_time(start_time + context->subs_delay, &h1, &m1, &s1, &ms1);
 			time_t start_time_int = (start_time + context->subs_delay) / 1000;
 			int start_time_dec = (start_time + context->subs_delay) % 1000;
 			struct tm *start_time_struct = gmtime(&start_time_int);
@@ -62,7 +62,7 @@ void xds_write_transcript_line_prefix (struct encoder_ctx *context, struct ccx_s
 		{
 			if (utc_refvalue == UINT64_MAX)
 			{
-				mstotime(end_time, &h2, &m2, &s2, &ms2);
+				millis_to_time(end_time, &h2, &m2, &s2, &ms2);
 				fdprintf(wb->fh, "%02u:%02u:%02u%c%03u|", h2, m2, s2, context->millis_separator, ms2);
 			}
 			else
@@ -72,7 +72,7 @@ void xds_write_transcript_line_prefix (struct encoder_ctx *context, struct ccx_s
 		}
 		else
 		{
-			mstotime(end_time, &h2, &m2, &s2, &ms2);
+			millis_to_time(end_time, &h2, &m2, &s2, &ms2);
 			time_t end_time_int = end_time / 1000;
 			int end_time_dec = end_time % 1000;
 			struct tm *end_time_struct = gmtime(&end_time_int);
@@ -92,4 +92,3 @@ void xds_write_transcript_line_prefix (struct encoder_ctx *context, struct ccx_s
 		fdprintf(wb->fh, "%s|", XDSclasses_short[cur_xds_packet_class]);
 	}
 }
-

--- a/src/lib_ccx/ccx_gxf.c
+++ b/src/lib_ccx/ccx_gxf.c
@@ -38,7 +38,7 @@ typedef enum
 	PKT_FLT         = 0xfc,
 	PKT_UMF         = 0xfd,
 } GXFPktType;
-   
+
 typedef enum
 {
 	MAT_NAME        = 0x40,
@@ -48,7 +48,7 @@ typedef enum
 	MAT_MARK_OUT    = 0x44,
 	MAT_SIZE        = 0x45,
 } GXFMatTag;
-   
+
 typedef enum
 {
 	/* Media file name */
@@ -98,7 +98,7 @@ typedef enum
 	 * -2 = Not available
 	 */
 	 TRACK_FPF       = 0x52,
-	 
+
 } GXFTrackTag;
 
 typedef enum
@@ -131,13 +131,13 @@ typedef enum
 	TRACK_TYPE_MPEG2_625 = 12,
 
 	/**
-	 * A video track encoded using SMPTE 314M or ISO/IEC 61834-2 DV 
+	 * A video track encoded using SMPTE 314M or ISO/IEC 61834-2 DV
 	 * encoded at 25 Mb/s for 525/60i
 	*/
 	TRACK_TYPE_DV_BASED_25MB_525 = 13,
 
 	/**
-	 * A video track encoded using SMPTE 314M or ISO/IEC 61834-2 DV encoding at 25 Mb/s 
+	 * A video track encoded using SMPTE 314M or ISO/IEC 61834-2 DV encoding at 25 Mb/s
 	 * for 625/50i.
 	 */
 	TRACK_TYPE_DV_BASED_25MB_625 = 14,
@@ -498,7 +498,7 @@ static void set_track_frame_rate(struct ccx_gxf_video_track *vid_track, int8_t v
 		case -2:
 		/*  Not available */
 		default:
-		/* Do nothing in case of no frame rate */	
+		/* Do nothing in case of no frame rate */
 			break;
 	}
 }
@@ -635,7 +635,7 @@ static int parse_ad_track_desc(struct ccx_demuxer *demux, int len)
 				ad_track->nb_field = auxi_info[3];
 				ad_track->field_size = *((int16_t*)(auxi_info+4));//RB16(auxi_info + 4);
 				ad_track->packet_size = *((int16_t*)(auxi_info+6)) * 256;//RB16(auxi_info + 6);
-				debug("ad_format %d nb_field %d field_size %d packet_size %d track id %d\n", 
+				debug("ad_format %d nb_field %d field_size %d packet_size %d track id %d\n",
 				ad_track->ad_format, ad_track->nb_field, ad_track->field_size, ad_track->packet_size, ad_track->id);
 				break;
 			case TRACK_VER:
@@ -761,7 +761,7 @@ static int parse_track_sec(struct ccx_demuxer *demux, int len, struct demuxer_da
 			}
 			else
 				continue;
-			
+
 		}
 	}
 error:
@@ -775,7 +775,7 @@ error:
 
 /**
  * Parse Caption Distribution Packet
- * General Syntax of cdp 
+ * General Syntax of cdp
  * cdp() {
  *   cdp_header();
  *   time_code_section();
@@ -790,7 +790,7 @@ error:
 
 int parse_ad_cdp (unsigned char*cdp, size_t len, struct demuxer_data *data)
 {
-	
+
 	int ret = CCX_OK;
         uint16_t cdp_length;
         uint16_t cdp_framerate;
@@ -808,7 +808,7 @@ int parse_ad_cdp (unsigned char*cdp, size_t len, struct demuxer_data *data)
 
 	/* Verify cdp header identifier */
 	if ( (cdp[0] != 0x96) || (cdp[1] != 0x69) )
-        {       
+        {
                 log(" could not find CDP identifier of 0x96 0x69\n");
                 return CCX_EINVAL;
         }
@@ -951,7 +951,7 @@ static int parse_ad_pyld(struct ccx_demuxer *demux, int len, struct demuxer_data
 		{
 			unsigned short dat = buffered_get_le16(demux);
 			/**
-			 * check parity for 0xFE and 0x01 they may be converted by GXF 
+			 * check parity for 0xFE and 0x01 they may be converted by GXF
 			 * from 0xFF and 0x00 recpectively and ignoring first 2 bit or byte
 			 * from 10 bit code in 16bit variable and we hope that they have not
 			 * changed its parity otherwise we have lost all 0xFF and 0x00
@@ -969,7 +969,7 @@ static int parse_ad_pyld(struct ccx_demuxer *demux, int len, struct demuxer_data
 	else if (( (d_id & 0xff) == CLOSED_CAP_DID ) && ( (sd_id & 0xff) == CLOSED_C608_SDID ))
 	{
 		log("Need Sample\n");
-		
+
 	}
 	else
 	{
@@ -1034,7 +1034,7 @@ static int parse_ad_field(struct ccx_demuxer *demux, int len, struct demuxer_dat
 	len -= 4;
 	if(buffered_get_le32(demux) != 4)
 		log("Warning: expeccted 4 acc GXF specs\n");
-			
+
 	len -= 4;
 	field_identifier = buffered_get_le32(demux);
 	debug("LOG: field identifier %d\n", field_identifier);
@@ -1049,7 +1049,7 @@ static int parse_ad_field(struct ccx_demuxer *demux, int len, struct demuxer_dat
 	/* Read Byte size of the ancillary data field section vector */
 	if(buffered_get_le32(demux) != len)
 		log("Warning: Unexpected sample size (!=%d)\n", len);
-	 
+
 	len -= 4;
 	result = buffered_read(demux, (unsigned char *)tag, 4);
 	demux->past += result;
@@ -1275,7 +1275,7 @@ static int parse_ad_packet(struct ccx_demuxer *demux, int len, struct demuxer_da
 	len -= 4;
 	if(buffered_get_le32(demux) != 65528)
 		log("Warning: ADT packet with non trivial length\n");
-			
+
 	len -= 4;
 	result = buffered_read(demux, (unsigned char*)tag, 4);
 	demux->past += result;
@@ -1320,7 +1320,7 @@ static int parse_ad_packet(struct ccx_demuxer *demux, int len, struct demuxer_da
 	/* Read byte size of the complete ancillary media packet */
 	if(buffered_get_le32(demux) != 65536)
 		log("Warning: Unexpected buffer size (!=65536)\n");
-	 
+
 	len -= 4;
 	val = buffered_get_le32(demux);
 	set_data_timebase(val, data);
@@ -1335,7 +1335,7 @@ static int parse_ad_packet(struct ccx_demuxer *demux, int len, struct demuxer_da
 	/* Read Byte size of the ancillary data field section vector */
 	if(buffered_get_le32(demux) != len)
 		log("Warning: Unexpected field sec  size (!=%d)\n", len);
-	 
+
 	len -= 4;
 	result = buffered_read(demux, (unsigned char*)tag, 4);
 	demux->past += result;
@@ -1664,11 +1664,11 @@ static int read_packet(struct ccx_demuxer *ctx, struct demuxer_data *data)
 }
 
 /**
- * @param buf buffer with atleast acceptable length atleast 7 byte 
+ * @param buf buffer with atleast acceptable length atleast 7 byte
  *            where we will test only important part of packet header
- *            In GXF packet header is of 16 byte and in header there is 
+ *            In GXF packet header is of 16 byte and in header there is
  *            packet leader of 5 bytes 00 00 00 00 01
- *            Stream Starts with Map packet which is known by looking at offset 0x05 
+ *            Stream Starts with Map packet which is known by looking at offset 0x05
  *            of packet header.
  *            TODO Map packet are sent per 100 packets so search MAP packet, there might be
  *            no MAP header at start if GXF is sliced at unknown region
@@ -1685,7 +1685,7 @@ int ccx_gxf_probe(unsigned char *buf, int len)
 
 }
 
-int ccx_gxf_getmoredata(struct ccx_demuxer *ctx, struct demuxer_data **ppdata)
+int ccx_gxf_get_more_data(struct ccx_demuxer *ctx, struct demuxer_data **ppdata)
 {
 	int ret;
 	struct demuxer_data *data;

--- a/src/lib_ccx/ccx_gxf.h
+++ b/src/lib_ccx/ccx_gxf.h
@@ -4,6 +4,6 @@
 #include "ccx_demuxer.h"
 
 int ccx_gxf_probe(unsigned char *buf, int len);
-int ccx_gxf_getmoredata(struct ccx_demuxer *ctx, struct demuxer_data **data);
+int ccx_gxf_get_more_data(struct ccx_demuxer *ctx, struct demuxer_data **data);
 struct ccx_gxf *ccx_gxf_init(struct ccx_demuxer *arg);
 #endif

--- a/src/lib_ccx/es_functions.c
+++ b/src/lib_ccx/es_functions.c
@@ -601,13 +601,13 @@ static int gop_header(struct lib_cc_decode *ctx, struct bitstream *esstream, str
 		{
 			mprint("\rWarning: Jump in GOP timing.\n");
 			mprint("  (old) %s",
-					print_mstime(gop_time.ms));
+					print_mstime_static(gop_time.ms));
 			mprint("  +  %s (%uF)",
-					print_mstime((LLONG) (ctx->frames_since_last_gop
+					print_mstime_static((LLONG) (ctx->frames_since_last_gop
 							*1000.0/current_fps)),
 					ctx->frames_since_last_gop);
 			mprint("  !=  (new) %s\n",
-					print_mstime(gtc.ms));
+					print_mstime_static(gtc.ms));
 		}
 
 		if (first_gop_time.inited == 0)
@@ -731,7 +731,7 @@ static int read_pic_info(struct lib_cc_decode *ctx, struct bitstream *esstream, 
 
 	dbg_print(CCX_DMT_VIDES, "  t:%d r:%d p:%d", ctx->top_field_first,
 			ctx->repeat_first_field, ctx->progressive_frame);
-	dbg_print(CCX_DMT_VIDES, "  FTS: %s\n", print_mstime(get_fts(ctx->timing, ctx->current_field)));
+	dbg_print(CCX_DMT_VIDES, "  FTS: %s\n", print_mstime_static(get_fts(ctx->timing, ctx->current_field)));
 
 	// Set min_pts/sync_pts according to the current time stamp.
 	// Use fts_at_gop_start as reference when a GOP header was seen

--- a/src/lib_ccx/es_userdata.c
+++ b/src/lib_ccx/es_userdata.c
@@ -154,7 +154,7 @@ int user_data(struct lib_cc_decode *ctx, struct bitstream *ustream, int udtype, 
 			unsigned field_number;
 			unsigned cc_data1;
 			unsigned cc_data2;
-            
+
 			for (unsigned j=0;j<cc_count;j++)
 			{
 				skip_bits(ustream,2); // priority - unused
@@ -327,7 +327,7 @@ int user_data(struct lib_cc_decode *ctx, struct bitstream *ustream, int udtype, 
 				dishdata[1]=dcd[1];
 				dishdata[2]=dcd[2];
 
-				dbg_print(CCX_DMT_PARSE, "%s", debug_608toASC( dishdata, 0) );
+				dbg_print(CCX_DMT_PARSE, "%s", debug_608_to_ASC( dishdata, 0) );
 
 				type=dcd[3];  // repeater (0x02 or 0x04)
 				hi = dishdata[1] & 0x7f; // Get only the 7 low bits
@@ -338,7 +338,7 @@ int user_data(struct lib_cc_decode *ctx, struct bitstream *ustream, int udtype, 
 					dishdata[4]=dishdata[1];
 					dishdata[5]=dishdata[2];
 
-					dbg_print(CCX_DMT_PARSE, "%s:\n", debug_608toASC( dishdata+3, 0) );
+					dbg_print(CCX_DMT_PARSE, "%s:\n", debug_608_to_ASC( dishdata+3, 0) );
 				}
 				else
 				{
@@ -369,8 +369,8 @@ int user_data(struct lib_cc_decode *ctx, struct bitstream *ustream, int udtype, 
 				dishdata[5]=dcd[4];
 				dishdata[6] = 0xFF; // Set end marker
 
-				dbg_print(CCX_DMT_PARSE, "%s", debug_608toASC( dishdata, 0) );
-				dbg_print(CCX_DMT_PARSE, "%s:\n", debug_608toASC( dishdata+3, 0) );
+				dbg_print(CCX_DMT_PARSE, "%s", debug_608_to_ASC( dishdata, 0) );
+				dbg_print(CCX_DMT_PARSE, "%s:\n", debug_608_to_ASC( dishdata+3, 0) );
 
 				store_hdcc(ctx, dishdata, cc_count, ctx->timing->current_tref, ctx->timing->fts_now, sub);
 
@@ -406,7 +406,7 @@ int user_data(struct lib_cc_decode *ctx, struct bitstream *ustream, int udtype, 
 					type=dcd[0]; // repeater (0x02 or 0x04)
 					dcd++; // Skip the repeater byte.
 
-					dbg_print(CCX_DMT_PARSE, " - R:%02X :%s", type, debug_608toASC( dishdata, 0) );
+					dbg_print(CCX_DMT_PARSE, " - R:%02X :%s", type, debug_608_to_ASC( dishdata, 0) );
 
 					hi = dishdata[1] & 0x7f; // Get only the 7 low bits
 					if (type==0x04 && hi<32)
@@ -415,7 +415,7 @@ int user_data(struct lib_cc_decode *ctx, struct bitstream *ustream, int udtype, 
 						dishdata[3]=0x04; // Field 1
 						dishdata[4]=dishdata[1];
 						dishdata[5]=dishdata[2];
-						dbg_print(CCX_DMT_PARSE, "%s:\n", debug_608toASC( dishdata+3, 0) );
+						dbg_print(CCX_DMT_PARSE, "%s:\n", debug_608_to_ASC( dishdata+3, 0) );
 					}
 					else
 					{
@@ -433,8 +433,8 @@ int user_data(struct lib_cc_decode *ctx, struct bitstream *ustream, int udtype, 
 					dishdata[5]=dcd[1];
 					dishdata[6] = 0xFF; // Set end marker
 
-					dbg_print(CCX_DMT_PARSE, ":%s", debug_608toASC( dishdata, 0) );
-					dbg_print(CCX_DMT_PARSE, "%s:\n", debug_608toASC( dishdata+3, 0) );
+					dbg_print(CCX_DMT_PARSE, ":%s", debug_608_to_ASC( dishdata, 0) );
+					dbg_print(CCX_DMT_PARSE, "%s:\n", debug_608_to_ASC( dishdata+3, 0) );
 				}
 
 				store_hdcc(ctx, dishdata, cc_count, ctx->timing->current_tref, ctx->timing->fts_now, sub);
@@ -474,7 +474,7 @@ int user_data(struct lib_cc_decode *ctx, struct bitstream *ustream, int udtype, 
 		uint8_t line_type;
 		uint8_t field = 1;
 		read_bytes(ustream, 4); //skip header code
-		read_bytes(ustream, 2); //skip data length 
+		read_bytes(ustream, 2); //skip data length
 		line_nb = read_bits(ustream, 16);
 		line_type = read_u8(ustream);
 		field = (line_type & 0x03);
@@ -488,7 +488,7 @@ int user_data(struct lib_cc_decode *ctx, struct bitstream *ustream, int udtype, 
 		if (udatalen < 720)
 			mprint("MPEG:VBI: Minimum 720 bytes in luma line required\n");
 
-		decode_vbi(ctx, field, ustream->pos, 720, sub); 
+		decode_vbi(ctx, field, ustream->pos, 720, sub);
 		dbg_print(CCX_DMT_VERBOSE, "GXF (vbi line %d) user data:\n", line_nb);
 	}
 	else

--- a/src/lib_ccx/ffmpeg_intgr.c
+++ b/src/lib_ccx/ffmpeg_intgr.c
@@ -188,7 +188,7 @@ int ff_get_ccframe(void *arg, unsigned char*data, int maxlen)
 	return len;
 }
 
-int ffmpeg_getmoredata(struct ccx_demuxer *ctx, struct demuxer_data **ppdata)
+int ffmpeg_get_more_data(struct ccx_demuxer *ctx, struct demuxer_data **ppdata)
 {
 	struct demuxer_data *data;
 	int ret = 0;

--- a/src/lib_ccx/ffmpeg_intgr.h
+++ b/src/lib_ccx/ffmpeg_intgr.h
@@ -14,5 +14,5 @@
  */
 void *init_ffmpeg(const char *path);
 
-int ffmpeg_getmoredata(struct ccx_demuxer *ctx, struct demuxer_data **ppdata);
+int ffmpeg_get_more_data(struct ccx_demuxer *ctx, struct demuxer_data **ppdata);
 #endif

--- a/src/lib_ccx/file_functions.c
+++ b/src/lib_ccx/file_functions.c
@@ -24,7 +24,7 @@ LLONG get_file_size (int in)
 	return length;
 }
 
-LLONG gettotalfilessize (struct lib_ccx_ctx *ctx) // -1 if one or more files failed to open
+LLONG get_total_file_size (struct lib_ccx_ctx *ctx) // -1 if one or more files failed to open
 {
 	LLONG ts=0;
 	int h;

--- a/src/lib_ccx/file_functions.c
+++ b/src/lib_ccx/file_functions.c
@@ -9,7 +9,7 @@ WSADATA wsaData = {0};
 int iResult = 0;
 #endif
 
-LLONG getfilesize (int in)
+LLONG get_file_size (int in)
 {
 	int ret = 0;
 	LLONG current = LSEEK (in, 0, SEEK_CUR);
@@ -55,7 +55,7 @@ LLONG gettotalfilessize (struct lib_ccx_ctx *ctx) // -1 if one or more files fai
 		}
 
 		if (!ccx_options.live_stream)
-			ts += getfilesize (h);
+			ts += get_file_size (h);
 		close (h);
 	}
 	return ts;

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -25,7 +25,7 @@ const static unsigned char DO_NOTHING[] = {0x80, 0x80};
 
 
 // Program stream specific data grabber
-int ps_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data ** ppdata)
+int ps_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data ** ppdata)
 {
 	int enough = 0;
 	int payload_read = 0;
@@ -326,7 +326,7 @@ int ps_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data ** ppdata)
 
 
 // Returns number of bytes read, or CCX_OF for EOF
-int general_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data **data)
+int general_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **data)
 {
 	int bytesread = 0;
 	int want;
@@ -542,7 +542,7 @@ void raw_loop (struct lib_ccx_ctx *ctx)
 		if (terminate_asap)
 			break;
 
-		ret = general_getmoredata(ctx, &data);
+		ret = general_get_more_data(ctx, &data);
 		if(ret == CCX_EOF)
 			break;
 
@@ -678,7 +678,7 @@ int process_data(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, str
 	}
 	else if (data_node->bufferdatatype == CCX_RAW) // Raw two byte 608 data from DVR-MS/ASF
 	{
-		// The asf_getmoredata() loop sets current_pts when possible
+		// The asf_get_more_data() loop sets current_pts when possible
 		if (dec_ctx->timing->pts_set == 0)
 		{
 			mprint("DVR-MS/ASF file without useful time stamps - count blocks.\n");
@@ -817,22 +817,22 @@ void general_loop(struct lib_ccx_ctx *ctx)
 		switch (stream_mode)
 		{
 			case CCX_SM_ELEMENTARY_OR_NOT_FOUND:
-				ret = general_getmoredata(ctx, &datalist);
+				ret = general_get_more_data(ctx, &datalist);
 				break;
 			case CCX_SM_TRANSPORT:
-				ret = ts_getmoredata(ctx->demux_ctx, &datalist);
+				ret = ts_get_more_data(ctx->demux_ctx, &datalist);
 				break;
 			case CCX_SM_PROGRAM:
-				ret = ps_getmoredata(ctx, &datalist);
+				ret = ps_get_more_data(ctx, &datalist);
 				break;
 			case CCX_SM_ASF:
-				ret = asf_getmoredata(ctx, &datalist);
+				ret = asf_get_more_data(ctx, &datalist);
 				break;
 			case CCX_SM_WTV:
-				ret = wtv_getmoredata(ctx, &datalist);
+				ret = wtv_get_more_data(ctx, &datalist);
 				break;
 			case CCX_SM_GXF:
-				ret = ccx_gxf_getmoredata(ctx->demux_ctx, &datalist);
+				ret = ccx_gxf_get_more_data(ctx->demux_ctx, &datalist);
 				break;
 #ifdef ENABLE_FFMPEG
 			case CCX_SM_FFMPEG:

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -159,7 +159,7 @@ int ps_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data ** ppdata)
 				continue;
 			}
 			//PES Header
-			//Private Stream 1 (non MPEG audio , subpictures) 
+			//Private Stream 1 (non MPEG audio , subpictures)
 			else if (nextheader[3] == 0xBD)
 			{
 				uint16_t packetlength = (nextheader[4] << 8) | nextheader[5];
@@ -178,19 +178,19 @@ int ps_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data ** ppdata)
 				buffered_skip(ctx->demux_ctx, (int)nextheader[6]);
 				ctx->demux_ctx->past += (int)nextheader[6];
 
-				//Substream ID 
+				//Substream ID
 				ret = buffered_read(ctx->demux_ctx, nextheader+7, 1);
 				ctx->demux_ctx->past += 1;
 				if(ret != 1)
 				{
 					end_of_file = 1;
-					break;					
+					break;
 				}
 
 				datalen = packetlength - 4 - nextheader[6];
 				// dbg_print(CCX_DMT_VERBOSE, "datalen :%d packetlen :%" PRIu16 " pes header ext :%d\n", datalen, packetlength, nextheader[6]);
 
-				//Subtitle substream ID 0x20 - 0x39 (32 possible)		
+				//Subtitle substream ID 0x20 - 0x39 (32 possible)
 				if( nextheader[7] >= 0x20 && nextheader[7] < 0x40)
 				{
 					dbg_print(CCX_DMT_VERBOSE, "Subtitle found Stream id:%02x\n", nextheader[7]);
@@ -201,7 +201,7 @@ int ps_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data ** ppdata)
 						end_of_file = 1;
 						break;
 					}
-					if (result>0) 
+					if (result>0)
 					{
 						payload_read+=(int) result;
 					}
@@ -291,7 +291,7 @@ int ps_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data ** ppdata)
 				{
 					continue;
 				}
-				
+
 				data->bufferdatatype = CCX_PES;
 
 				result = buffered_read (ctx->demux_ctx, data->buffer+data->len, want);
@@ -655,7 +655,7 @@ int process_data(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, str
 		got = process_m2v (dec_ctx, data_node->buffer, data_node->len, dec_sub);
 	}
 	else if (data_node->bufferdatatype == CCX_DVD_SUBTITLE)
-	{	
+	{
 		if(dec_ctx-> is_alloc == 0)
 		{
 			dec_ctx->private_data = init_dvdsub_decode();
@@ -708,9 +708,9 @@ int process_data(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, str
 		}
 
 		dbg_print(CCX_DMT_VIDES, "PTS: %s (%8u)",
-				print_mstime(dec_ctx->timing->current_pts/(MPEG_CLOCK_FREQ/1000)),
+				print_mstime_static(dec_ctx->timing->current_pts/(MPEG_CLOCK_FREQ/1000)),
 				(unsigned) (dec_ctx->timing->current_pts));
-		dbg_print(CCX_DMT_VIDES, "  FTS: %s\n", print_mstime(get_fts(dec_ctx->timing, dec_ctx->current_field)));
+		dbg_print(CCX_DMT_VIDES, "  FTS: %s\n", print_mstime_static(get_fts(dec_ctx->timing, dec_ctx->current_field)));
 
 		got = process_raw(dec_ctx, dec_sub, data_node->buffer, data_node->len);
 	}
@@ -873,7 +873,7 @@ void general_loop(struct lib_ccx_ctx *ctx)
 			dec_ctx = update_decoder_list_cinfo(ctx, cinfo);
 			dec_ctx->dtvcc->encoder = (void *)enc_ctx; //WARN: otherwise cea-708 will not work
 			enc_ctx->timing = dec_ctx->timing;
-			
+
 			if(data_node->pts != CCX_NOPTS)
 			{
 				struct ccx_rational tb = {1,MPEG_CLOCK_FREQ};
@@ -975,7 +975,7 @@ void general_loop(struct lib_ccx_ctx *ctx)
 		// Flush remaining HD captions
 		if (dec_ctx->has_ccdata_buffered)
 					process_hdcc(dec_ctx, &dec_ctx->dec_sub);
-		
+
 	mprint ("\nNumber of NAL_type_7: %ld\n",dec_ctx->avc_ctx->num_nal_unit_type_7);
 	mprint ("Number of VCL_HRD: %ld\n",dec_ctx->avc_ctx->num_vcl_hrd);
 	mprint ("Number of NAL HRD: %ld\n",dec_ctx->avc_ctx->num_nal_hrd);
@@ -1005,7 +1005,7 @@ void rcwt_loop(struct lib_ccx_ctx *ctx)
 	int bread = 0; // Bytes read
 	LLONG result;
 	struct encoder_ctx *enc_ctx = update_encoder_list(ctx);
-		
+
 	// As BUFSIZE is a macro this is just a reminder
 	if (BUFSIZE < (3*0xFFFF + 10))
 		fatal (CCX_COMMON_EXIT_BUG_BUG, "BUFSIZE too small for RCWT caption block.\n");
@@ -1088,7 +1088,7 @@ void rcwt_loop(struct lib_ccx_ctx *ctx)
 		cbcount = *((uint16_t*)(parsebuf+8));
 
 		dbg_print(CCX_DMT_PARSE, "RCWT data header FTS: %s  blocks: %u\n",
-				print_mstime(currfts), cbcount);
+				print_mstime_static(currfts), cbcount);
 
 		if ( cbcount > 0 )
 		{
@@ -1113,7 +1113,7 @@ void rcwt_loop(struct lib_ccx_ctx *ctx)
 			set_fts(dec_ctx->timing); // Now set the FTS related variables
 
 			for (int j=0; j<cbcount*3; j=j+3)
-			{				
+			{
 				do_cb(dec_ctx, parsebuf+j, dec_sub);
 			}
 		}

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -397,10 +397,10 @@ void process_hex (struct lib_ccx_ctx *ctx, char *filename)
 		{
 			unsigned char high1=c2[1];
 			unsigned char low1=c2[2];
-			int value1=hex2int (high1,low1);
+			int value1=hex_to_int (high1,low1);
 			unsigned char high2=c2[4];
 			unsigned char low2=c2[5];
-			int value2=hex2int (high2,low2);
+			int value2=hex_to_int (high2,low2);
 			buffer[0]=value1;
 			buffer[1]=value2;
 			data->windedx =2;
@@ -440,7 +440,7 @@ void process_hex (struct lib_ccx_ctx *ctx, char *filename)
 		{
 			unsigned char high=c2[0];
 			unsigned char low=c2[1];
-			int value=hex2int (high,low);
+			int value=hex_to_int (high,low);
 			if (value==-1)
 				fatal (EXIT_FAILURE, "Incorrect format, unexpected non-hex string.");
 			bytes[i]=value;

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -836,7 +836,7 @@ void general_loop(struct lib_ccx_ctx *ctx)
 				break;
 #ifdef ENABLE_FFMPEG
 			case CCX_SM_FFMPEG:
-				ret = ffmpeg_getmoredata(ctx->demux_ctx, &datalist);
+				ret = ffmpeg_get_more_data(ctx->demux_ctx, &datalist);
 				break;
 #endif
 			default:

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -362,7 +362,7 @@ int general_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data **data)
 }
 #ifdef WTV_DEBUG
 // Hexadecimal dump process
-void processhex (struct lib_ccx_ctx *ctx, char *filename)
+void process_hex (struct lib_ccx_ctx *ctx, char *filename)
 {
 	size_t max=(size_t) ctx->inputsize+1; // Enough for the whole thing. Hex dumps are small so we can be lazy here
 	char *line=(char *) malloc (max);

--- a/src/lib_ccx/hardsubx.h
+++ b/src/lib_ccx/hardsubx.h
@@ -43,7 +43,7 @@ struct lib_hardsubx_ctx
 	const char *extension;
 	int current_file;
 	char **inputfile;
-	int num_input_files; 
+	int num_input_files;
 	LLONG system_start_time;
 	enum ccx_output_format write_format;
 
@@ -87,8 +87,8 @@ int hardsubx_process_frames_linear(struct lib_hardsubx_ctx *ctx, struct encoder_
 int hardsubx_process_frames_binary(struct lib_hardsubx_ctx *ctx);
 
 //hardsubx_imgops.c
-void rgb2hsv(float R, float G, float B,float *H, float *S, float *V);
-void rgb2lab(float R, float G, float B,float *L, float *a, float *b);
+void rgb_to_hsv(float R, float G, float B,float *H, float *S, float *V);
+void rgb_to_lab(float R, float G, float B,float *L, float *a, float *b);
 
 //hardsubx_classifier.c
 char *get_ocr_text_simple(struct lib_hardsubx_ctx *ctx, PIX *image);

--- a/src/lib_ccx/hardsubx_decoder.c
+++ b/src/lib_ccx/hardsubx_decoder.c
@@ -33,7 +33,7 @@ char* _process_frame_white_basic(struct lib_hardsubx_ctx *ctx, AVFrame *frame, i
 			int b=frame->data[0][p+2];
 			pixSetRGBPixel(im,j,i,r,g,b);
 			float L,A,B;
-			rgb2lab((float)r,(float)g,(float)b,&L,&A,&B);
+			rgb_to_lab((float)r,(float)g,(float)b,&L,&A,&B);
 			if(L > ctx->lum_thresh)
 				pixSetRGBPixel(lum_im,j,i,255,255,255);
 			else
@@ -119,7 +119,7 @@ char *_process_frame_color_basic(struct lib_hardsubx_ctx *ctx, AVFrame *frame, i
 			int b=frame->data[0][p+2];
 			pixSetRGBPixel(im,j,i,r,g,b);
 			float H,S,V;
-			rgb2hsv((float)r,(float)g,(float)b,&H,&S,&V);
+			rgb_to_hsv((float)r,(float)g,(float)b,&H,&S,&V);
 			if(abs(H-ctx->hue)<20)
 			{
 				pixSetRGBPixel(hue_im,j,i,r,g,b);
@@ -154,7 +154,7 @@ char *_process_frame_color_basic(struct lib_hardsubx_ctx *ctx, AVFrame *frame, i
 			}
 		}
 	}
-	
+
 
 	if(ctx->detect_italics)
 	{
@@ -212,7 +212,7 @@ void _display_frame(struct lib_hardsubx_ctx *ctx, AVFrame *frame, int width, int
 			int b=frame->data[0][p+2];
 			pixSetRGBPixel(im,j,i,r,g,b);
 			float H,S,V;
-			rgb2hsv((float)r,(float)g,(float)b,&H,&S,&V);
+			rgb_to_hsv((float)r,(float)g,(float)b,&H,&S,&V);
 			if(abs(H-ctx->hue)<20)
 			{
 				pixSetRGBPixel(hue_im,j,i,r,g,b);
@@ -300,7 +300,7 @@ int hardsubx_process_frames_linear(struct lib_hardsubx_ctx *ctx, struct encoder_
 						ctx->rgb_frame->data,
 						ctx->rgb_frame->linesize
 					);
-				
+
 
 				// Send the frame to other functions for processing
 				if(ctx->subcolor==HARDSUBX_COLOR_WHITE)

--- a/src/lib_ccx/hardsubx_imgops.c
+++ b/src/lib_ccx/hardsubx_imgops.c
@@ -16,7 +16,7 @@
 #define min_f(a, b, c)  (fminf(a, fminf(b, c)))
 #define max_f(a, b, c) (fmaxf(a, fmaxf(b, c)))
 
-void rgb2hsv(float R, float G, float B,float *H, float *S, float *V)
+void rgb_to_hsv(float R, float G, float B,float *H, float *S, float *V)
 {
 	//Conversion into HSV color space to get Hue
 	float r = R / 255.0f;
@@ -59,7 +59,7 @@ void rgb2hsv(float R, float G, float B,float *H, float *S, float *V)
 	*V = (unsigned char)(v * 255); // dst_v : 0-255
 }
 
-void rgb2lab(float R, float G, float B,float *L, float *a, float *b)
+void rgb_to_lab(float R, float G, float B,float *L, float *a, float *b)
 {
 	//Conversion to the CIE-LAB color space to get the Luminance
 	float X, Y, Z, fX, fY, fZ;

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -151,7 +151,7 @@ void dinit_libraries( struct lib_ccx_ctx **ctx);
 
 //params.c
 int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[]);
-void usage (void);
+void print_usage (void);
 int detect_input_file_overwrite(struct lib_ccx_ctx *ctx, const char *output_filename);
 int atoi_hex (char *s);
 int stringztoms (const char *s, struct ccx_boundary_time *bt);

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -187,7 +187,7 @@ int user_data(struct lib_cc_decode *ctx, struct bitstream *ustream, int udtype, 
 
 // file_functions.c
 LLONG get_file_size (int in);
-LLONG gettotalfilessize (struct lib_ccx_ctx *ctx);
+LLONG get_total_file_size (struct lib_ccx_ctx *ctx);
 void prepare_for_new_file (struct lib_ccx_ctx *ctx);
 void close_input_file (struct lib_ccx_ctx *ctx);
 int switch_to_next_file (struct lib_ccx_ctx *ctx, LLONG bytesinbuffer);

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -125,8 +125,8 @@ struct lib_ccx_ctx
 	struct EIT_program *eit_programs;
 	int32_t *eit_current_events;
 	int16_t *ATSC_source_pg_map;
-	int epg_last_output; 
-	int epg_last_live_output; 
+	int epg_last_output;
+	int epg_last_live_output;
 	struct file_report freport;
 
 	unsigned int hauppauge_mode; // If 1, use PID=1003, process specially and so on
@@ -159,8 +159,8 @@ int stringztoms (const char *s, struct ccx_boundary_time *bt);
 // general_loop.c
 void position_sanity_check(struct ccx_demuxer *ctx);
 int init_file_buffer(struct ccx_demuxer *ctx);
-int ps_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata);
-int general_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data **data);
+int ps_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata);
+int general_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **data);
 void raw_loop (struct lib_ccx_ctx *ctx);
 size_t process_raw(struct lib_cc_decode *ctx, struct cc_subtitle *sub, unsigned char *buffer, size_t len);
 void general_loop(struct lib_ccx_ctx *ctx);
@@ -170,10 +170,10 @@ void rcwt_loop(struct lib_ccx_ctx *ctx);
 extern int end_of_file;
 
 // asf_functions.c
-int asf_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata);
+int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata);
 
 // wtv_functions.c
-int wtv_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata);
+int wtv_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata);
 
 // es_functions.c
 size_t process_m2v(struct lib_cc_decode *ctx, unsigned char *data, size_t length, struct cc_subtitle *sub);
@@ -222,7 +222,7 @@ int read_video_pes_header (struct ccx_demuxer *ctx, struct demuxer_data *data, u
 void init_ts(struct ccx_demuxer *ctx);
 int ts_readpacket(struct ccx_demuxer* ctx, struct ts_payload *payload);
 long ts_readstream(struct ccx_demuxer *ctx, struct demuxer_data **data);
-int ts_getmoredata(struct ccx_demuxer *ctx, struct demuxer_data **data);
+int ts_get_more_data(struct ccx_demuxer *ctx, struct demuxer_data **data);
 int write_section(struct ccx_demuxer *ctx, struct ts_payload *payload, unsigned char*buf, int size,  struct program_info *pinfo);
 void ts_buffer_psi_packet(struct ccx_demuxer *ctx);
 int parse_PMT (struct ccx_demuxer *ctx, unsigned char *buf, int len,  struct program_info *pinfo);

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -241,7 +241,7 @@ void mprint (const char *fmt, ...);
 void sleep_secs (int secs);
 void dump (LLONG mask, unsigned char *start, int l, unsigned long abs_start, unsigned clear_high_bit);
 bool_t in_array(uint16_t *array, uint16_t length, uint16_t element) ;
-int hex2int (char high, char low);
+int hex_to_int (char high, char low);
 void timestamp_to_srttime(uint64_t timestamp, char *buffer);
 void timestamp_to_smptetttime(uint64_t timestamp, char *buffer);
 int levenshtein_dist (const uint64_t *s1, const uint64_t *s2, unsigned s1len, unsigned s2len);

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -186,7 +186,7 @@ int user_data(struct lib_cc_decode *ctx, struct bitstream *ustream, int udtype, 
 // bitstream.c - see bitstream.h
 
 // file_functions.c
-LLONG getfilesize (int in);
+LLONG get_file_size (int in);
 LLONG gettotalfilessize (struct lib_ccx_ctx *ctx);
 void prepare_for_new_file (struct lib_ccx_ctx *ctx);
 void close_input_file (struct lib_ccx_ctx *ctx);

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -164,7 +164,7 @@ int general_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data **data);
 void raw_loop (struct lib_ccx_ctx *ctx);
 size_t process_raw(struct lib_cc_decode *ctx, struct cc_subtitle *sub, unsigned char *buffer, size_t len);
 void general_loop(struct lib_ccx_ctx *ctx);
-void processhex (char *filename);
+void process_hex (char *filename);
 void rcwt_loop(struct lib_ccx_ctx *ctx);
 
 extern int end_of_file;

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -242,6 +242,7 @@ void sleep_secs (int secs);
 void dump (LLONG mask, unsigned char *start, int l, unsigned long abs_start, unsigned clear_high_bit);
 bool_t in_array(uint16_t *array, uint16_t length, uint16_t element) ;
 int hex_to_int (char high, char low);
+int hex_string_to_int(char* string, int len);
 void timestamp_to_srttime(uint64_t timestamp, char *buffer);
 void timestamp_to_smptetttime(uint64_t timestamp, char *buffer);
 int levenshtein_dist (const uint64_t *s1, const uint64_t *s2, unsigned s1len, unsigned s2len);

--- a/src/lib_ccx/output.c
+++ b/src/lib_ccx/output.c
@@ -156,7 +156,7 @@ void writeDVDraw (const unsigned char *data1, int length1,
 
 }
 
-void printdata (struct lib_cc_decode *ctx, const unsigned char *data1, int length1,
+void print_data (struct lib_cc_decode *ctx, const unsigned char *data1, int length1,
                 const unsigned char *data2, int length2, struct cc_subtitle *sub)
 {
 	if (ctx->write_format==CCX_OF_DVDRAW)

--- a/src/lib_ccx/output.c
+++ b/src/lib_ccx/output.c
@@ -10,7 +10,7 @@ void dinit_write(struct ccx_s_write *wb)
 {
 	if (wb->fh > 0)
 		close(wb->fh);
-	freep(&wb->filename);	
+	freep(&wb->filename);
 	if (wb->with_semaphore && wb->semaphore_filename)
 		unlink(wb->semaphore_filename);
 	freep(&wb->semaphore_filename);
@@ -49,7 +49,7 @@ int init_write (struct ccx_s_write *wb, char *filename, int with_semaphore)
 {
 	memset(wb, 0, sizeof(struct ccx_s_write));
 	wb->fh=-1;
-	wb->temporarily_closed = 0; 
+	wb->temporarily_closed = 0;
 	wb->filename = filename;
 	wb->with_semaphore = with_semaphore;
 	wb->append_mode = ccx_options.enc_cfg.append_mode;
@@ -223,7 +223,7 @@ void writercwtdata (struct lib_cc_decode *ctx, const unsigned char *data, struct
 				}
 			}
 			dbg_print(CCX_DMT_CBRAW, "%s Write %d RCWT blocks - skipped %d padding / %d unused blocks.\n",
-					print_mstime(prevfts), cbcount, storecbcount - cbcount, cbempty);
+					print_mstime_static(prevfts), cbcount, storecbcount - cbcount, cbempty);
 		}
 
 		// New FTS, write data header
@@ -287,7 +287,7 @@ void writercwtdata (struct lib_cc_decode *ctx, const unsigned char *data, struct
 		cbempty = 0;
 
 		dbg_print(CCX_DMT_CBRAW, "%s Write final padding RCWT blocks.\n",
-				print_mstime(currfts));
+				print_mstime_static(currfts));
 	}
 
 	prevfts = currfts;

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -245,7 +245,7 @@ void set_input_format (struct ccx_s_options *opt, const char *format)
 	{
 		opt->demux_cfg.auto_stream = CCX_SM_TRANSPORT;
 		opt->demux_cfg.m2ts = 0;
-	}	
+	}
 	else if (strcmp(format, "m2ts") == 0)
 	{
 		opt->demux_cfg.auto_stream = CCX_SM_TRANSPORT;
@@ -271,7 +271,7 @@ void set_input_format (struct ccx_s_options *opt, const char *format)
 		fatal (EXIT_MALFORMED_PARAMETER, "Unknown input file format: %s\n", format);
 }
 
-void usage (void)
+void print_usage (void)
 {
 	mprint ("Originally based on McPoodle's tools. Check his page for lots of information\n");
 	mprint ("on closed captions technical details.\n");
@@ -550,7 +550,7 @@ void usage (void)
 	mprint (" -nobi -nobufferinput: Disables input buffering.\n");
 	mprint (" -bs --buffersize val: Specify a size for reading, in bytes (suffix with K or\n");
 	mprint ("                       or M for kilobytes and megabytes). Default is 16M.\n");
-	mprint ("                 -koc: keep-output-close. If used then CCExtractor will close\n"); 
+	mprint ("                 -koc: keep-output-close. If used then CCExtractor will close\n");
 	mprint ("                       the output file after writing each subtitle frame and\n");
 	mprint ("                       attempt to create it again when needed.\n");
 	mprint ("     -ff --forceflush: Flush the file buffer whenever content is written.\n");
@@ -978,7 +978,7 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 	{
 		if (!strcmp (argv[i],"--help") || !strcmp(argv[i], "-h"))
 		{
-			usage();
+			print_usage();
 			return EXIT_WITH_HELP;
 		}
 		if (!strcmp(argv[i], "--version"))
@@ -1011,7 +1011,7 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 			}
 			continue;
 		}
-		
+
 #ifdef ENABLE_HARDSUBX
 		// Parse -hardsubx and related parameters
 		if (strcmp(argv[i], "-hardsubx")==0)
@@ -1234,8 +1234,8 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		}
 		if (strcmp(argv[i], "-sem") == 0){
 			opt->enc_cfg.with_semaphore = 1;
-			continue;		
-		}	
+			continue;
+		}
 		if (strcmp (argv[i],"-nots")==0 ||
 				strcmp (argv[i],"--notypesetting")==0)
 		{
@@ -1517,7 +1517,7 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 			opt->enc_cfg.splitbysentence = 1;
 			continue;
 		}
-		 
+
 		if ((strcmp (argv[i],"--capfile")==0 ||
 					strcmp (argv[i],"-caf")==0)
 				&& i<argc-1)
@@ -1893,7 +1893,7 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 			}
 			continue;
 		}
-		
+
 		if (strcmp (argv[i],"-xmltvliveinterval")==0)
 		{
 			if (i==argc-1 // Means no following argument
@@ -1906,7 +1906,7 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 			}
 			continue;
 		}
-		
+
 		if (strcmp (argv[i],"-xmltvoutputinterval")==0)
 		{
 			if (i==argc-1 // Means no following argument
@@ -1925,7 +1925,7 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 			i++;
 			continue;
 		}
-		
+
 		if (strcmp (argv[i],"-unixts")==0 && i<argc-1)
 		{
 			uint64_t t = 0;
@@ -2189,7 +2189,7 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 	{
 		print_error(opt->gui_mode_reports, "You can't extract both fields to stdout at the same time in broadcast mode.");
 		return EXIT_INCOMPATIBLE_PARAMETERS;
-	}		
+	}
 	if (opt->write_format == CCX_OF_SPUPNG && opt->cc_to_stdout)
 	{
 		print_error(opt->gui_mode_reports, "You cannot use -out=spupng with -stdout.");

--- a/src/lib_ccx/sequencing.c
+++ b/src/lib_ccx/sequencing.c
@@ -68,7 +68,7 @@ void store_hdcc(struct lib_cc_decode *ctx, unsigned char *cc_data, int cc_count,
 	   printf("\nCC blocks, channel 0:\n");
 	   for ( int i=0; i < cc_count*3; i+=3)
 	   {
-	   printf("%s", debug_608toASC( cc_data+i, 0) );
+	   printf("%s", debug_608_to_ASC( cc_data+i, 0) );
 	   }
 	   printf("\n");
 	 */

--- a/src/lib_ccx/ts_functions.c
+++ b/src/lib_ccx/ts_functions.c
@@ -130,7 +130,7 @@ int ts_readpacket(struct ccx_demuxer* ctx, struct ts_payload *payload)
 	{
 		/* M2TS just adds 4 bytes to each packet (so size goes from 188 to 192)
 		   The 4 bytes are not important to us, so just skip
-		// TP_extra_header {   
+		// TP_extra_header {
 		Copy_permission_indicator 2  unimsbf
 		Arrival_time_stamp 30 unimsbf
 		} */
@@ -495,7 +495,7 @@ int copy_capbuf_demux_data(struct ccx_demuxer *ctx, struct demuxer_data **data, 
 
 void cinfo_cremation(struct ccx_demuxer *ctx, struct demuxer_data **data)
 {
-	struct cap_info* iter; 
+	struct cap_info* iter;
 	list_for_each_entry(iter, &ctx->cinfo_tree.all_stream, all_stream, struct cap_info)
 	{
 		copy_capbuf_demux_data(ctx, data, iter);
@@ -515,7 +515,7 @@ int copy_payload_to_capbuf(struct cap_info *cinfo, struct ts_payload *payload)
 	//Verify PES before copy to capbuf
 	if(cinfo->capbuflen == 0 )
 	{
-		if(payload->start[0] != 0x00 || payload->start[1] != 0x00 || 
+		if(payload->start[0] != 0x00 || payload->start[1] != 0x00 ||
 			payload->start[2] != 0x01)
 		{
 			mprint("Notice: Missing PES header\n");
@@ -581,7 +581,7 @@ long ts_readstream(struct ccx_demuxer *ctx, struct demuxer_data **data)
 				parse_PAT(ctx); // Returns 1 if there was some data in the buffer already
 			continue;
 		}
-		
+
 		if( ccx_options.xmltv >= 1 && payload.pid == 0x11) {// This is SDT (or BAT)
 			ts_buffer_psi_packet(ctx);
 			if(ctx->PID_buffers[payload.pid]!=NULL && ctx->PID_buffers[payload.pid]->buffer_length>0)
@@ -692,11 +692,11 @@ long ts_readstream(struct ccx_demuxer *ctx, struct demuxer_data **data)
         // with the continuity counter not being incremented in empty
         // packets.
         if ( !payload.length )
-        {   
+        {
                 dbg_print(CCX_DMT_VERBOSE, "Packet (pid %u) skipped - no payload.\n",
                         payload.pid);
                 continue;
-        }   
+        }
 
 
 		cinfo = get_cinfo(ctx, payload.pid);
@@ -728,7 +728,7 @@ long ts_readstream(struct ccx_demuxer *ctx, struct demuxer_data **data)
 				}
 				cinfo->codec_private_data = NULL;
 			}
-			
+
 			if (cinfo->capbuflen > 0)
 			{
 				freep(&cinfo->capbuf);
@@ -793,7 +793,7 @@ long ts_readstream(struct ccx_demuxer *ctx, struct demuxer_data **data)
 
 
 // TS specific data grabber
-int ts_getmoredata(struct ccx_demuxer *ctx, struct demuxer_data **data)
+int ts_get_more_data(struct ccx_demuxer *ctx, struct demuxer_data **data)
 {
 	int ret = CCX_OK;
 

--- a/src/lib_ccx/ts_info.c
+++ b/src/lib_ccx/ts_info.c
@@ -1,7 +1,7 @@
 #include "ccx_demuxer.h"
 #include "ccx_common_common.h"
 #include "lib_ccx.h"
-#include "dvb_subtitle_decoder.h" 
+#include "dvb_subtitle_decoder.h"
 
 /**
     We need stream info from PMT table when any of the following Condition meets:
@@ -9,9 +9,9 @@
     2) Want a streams per program, and program_number has never been registered
     3) We need single stream and its info about codec and buffertype is incomplete
 */
-int need_capInfo(struct ccx_demuxer *ctx, int program_number)
+int need_cap_info(struct ccx_demuxer *ctx, int program_number)
 {
-	struct cap_info* iter; 
+	struct cap_info* iter;
 	if(list_empty(&ctx->cinfo_tree.all_stream))
 	{
 		return CCX_TRUE;
@@ -39,7 +39,7 @@ int need_capInfo(struct ccx_demuxer *ctx, int program_number)
 
 void ignore_other_stream(struct ccx_demuxer *ctx, int pid)
 {
-	struct cap_info* iter; 
+	struct cap_info* iter;
 	list_for_each_entry(iter, &ctx->cinfo_tree.all_stream, all_stream, struct cap_info)
 	{
 		if(iter->pid != pid)
@@ -89,7 +89,7 @@ struct cap_info* get_best_sib_stream(struct cap_info* program)
 
 void ignore_other_sib_stream(struct cap_info* head, int pid)
 {
-	struct cap_info* iter; 
+	struct cap_info* iter;
 	list_for_each_entry(iter, &head->sib_head, sib_stream, struct cap_info)
 	{
 		if(iter->pid != pid)
@@ -136,9 +136,9 @@ struct demuxer_data *get_data_stream(struct demuxer_data *data, int pid)
 
 	return NULL;
 }
-int need_capInfo_for_pid(struct ccx_demuxer *ctx, int pid)
+int need_cap_info_for_pid(struct ccx_demuxer *ctx, int pid)
 {
-	struct cap_info* iter; 
+	struct cap_info* iter;
 	if(list_empty(&ctx->cinfo_tree.all_stream))
 	{
 		return CCX_FALSE;
@@ -251,7 +251,7 @@ int update_capinfo(struct ccx_demuxer *ctx, int pid, enum ccx_stream_type stream
 
 void dinit_cap (struct ccx_demuxer *ctx)
 {
-	struct cap_info* iter; 
+	struct cap_info* iter;
 	while(!list_empty(&ctx->cinfo_tree.all_stream))
 	{
 		iter = list_entry(ctx->cinfo_tree.all_stream.next, struct cap_info, all_stream);
@@ -266,7 +266,7 @@ void dinit_cap (struct ccx_demuxer *ctx)
 
 struct cap_info * get_cinfo(struct ccx_demuxer *ctx, int pid)
 {
-	struct cap_info* iter; 
+	struct cap_info* iter;
 
 	list_for_each_entry(iter, &ctx->cinfo_tree.all_stream, all_stream, struct cap_info)
 	{
@@ -275,4 +275,3 @@ struct cap_info * get_cinfo(struct ccx_demuxer *ctx, int pid)
 	}
 	return NULL;
 }
-

--- a/src/lib_ccx/ts_tables.c
+++ b/src/lib_ccx/ts_tables.c
@@ -421,7 +421,7 @@ int parse_PMT (struct ccx_demuxer *ctx, unsigned char *buf, int len,  struct pro
 			//	program_number , desc[stream_type], stream_type, elementary_PID);
 		}
 
-		if(need_capInfo_for_pid(ctx, elementary_PID) == CCX_TRUE)
+		if(need_cap_info_for_pid(ctx, elementary_PID) == CCX_TRUE)
 		{
 			// We found the user selected CAPPID in PMT. We make a note of its type and don't
 			// touch anything else
@@ -655,7 +655,7 @@ int parse_PAT (struct ccx_demuxer *ctx)
 		 * is already there in pinfo array and if we have program number
 		 * already in our array we dont need to update our array
 		 * so we break if program_number already exist and make j != ctx->nb_program
-		 * 
+		 *
 		 * Loop without break means j would be equal to ctx->nb_program
 		 */
 		for (j = 0; j < ctx->nb_program; j++)

--- a/src/lib_ccx/utility.c
+++ b/src/lib_ccx/utility.c
@@ -360,6 +360,21 @@ int hex_to_int (char high, char low)
 		return -1;
 	return h * 16+l;
 }
+int hex_string_to_int(char* string, int len)
+{
+  int total_return = 0;
+  while(*string && len-- > 0 && total_return >= 0){
+    unsigned char c = *string;
+    if(c >= '0' && c <= '9')
+      total_return = total_return * 16 + (c - '0');
+    else if(*string >= 'a' && *string <= 'f')
+      total_return = total_return * 16 + (c - 'a' + 10);
+    else
+      total_return = -1;
+    string++;
+  }
+  return total_return;
+}
 
 #ifndef _WIN32
 void m_signal(int sig, void (*func)(int))

--- a/src/lib_ccx/utility.c
+++ b/src/lib_ccx/utility.c
@@ -343,7 +343,7 @@ void sleep_secs (int secs)
 #endif
 }
 
-int hex2int (char high, char low)
+int hex_to_int (char high, char low)
 {
 	unsigned char h,l;
 	if (high >= '0' && high <= '9')

--- a/src/lib_ccx/wtv_functions.c
+++ b/src/lib_ccx/wtv_functions.c
@@ -452,7 +452,7 @@ LLONG get_data(struct lib_ccx_ctx *ctx, struct wtv_chunked_buffer *cb, struct de
 	}
 }
 
-int wtv_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data ** ppdata)
+int wtv_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data ** ppdata)
 {
 	static struct wtv_chunked_buffer cb;
 	int ret = CCX_OK;


### PR DESCRIPTION
Aside from renaming hex2int --> hex_to_int and processhex --> process_hex for consistency, I also took the liberty to implement a hex_string_to_int function. It seems like hexadecimal characters are accessed from a string before being passed to hex_to_int, so it seems logical to eliminate that extra step and generalize the behavior a bit more. I did not introduce the new hex_string_to_int function into existing code to make sure it's reviewed before it's used.