### PR TITLE
Fixed memory leak with XDS videos

### DIFF
--- a/src/lib_ccx/ts_info.c
+++ b/src/lib_ccx/ts_info.c
@@ -256,6 +256,7 @@ void dinit_cap (struct ccx_demuxer *ctx)
 	{
 		iter = list_entry(ctx->cinfo_tree.all_stream.next, struct cap_info, all_stream);
 		list_del(&iter->all_stream);
+		freep(&iter->capbuf);
 		free(iter);
 	}
 	INIT_LIST_HEAD(&ctx->cinfo_tree.all_stream);


### PR DESCRIPTION
Fixed memory leak

Valgrind log:
```
==24485== 
==24485== HEAP SUMMARY:
==24485==     in use at exit: 31,603,588 bytes in 1,084 blocks
==24485==   total heap usage: 185,004 allocs, 183,920 frees, 3,539,953,180 bytes allocated
==24485== 
==24485== 184,823 bytes in 3 blocks are possibly lost in loss record 1 of 2
==24485==    at 0x4C2FD5F: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==24485==    by 0x459590: copy_payload_to_capbuf (ts_functions.c:532)
==24485==    by 0x45A17E: ts_readstream (ts_functions.c:774)
==24485==    by 0x45A226: ts_getmoredata (ts_functions.c:801)
==24485==    by 0x449D50: general_loop (general_loop.c:825)
==24485==    by 0x4300B4: main (ccextractor.c:210)
==24485== 
==24485== 31,418,765 bytes in 1,081 blocks are definitely lost in loss record 2 of 2
==24485==    at 0x4C2FD5F: realloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==24485==    by 0x459590: copy_payload_to_capbuf (ts_functions.c:532)
==24485==    by 0x45A17E: ts_readstream (ts_functions.c:774)
==24485==    by 0x45A226: ts_getmoredata (ts_functions.c:801)
==24485==    by 0x449D50: general_loop (general_loop.c:825)
==24485==    by 0x4300B4: main (ccextractor.c:210)
==24485== 
==24485== LEAK SUMMARY:
==24485==    definitely lost: 31,418,765 bytes in 1,081 blocks
==24485==    indirectly lost: 0 bytes in 0 blocks
==24485==      possibly lost: 184,823 bytes in 3 blocks
==24485==    still reachable: 0 bytes in 0 blocks
==24485==         suppressed: 0 bytes in 0 blocks
==24485== 
==24485== For counts of detected and suppressed errors, rerun with: -v
==24485== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
```

I checked out a few types of files (single file checked for single type) from https://sampleplatform.ccextractor.org/, leaks no longer detected.
If you have all the files from sampleplatform (it is a huge), then you can start valgrind automatically for all tests with error detection and you will get a full list of leaks.