### PR TITLE
GCI task: Added error when output file cannot be generated

### DIFF
--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -81,9 +81,9 @@ int main(int argc, char *argv[])
 		fatal (CCX_COMMON_EXIT_FILE_CREATION_FAILED, "Unable to create Output File\n");
 	else if (!ctx)
 		fatal (EXIT_NOT_CLASSIFIED, "Unable to create Library Context %d\n",errno);
-	else {
+	else
 	fatal (CCX_COMMON_EXIT_FILE_CREATION_FAILED,"Unable to create output file due to unknown reasons.",errno);
-	}
+	
 #ifdef WITH_LIBCURL
 	curl_global_init(CURL_GLOBAL_ALL);
  

--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -81,7 +81,9 @@ int main(int argc, char *argv[])
 		fatal (CCX_COMMON_EXIT_FILE_CREATION_FAILED, "Unable to create Output File\n");
 	else if (!ctx)
 		fatal (EXIT_NOT_CLASSIFIED, "Unable to create Library Context %d\n",errno);
-
+	else {
+	fatal (CCX_COMMON_EXIT_FILE_CREATION_FAILED,"Unable to create output file due to unknown reasons.",errno);
+	}
 #ifdef WITH_LIBCURL
 	curl_global_init(CURL_GLOBAL_ALL);
  


### PR DESCRIPTION
error when output file cannot be generated due to unknown reason
https://codein.withgoogle.com/dashboard/task-instances/6574220542738432/