### PR TITLE
Added basic ASS/SSA encoding support

### DIFF
--- a/src/lib_ccx/ccx_common_constants.h
+++ b/src/lib_ccx/ccx_common_constants.h
@@ -170,6 +170,7 @@ enum ccx_output_format
 	CCX_OF_SIMPLE_XML = 10,
 	CCX_OF_G608 = 11,
 	CCX_OF_CURL = 12,
+	CCX_OF_SSA = 13,
 };
 
 enum ccx_output_date_format

--- a/src/lib_ccx/ccx_common_option.h
+++ b/src/lib_ccx/ccx_common_option.h
@@ -140,6 +140,7 @@ struct ccx_s_options // Options from user parameters
 	enum ccx_output_date_format date_format;
 	unsigned send_to_srv;
 	enum ccx_output_format write_format; // 0=Raw, 1=srt, 2=SMI
+	int use_ass_instead_of_ssa;
 	LLONG debug_mask; // dbg_print will use this mask to print or ignore different types
 	LLONG debug_mask_on_debug; // If we're using temp_debug to enable/disable debug "live", this is the mask when temp_debug=1
 	/* Networking */

--- a/src/lib_ccx/ccx_decoders_common.c
+++ b/src/lib_ccx/ccx_decoders_common.c
@@ -310,6 +310,7 @@ struct lib_cc_decode* init_cc_decode (struct ccx_decoders_common_settings_t *set
 	else if (setting->output_format==CCX_OF_SMPTETT ||
 		setting->output_format==CCX_OF_SAMI ||
 		setting->output_format==CCX_OF_SRT ||
+		setting->output_format==CCX_OF_SSA ||
 		setting->output_format == CCX_OF_WEBVTT ||
 		setting->output_format==CCX_OF_TRANSCRIPT ||
 		setting->output_format==CCX_OF_SPUPNG ||
@@ -369,9 +370,10 @@ void flush_cc_decode(struct lib_cc_decode *ctx, struct cc_subtitle *sub)
 	{
 		if (ctx->extract != 2)
 		{
-			if (ctx->write_format==CCX_OF_SMPTETT || ctx->write_format==CCX_OF_SAMI || 
+			if (ctx->write_format==CCX_OF_SMPTETT || ctx->write_format==CCX_OF_SAMI ||
 					ctx->write_format==CCX_OF_SRT || ctx->write_format==CCX_OF_TRANSCRIPT ||
-					ctx->write_format == CCX_OF_WEBVTT || ctx->write_format == CCX_OF_SPUPNG)
+					ctx->write_format == CCX_OF_WEBVTT || ctx->write_format == CCX_OF_SPUPNG ||
+					ctx->write_format == CCX_OF_SSA)
 			{
 				flush_608_context(ctx->context_cc608_field_1, sub);
 			}
@@ -385,7 +387,8 @@ void flush_cc_decode(struct lib_cc_decode *ctx, struct cc_subtitle *sub)
 		{
 			if (ctx->write_format == CCX_OF_SMPTETT || ctx->write_format == CCX_OF_SAMI ||
 					ctx->write_format == CCX_OF_SRT || ctx->write_format == CCX_OF_TRANSCRIPT ||
-					ctx->write_format == CCX_OF_WEBVTT || ctx->write_format == CCX_OF_SPUPNG)
+					ctx->write_format == CCX_OF_WEBVTT || ctx->write_format == CCX_OF_SPUPNG ||
+					ctx->write_format == CCX_OF_SSA)
 			{
 				flush_608_context(ctx->context_cc608_field_2, sub);
 			}

--- a/src/lib_ccx/ccx_encoders_common.h
+++ b/src/lib_ccx/ccx_encoders_common.h
@@ -162,6 +162,7 @@ void dinit_encoder(struct encoder_ctx **arg, LLONG current_fts);
 int encode_sub(struct encoder_ctx *ctx,struct cc_subtitle *sub);
 
 int write_cc_buffer_as_srt            (struct eia608_screen *data, struct encoder_ctx *context);
+int write_cc_buffer_as_ssa            (struct eia608_screen *data, struct encoder_ctx *context);
 int write_cc_buffer_as_webvtt         (struct eia608_screen *data, struct encoder_ctx *context);
 int write_cc_buffer_as_sami           (struct eia608_screen *data, struct encoder_ctx *context);
 int write_cc_buffer_as_smptett        (struct eia608_screen *data, struct encoder_ctx *context);
@@ -173,6 +174,7 @@ int write_cc_buffer_as_transcript2    (struct eia608_screen *data, struct encode
 void write_cc_line_as_transcript2     (struct eia608_screen *data, struct encoder_ctx *context, int line_number);
 
 int write_cc_subtitle_as_srt          (struct cc_subtitle *sub, struct encoder_ctx *context);
+int write_cc_subtitle_as_ssa          (struct cc_subtitle *sub, struct encoder_ctx *context);
 int write_cc_subtitle_as_webvtt       (struct cc_subtitle *sub, struct encoder_ctx *context);
 int write_cc_subtitle_as_sami         (struct cc_subtitle *sub, struct encoder_ctx *context);
 int write_cc_subtitle_as_smptett      (struct cc_subtitle *sub, struct encoder_ctx *context);
@@ -181,12 +183,14 @@ int write_cc_subtitle_as_transcript   (struct cc_subtitle *sub, struct encoder_c
 
 
 int write_stringz_as_srt              (char *string, struct encoder_ctx *context, LLONG ms_start, LLONG ms_end);
+int write_stringz_as_ssa              (char *string, struct encoder_ctx *context, LLONG ms_start, LLONG ms_end);
 int write_stringz_as_webvtt           (char *string, struct encoder_ctx *context, LLONG ms_start, LLONG ms_end);
 int write_stringz_as_sami             (char *string, struct encoder_ctx *context, LLONG ms_start, LLONG ms_end);
 void write_stringz_as_smptett         (char *string, struct encoder_ctx *context, LLONG ms_start, LLONG ms_end);
 
 
 int write_cc_bitmap_as_srt             (struct cc_subtitle *sub, struct encoder_ctx *context);
+int write_cc_bitmap_as_ssa             (struct cc_subtitle *sub, struct encoder_ctx *context);
 int write_cc_bitmap_as_webvtt          (struct cc_subtitle *sub, struct encoder_ctx *context);
 int write_cc_bitmap_as_sami            (struct cc_subtitle *sub, struct encoder_ctx *context);
 int write_cc_bitmap_as_smptett         (struct cc_subtitle *sub, struct encoder_ctx *context);

--- a/src/lib_ccx/ccx_encoders_ssa.c
+++ b/src/lib_ccx/ccx_encoders_ssa.c
@@ -1,0 +1,173 @@
+#include "lib_ccx.h"
+#include "ccx_common_option.h"
+#include "ccx_encoders_common.h"
+#include "utility.h"
+#include "ccx_encoders_helpers.h"
+#include "ocr.h"
+
+int write_stringz_as_ssa(char *string, struct encoder_ctx *context, LLONG ms_start, LLONG ms_end)
+{
+	// TODO: write it
+	return 0;
+}
+
+int write_cc_bitmap_as_ssa(struct cc_subtitle *sub, struct encoder_ctx *context)
+{
+	// TODO: write it
+	return 0;
+}
+
+int write_cc_subtitle_as_ssa(struct cc_subtitle *sub,struct encoder_ctx *context)
+{
+	int ret = 0;
+	struct cc_subtitle *osub = sub;
+	struct cc_subtitle *lsub = sub;
+
+	while(sub)
+	{
+		if(sub->type == CC_TEXT)
+		{
+			ret = write_stringz_as_ssa(sub->data, context, sub->start_time, sub->end_time);
+			freep(&sub->data);
+			sub->nb_data = 0;
+			ret = 1;
+		}
+		lsub = sub;
+		sub = sub->next;
+	}
+	while(lsub != osub)
+	{
+		sub = lsub->prev;
+		freep(&lsub);
+		lsub = sub;
+	}
+
+	return ret;
+}
+int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *context)
+{
+	int used;
+	unsigned h1,m1,s1,ms1;
+	unsigned h2,m2,s2,ms2;
+	LLONG ms_start, ms_end;
+	int wrote_something = 0;
+	ms_start = data->start_time;
+
+	int prev_line_start=-1, prev_line_end=-1; // Column in which the previous line started and ended, for autodash
+	int prev_line_center1=-1, prev_line_center2=-1; // Center column of previous line text
+	int empty_buf=1;
+	for (int i=0;i<15;i++)
+	{
+		if (data->row_used[i])
+		{
+			empty_buf=0;
+			break;
+		}
+	}
+	if (empty_buf)
+		return 0;
+
+	ms_start+=context->subs_delay;
+	if (ms_start<0)
+		return 0;
+
+	ms_end = data->end_time;
+
+	mstotime (ms_start,&h1,&m1,&s1,&ms1);
+	mstotime (ms_end-1,&h2,&m2,&s2,&ms2); // -1 To prevent overlapping with next line.
+	char timeline[128];
+	sprintf (timeline, "Dialogue: 0,%02u:%02u:%02u.%01u,%02u:%02u:%02u.%02u,Default,,0000,0000,0000,,",
+			 h1, m1, s1, ms1 / 10, h2, m2, s2, ms2 / 10);
+	used = encode_line(context, context->buffer,(unsigned char *) timeline);
+
+	dbg_print(CCX_DMT_DECODER_608, "\n- - - ASS/SSA caption - - -\n");
+	dbg_print(CCX_DMT_DECODER_608, "%s",timeline);
+
+	write (context->out->fh, context->buffer, used);
+
+	int line_count = 0;
+	for (int i=0;i<15;i++)
+	{
+		if (data->row_used[i])
+		{
+			if (context->sentence_cap)
+			{
+				if (clever_capitalize (context, i, data))
+					correct_case_with_dictionary(i, data);
+			}
+			if (context->autodash && context->trim_subs)
+			{
+				int first=0, last=31, center1=-1, center2=-1;
+				unsigned char *line = data->characters[i];
+				int do_dash=1, colon_pos=-1;
+				find_limit_characters(line, &first, &last, CCX_DECODER_608_SCREEN_WIDTH);
+				if (first==-1 || last==-1)  // Probably a bug somewhere though
+					break;
+				// Is there a speaker named, for example: TOM: What are you doing?
+				for (int j=first;j<=last;j++)
+				{
+					if (line[j]==':')
+					{
+						colon_pos=j;
+						break;
+					}
+					if (!isupper (line[j]))
+						break;
+				}
+				if (prev_line_start==-1)
+					do_dash=0;
+				if (first==prev_line_start) // Case of left alignment
+					do_dash=0;
+				if (last==prev_line_end)  // Right align
+					do_dash=0;
+				if (first>prev_line_start && last<prev_line_end) // Fully contained
+					do_dash=0;
+				if ((first>prev_line_start && first<prev_line_end) || // Overlap
+					(last>prev_line_start && last<prev_line_end))
+					do_dash=0;
+
+				center1=(first+last)/2;
+				if (colon_pos!=-1)
+				{
+					while (colon_pos<CCX_DECODER_608_SCREEN_WIDTH &&
+						   (line[colon_pos]==':' ||
+							line[colon_pos]==' ' ||
+							line[colon_pos]==0x89))
+						colon_pos++; // Find actual text
+					center2=(colon_pos+last)/2;
+				}
+				else
+					center2=center1;
+
+				if (center1>=prev_line_center1-1 && center1<=prev_line_center1+1 && center1!=-1) // Center align
+					do_dash=0;
+				if (center2>=prev_line_center2-2 && center1<=prev_line_center2+2 && center1!=-1) // Center align
+					do_dash=0;
+
+				if (do_dash)
+					write(context->out->fh, "- ", 2);
+				prev_line_start=first;
+				prev_line_end=last;
+				prev_line_center1=center1;
+				prev_line_center2=center2;
+
+			}
+			int length = get_decoder_line_encoded (context, context->subline, i, data);
+			if (context->encoding!=CCX_ENC_UNICODE)
+			{
+				dbg_print(CCX_DMT_DECODER_608, "\r");
+				dbg_print(CCX_DMT_DECODER_608, "%s\n",context->subline);
+			}
+			if (line_count)
+				write(context->out->fh, "\\N", 2);
+			write(context->out->fh, context->subline, length);
+			line_count++;
+			wrote_something=1;
+		}
+	}
+
+	dbg_print(CCX_DMT_DECODER_608, "- - - - - - - - - - - -\r\n");
+
+	write (context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
+	return wrote_something;
+}

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -176,7 +176,11 @@ void set_output_format (struct ccx_s_options *opt, const char *format)
 
 	if (strcmp (format,"srt")==0)
 		opt->write_format=CCX_OF_SRT;
-	else if (strcmp(format, "webvtt") == 0)
+	else if (strcmp (format,"ass")==0 || strcmp (format,"ssa")==0) {
+		opt->write_format = CCX_OF_SSA;
+		if (strcmp (format,"ass")==0)
+			opt->use_ass_instead_of_ssa = 1;
+	} else if (strcmp(format, "webvtt") == 0)
 		opt->write_format = CCX_OF_WEBVTT;
 	else if (strcmp (format,"sami")==0 || strcmp (format,"smi")==0)
 		opt->write_format=CCX_OF_SAMI;
@@ -372,6 +376,7 @@ void usage (void)
 	mprint ("                 -out=format\n\n");
 	mprint ("       where format is one of these:\n");
 	mprint ("                      srt     -> SubRip (default, so not actually needed).\n");
+	mprint ("                      ass/ssa -> SubStation Alpha.\n");
 	mprint ("                      webvtt  -> WebVTT format\n");
 	mprint ("                      sami    -> MS Synchronized Accesible Media Interface.\n");
 	mprint ("                      bin     -> CC data in CCExtractor's own binary format.\n");

--- a/src/lib_ccx/utility.c
+++ b/src/lib_ccx/utility.c
@@ -493,6 +493,8 @@ char *get_file_extension(enum ccx_output_format write_format)
 			return strdup(".raw");
 		case CCX_OF_SRT:
 			return strdup(".srt");
+		case CCX_OF_SSA:
+			return strdup(".ass");
 		case CCX_OF_WEBVTT:
 			return strdup (".vtt");
 		case CCX_OF_SAMI:


### PR DESCRIPTION
[https://codein.withgoogle.com/dashboard/task-instances/5110381871628288/](https://codein.withgoogle.com/dashboard/task-instances/5110381871628288/)

Added basic ASS/SSA encoding support.
I checked some files, works well. Run with args: `file -out=ssa` or `file -out=ass`.
`src/lib_ccx/ccx_encoders_ssa.c` has two empty functions, as I can't check it without example video file, on which this functions will be called. Please give me test file if you can.
`use_ass_instead_of_ssa` there is, as the format is slightly different, so it is possible to generate a little different files because of different formats .ass and .ssa, but maybe we need only one format.
Please give your opinion about the `ssa_header`, maybe there is something to change in style.

Last pull request was closed because of bug.