### PR TITLE
Fixed bug with -out=null

### DIFF
--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -667,9 +667,11 @@ int process_data(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, str
 	else if (data_node->bufferdatatype == CCX_TELETEXT)
 	{
 		//telxcc_update_gt(dec_ctx->private_data, ctx->demux_ctx->global_timestamp);
-		ret = tlt_process_pes_packet (dec_ctx, data_node->buffer, data_node->len, dec_sub, enc_ctx->sentence_cap);
-		if(ret == CCX_EINVAL)
-			return ret;
+		if (enc_ctx) {
+			ret = tlt_process_pes_packet(dec_ctx, data_node->buffer, data_node->len, dec_sub, enc_ctx->sentence_cap);
+			if (ret == CCX_EINVAL)
+				return ret;
+		}
 		got = data_node->len;
 	}
 	else if (data_node->bufferdatatype == CCX_PRIVATE_MPEG2_CC)
@@ -872,7 +874,8 @@ void general_loop(struct lib_ccx_ctx *ctx)
 			enc_ctx = update_encoder_list_cinfo(ctx, cinfo);
 			dec_ctx = update_decoder_list_cinfo(ctx, cinfo);
 			dec_ctx->dtvcc->encoder = (void *)enc_ctx; //WARN: otherwise cea-708 will not work
-			enc_ctx->timing = dec_ctx->timing;
+			if (enc_ctx)
+				enc_ctx->timing = dec_ctx->timing;
 			
 			if(data_node->pts != CCX_NOPTS)
 			{
@@ -930,7 +933,8 @@ void general_loop(struct lib_ccx_ctx *ctx)
 				enc_ctx = update_encoder_list_cinfo(ctx, cinfo);
 				dec_ctx = update_decoder_list_cinfo(ctx, cinfo);
 				dec_ctx->dtvcc->encoder = (void *)enc_ctx; //WARN: otherwise cea-708 will not work
-				dec_ctx->timing = enc_ctx->timing;
+				if (enc_ctx)
+					dec_ctx->timing = enc_ctx->timing;
 				if(data_node->pts != CCX_NOPTS)
 					set_current_pts(dec_ctx->timing, data_node->pts);
 				process_data(enc_ctx, dec_ctx, data_node);

--- a/src/lib_ccx/lib_ccx.c
+++ b/src/lib_ccx/lib_ccx.c
@@ -83,7 +83,7 @@ struct encoder_ctx *get_encoder_by_pn(struct lib_ccx_ctx *ctx, int pn)
 	struct  encoder_ctx *enc_ctx;
 	list_for_each_entry(enc_ctx, &ctx->enc_ctx_head, list, struct encoder_ctx)
 	{
-		if (enc_ctx->program_number == pn)
+		if (enc_ctx && enc_ctx->program_number == pn)
 			return enc_ctx;
 	}
 	return NULL;


### PR DESCRIPTION
[https://codein.withgoogle.com/dashboard/task-instances/5591734023094272/](url)

I checked the correctness (I had segfault too).
Falling test - the only test that has an argument `-out=null`. But I checked some other files, and they too gave segfault with `-out=null`.
How is it? Firstly, after this line [#1](https://github.com/CCExtractor/ccextractor/blob/master/src/lib_ccx/general_loop.c#L930) `enc_ctx` becomes NULL (from function [#2](https://github.com/CCExtractor/ccextractor/blob/master/src/lib_ccx/lib_ccx.c#L332)), and we get an error in this line [#3](https://github.com/CCExtractor/ccextractor/blob/master/src/lib_ccx/general_loop.c#L933)
If we run it with other files, then we almost always get an segfault error in other places associated with the fact that `enc_ctx = NULL`.
I have added the necessary checks, and now works well.