### PR TITLE
GCI task: Return a non-zero return code if no subtitles were found (CCExtractor Development)

### DIFF
--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -136,6 +136,9 @@ int main(int argc, char *argv[])
 				fatal(EXIT_READ_ERROR, "Failed to open file: Reason unknown");
 			}
 		}
+		else if(ctx->total_inputsize<=3){
+		fatal(EXIT_READ_ERROR,"Failed to read file: Only whitespace characters found.")
+		}
 	}
 
 #ifndef _WIN32


### PR DESCRIPTION
added error for when there are no subtitles are found in the file