### PR TITLE
Fixed memory leaks

### DIFF
--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -367,6 +367,7 @@ int main(int argc, char *argv[])
 			break;
 	} // file loop
 	close_input_file(ctx);
+	free((void *) ctx->extension);
 
 	prepare_for_new_file (ctx); // To reset counters used by handle_end_of_data()
 

--- a/src/gpacmp4/mp4.c
+++ b/src/gpacmp4/mp4.c
@@ -303,6 +303,7 @@ int processmp4 (struct lib_ccx_ctx *ctx,struct ccx_s_mp4Cfg *cfg, char *file)
 	if((f = gf_isom_open(file, GF_ISOM_OPEN_READ, NULL)) == NULL)
 	{
 		mprint("failed to open\n");
+		free(dec_ctx->xds_ctx);
 		return -2;
 	}
 
@@ -342,6 +343,7 @@ int processmp4 (struct lib_ccx_ctx *ctx,struct ccx_s_mp4Cfg *cfg, char *file)
 			if(process_xdvb_track(ctx, file, f, i + 1, &dec_sub) != 0)
 			{
 				mprint("error\n");
+				free(dec_ctx->xds_ctx);
 				return -3;
 			}
 			if(dec_sub.got_output)
@@ -368,6 +370,7 @@ int processmp4 (struct lib_ccx_ctx *ctx,struct ccx_s_mp4Cfg *cfg, char *file)
 			if(process_avc_track(ctx, file, f, i + 1, &dec_sub) != 0)
 			{
 				mprint("error\n");
+				free(dec_ctx->xds_ctx);
 				return -3;
 			}
 			if(dec_sub.got_output)
@@ -522,6 +525,8 @@ int processmp4 (struct lib_ccx_ctx *ctx,struct ccx_s_mp4Cfg *cfg, char *file)
 					}
 					atomStart += atomLength;
 				}
+				free(sample->data);
+				free(sample);
 
 				// End of change
 				int progress = (int) ((k*100) / num_samples);
@@ -536,6 +541,8 @@ int processmp4 (struct lib_ccx_ctx *ctx,struct ccx_s_mp4Cfg *cfg, char *file)
 			activity_progress(100, cur_sec/60, cur_sec%60);
 		}
 	}
+
+	free(dec_ctx->xds_ctx);
 
 	mprint("\nclosing media: ");
 

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -981,6 +981,7 @@ void general_loop(struct lib_ccx_ctx *ctx)
 	mprint ("Number of NAL HRD: %ld\n",dec_ctx->avc_ctx->num_nal_hrd);
 	mprint ("Number of jump-in-frames: %ld\n",dec_ctx->avc_ctx->num_jump_in_frames);
 	mprint ("Number of num_unexpected_sei_length: %ld", dec_ctx->avc_ctx->num_unexpected_sei_length);
+		free(dec_ctx->xds_ctx);
 	}
 
 	delete_datalist(datalist);

--- a/src/lib_ccx/spupng_encoder.c
+++ b/src/lib_ccx/spupng_encoder.c
@@ -115,6 +115,11 @@ void write_spumux_header(struct encoder_ctx *ctx, struct ccx_s_write *out)
 		out->spupng_data = spunpg_init(out);
 
 	spupng_write_header((struct spupng_t*)out->spupng_data, ctx->multiple_files, ctx->first_input_file);
+
+	if (ctx->write_format == CCX_OF_RAW) {		// WARN: Memory leak with this flag, free by hand. Maybe bug.
+		spupng_write_footer(out->spupng_data);
+		spunpg_free(out->spupng_data);
+	}
 }
 
 void write_spumux_footer(struct ccx_s_write *out)


### PR DESCRIPTION
[https://codein.withgoogle.com/dashboard/task-instances/5086033567809536/](url)

Firstly you must make project after changes in code. Go to project folder and run `cmake src` and then `make`.
Run `valgring --leak-check=yes ./ccextractor [args]`.

If we run without arguments, then OK - no leaks are possible
```
==3145== 
==3145== HEAP SUMMARY:
==3145==     in use at exit: 0 bytes in 0 blocks
==3145==   total heap usage: 2 allocs, 2 frees, 1,576 bytes allocated
==3145== 
==3145== All heap blocks were freed -- no leaks are possible
==3145== 
==3145== For counts of detected and suppressed errors, rerun with: -v
==3145== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Run with random file `valgring --leak-check=yes ./ccextractor /home/izaron/video/itunes.m4v`. Oops, the lake of bytes lost in third blocks :(
```
==3238== 
==3238== HEAP SUMMARY:
==3238==     in use at exit: 90,403 bytes in 1,844 blocks
==3238==   total heap usage: 3,798 allocs, 1,954 frees, 27,856,944 bytes allocated
==3238== 
==3238== 5 bytes in 1 blocks are definitely lost in loss record 1 of 4
==3238==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3238==    by 0x53F2A59: strdup (strdup.c:42)
==3238==    by 0x4320B5: get_file_extension (utility.c:495)
==3238==    by 0x44B528: init_libraries (lib_ccx.c:165)
==3238==    by 0x42FD34: main (ccextractor.c:73)
==3238== 
==3238== 880 bytes in 1 blocks are definitely lost in loss record 2 of 4
==3238==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3238==    by 0x4551A5: ccx_decoders_xds_init_library (ccx_decoders_xds.c:131)
==3238==    by 0x44CE8D: init_cc_decode (ccx_decoders_common.c:361)
==3238==    by 0x44BA84: update_decoder_list (lib_ccx.c:272)
==3238==    by 0x44DBB6: processmp4 (mp4.c:295)
==3238==    by 0x430176: main (ccextractor.c:228)
==3238== 
==3238== 89,518 (29,472 direct, 60,046 indirect) bytes in 921 blocks are definitely lost in loss record 4 of 4
==3238==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3238==    by 0x48CA55: gf_isom_sample_new (isom_read.c:75)
==3238==    by 0x48EC71: gf_isom_get_sample (isom_read.c:1082)
==3238==    by 0x44E0BC: processmp4 (mp4.c:402)
==3238==    by 0x430176: main (ccextractor.c:228)
==3238== 
==3238== LEAK SUMMARY:
==3238==    definitely lost: 30,357 bytes in 923 blocks
==3238==    indirectly lost: 60,046 bytes in 921 blocks
==3238==      possibly lost: 0 bytes in 0 blocks
==3238==    still reachable: 0 bytes in 0 blocks
==3238==         suppressed: 0 bytes in 0 blocks
==3238== 
==3238== For counts of detected and suppressed errors, rerun with: -v
==3238== ERROR SUMMARY: 3 errors from 3 contexts (suppressed: 0 from 0)
```

But after exploring, only 2 lines cut down third block
```
free(sample->data);
free(sample);
```
And so on.

I checked the files with formats ts, mp4, mp4, vob on all types of subtitles and options. In the case of memory leaks, I fixed it. It took me a long time, because the slightest mistake led to a crash. The hardest thing was to fix raw format, seems like there are a bug.
In all cases I had 0 errors.