### PR TITLE
Completed TODO: Get from framerates_values[].

### DIFF
--- a/src/lib_ccx/ccx_common_timing.c
+++ b/src/lib_ccx/ccx_common_timing.c
@@ -11,14 +11,14 @@
 // Count 608 (per field) and 708 blocks since last set_fts() call
 int cb_field1, cb_field2, cb_708;
 
-int MPEG_CLOCK_FREQ = 90000; // This "constant" is part of the standard
+int MPEG_CLOCK_FREQ = 90000; // This "constant" is part of the standard.  Not defined as constant because added "-90090" parameter which changes the clock frequency.
 
 int max_dif = 5;
 unsigned pts_big_change;
 
 // PTS timing related stuff
 
-double current_fps = (double) 30000.0 / 1001; /* 29.97 */ // TODO: Get from framerates_values[] instead
+double current_fps = framerates_values[4]; /* (30000.0 / 1001) = 29.97 */ // Getting from framerates_values[].
 
 int frames_since_ref_time = 0;
 unsigned total_frames_count;


### PR DESCRIPTION
Also Removed ambiguity Added comment answering why MPEG_CLOCK_FREQ is not defined as a constant. Might create confusion when going through code for first time.