### PR TITLE
Make error messages clearer and unambiguous

### DIFF
--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
 	else if (!ctx && errno == EPERM)
 		fatal (CCX_COMMON_EXIT_FILE_CREATION_FAILED, "Unable to create Output File\n");
 	else if (!ctx && errno == EACCES)
-		fatal (CCX_COMMON_EXIT_FILE_CREATION_FAILED, "Unable to create Output File\n");
+		fatal (CCX_COMMON_EXIT_FILE_CREATION_FAILED, "Unable to create Output File: Program does not have access. \n");
 	else if (!ctx)
 		fatal (EXIT_NOT_CLASSIFIED, "Unable to create Library Context %d\n",errno);
 

--- a/src/lib_ccx/asf_functions.c
+++ b/src/lib_ccx/asf_functions.c
@@ -33,7 +33,7 @@ uint32_t asf_readval(void *val, int ltype)
 			rval = *((uint32_t*)val);
 			break;
 		default:
-			fatal (CCX_COMMON_EXIT_BUG_BUG, "Wrong type ...\n");
+			fatal (CCX_COMMON_EXIT_BUG_BUG, "Wrong or no type for ASF parsing! Type must be BYTE, WORD, or DWORD.\n");
 			break;
 	}
 	return rval;
@@ -190,7 +190,7 @@ int asf_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 		if (asf_data_container.HeaderObjectSize > asf_data_container.parsebufsize) {
 			asf_data_container.parsebuf = (unsigned char*)realloc(asf_data_container.parsebuf, (size_t)asf_data_container.HeaderObjectSize);
 			if (!asf_data_container.parsebuf)
-				fatal(EXIT_NOT_ENOUGH_MEMORY, "Out of memory");
+				fatal(EXIT_NOT_ENOUGH_MEMORY, "Could not allocate memory to asf data container parsing. Possible out of memory?\n");
 			asf_data_container.parsebufsize = (long)asf_data_container.HeaderObjectSize;
 		}
 
@@ -263,7 +263,7 @@ int asf_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 					unsigned char *hecurpos=curpos+46;
 
 					if ( HeaderExtensionDataSize != hpobjectsize - 46 )
-						fatal(EXIT_NOT_CLASSIFIED, "HeaderExtensionDataSize size wrong");
+						fatal(EXIT_NOT_CLASSIFIED, "Size of variable HeaderExtensionDataSize wrong! File a bug report on the Github.\n");
 
 					dbg_print(CCX_DMT_PARSE, "\nReading Header Extension Sub-Objects\n");
 					while( hecurpos < curpos+46 + HeaderExtensionDataSize )
@@ -285,7 +285,7 @@ int asf_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 									StreamNumber, StreamNameCount, PayloadExtensionSystemCount);
 
 							if ( StreamNumber >= STREAMNUM )
-								fatal(CCX_COMMON_EXIT_BUG_BUG, "STREAMNUM too small. Send bug report!/n");
+								fatal(CCX_COMMON_EXIT_BUG_BUG, "STREAMNUM too small. File a bug report on the Github.\n");
 
 							for(int i=0; i<StreamNameCount; i++)
 							{
@@ -297,7 +297,7 @@ int asf_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 							int extensionsysteminfolength;
 
 							if ( PayloadExtensionSystemCount > PAYEXTNUM )
-								fatal(CCX_COMMON_EXIT_BUG_BUG, "PAYEXTNUM too small. Send bug report!/n");
+								fatal(CCX_COMMON_EXIT_BUG_BUG, "PAYEXTNUM too small. File a bug report on the Github.\n");
 
 							for(int i=0; i<PayloadExtensionSystemCount; i++)
 							{
@@ -467,7 +467,7 @@ int asf_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 							dbg_print(CCX_DMT_PARSE, "%u (WORD)\n",(int)*((uint16_t*)edescval));
 							break;
 						default:
-							fatal(CCX_COMMON_EXIT_BUG_BUG, "Wrong type ...\n");
+							fatal(CCX_COMMON_EXIT_BUG_BUG, "The descriptor is of a wrong or no data type!\n");
 							break;
 					}
 
@@ -686,7 +686,7 @@ int asf_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 				// For multiple payloads we can get away without a given
 				// Packet Lenght as individual payload length are given
 				if (asf_data_container.PacketLength == 0 && asf_data_container.MultiplePayloads == 0)
-					fatal(EXIT_NOT_CLASSIFIED, "No idea how long the data packet will be. Abort.\n");
+					fatal(EXIT_NOT_CLASSIFIED, "Length of data packet is undefined. Abort.\n");
 			}
 
 			dbg_print(CCX_DMT_PARSE, "Lengths - Packet: %d / Sequence %d / Padding %d\n",
@@ -764,7 +764,7 @@ int asf_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 				{
 					asf_data_container.parsebuf = (unsigned char*)realloc(asf_data_container.parsebuf, ReplicatedLength);
 					if (!asf_data_container.parsebuf)
-						fatal(EXIT_NOT_ENOUGH_MEMORY, "Out of memory");
+						fatal(EXIT_NOT_ENOUGH_MEMORY, "Could not allocate memory to parse buffer. Out of memory?");
 					asf_data_container.parsebufsize = ReplicatedLength;
 				}
 				result = buffered_read(ctx->demux_ctx, asf_data_container.parsebuf, (long)ReplicatedLength);

--- a/src/lib_ccx/avc_functions.c
+++ b/src/lib_ccx/avc_functions.c
@@ -158,7 +158,7 @@ size_t process_avc ( struct lib_cc_decode *ctx, unsigned char *avcbuf, size_t av
 	if(avcbuflen <= 5)
 	{
 		fatal(CCX_COMMON_EXIT_BUG_BUG,
-				"NAL unit need at last 5 bytes ...");
+				"Length of the NAL unit must be at least 5 bytes.");
 	}
 
 	// Warning there should be only leading zeros, nothing else
@@ -509,7 +509,7 @@ void user_data_registered_itu_t_t35 (struct avc_ctx *ctx, unsigned char *userbuf
 						{
 							ctx->cc_data = (unsigned char*)realloc(ctx->cc_data, (size_t) ( (ctx->cc_count + local_cc_count) * 6) + 1);
 							if (!ctx->cc_data)
-								fatal(EXIT_NOT_ENOUGH_MEMORY, "Out of memory");
+								fatal(EXIT_NOT_ENOUGH_MEMORY, "Failed to reallocate memory in avc_functions");
 							ctx->cc_databufsize = (long) ( (ctx->cc_count + local_cc_count) * 6) + 1;
 						}
 						// Copy new cc data into cc_data
@@ -581,7 +581,7 @@ void user_data_registered_itu_t_t35 (struct avc_ctx *ctx, unsigned char *userbuf
 			{
 				ctx->cc_data = (unsigned char*)realloc(ctx->cc_data, (size_t) (((local_cc_count + ctx->cc_count) * 6) + 1));
 				if (!ctx->cc_data)
-					fatal(EXIT_NOT_ENOUGH_MEMORY, "Out of memory");
+					fatal(EXIT_NOT_ENOUGH_MEMORY, "Failed to reallocate memory in avc_functions");
 				ctx->cc_databufsize = (long) (((local_cc_count + ctx->cc_count) * 6) + 1);
 			}
 			// Copy new cc data into cc_data - replace command below.

--- a/src/lib_ccx/ccx_decoders_common.c
+++ b/src/lib_ccx/ccx_decoders_common.c
@@ -200,7 +200,7 @@ int do_cb (struct lib_cc_decode *ctx, unsigned char *cc_block, struct cc_subtitl
 				// printf ("Warning: Losing EIA-708 data!\n");
 				break;
 			default:
-				fatal(CCX_COMMON_EXIT_BUG_BUG, "Cannot be reached!");
+				fatal(CCX_COMMON_EXIT_BUG_BUG, "CC type is invalid or not specified!");
 		} // switch (cc_type)
 	} // cc_valid
 	else

--- a/src/lib_ccx/ccx_demuxer.c
+++ b/src/lib_ccx/ccx_demuxer.c
@@ -142,7 +142,7 @@ static int ccx_demuxer_open(struct ccx_demuxer *ctx, const char *file)
 #endif
 			case CCX_SM_MYTH:
 			case CCX_SM_AUTODETECT:
-				fatal(CCX_COMMON_EXIT_BUG_BUG, "Cannot be reached!");
+				fatal(CCX_COMMON_EXIT_BUG_BUG, "CCX stream mode detection failed!");
 				break;
 		}
 	}

--- a/src/lib_ccx/ccx_encoders_srt.c
+++ b/src/lib_ccx/ccx_encoders_srt.c
@@ -34,7 +34,7 @@ int write_stringz_as_srt(char *string, struct encoder_ctx *context, LLONG ms_sta
 	unsigned char *unescaped= (unsigned char *) malloc (len+1);
 	unsigned char *el = (unsigned char *) malloc (len*3+1); // Be generous
 	if (el==NULL || unescaped==NULL)
-		fatal (EXIT_NOT_ENOUGH_MEMORY, "In write_stringz_as_srt() - not enough memory.\n");
+		fatal (EXIT_NOT_ENOUGH_MEMORY, "Memory allocation failure in write_stringz_as_srt()\n");
 	int pos_r=0;
 	int pos_w=0;
 	// Scan for \n in the string and replace it with a 0

--- a/src/lib_ccx/ccx_share.c
+++ b/src/lib_ccx/ccx_share.c
@@ -84,7 +84,7 @@ ccx_share_status ccx_share_start(const char *stream_name) //TODO add stream
 	ccx_share_ctx.nn_sock = nn_socket(AF_SP, NN_PUB);
 	if (ccx_share_ctx.nn_sock < 0) {
 		perror("[share] ccx_share_start: can't nn_socket()\n");
-		fatal(EXIT_NOT_CLASSIFIED, "ccx_share_start");
+		fatal(EXIT_NOT_CLASSIFIED, "ccx share socket number is less than zero!");
 	}
 
 	if (!ccx_options.sharing_url) {
@@ -96,14 +96,14 @@ ccx_share_status ccx_share_start(const char *stream_name) //TODO add stream
 	ccx_share_ctx.nn_binder = nn_bind(ccx_share_ctx.nn_sock, ccx_options.sharing_url);
 	if (ccx_share_ctx.nn_binder < 0) {
 		perror("[share] ccx_share_start: can't nn_bind()\n");
-		fatal(EXIT_NOT_CLASSIFIED, "ccx_share_start");
+		fatal(EXIT_NOT_CLASSIFIED, "ccx share binder number is less than zero!");
 	}
 
 	int linger = -1;
 	int rc = nn_setsockopt(ccx_share_ctx.nn_sock, NN_SOL_SOCKET, NN_LINGER, &linger, sizeof(int));
 	if (rc < 0) {
 		perror("[share] ccx_share_start: can't nn_setsockopt()\n");
-		fatal(EXIT_NOT_CLASSIFIED, "ccx_share_start");
+		fatal(EXIT_NOT_CLASSIFIED, "ccx socket output number is less than zero!");
 	}
 
 	//TODO remove path from stream name to minimize traffic (/?)
@@ -205,7 +205,7 @@ ccx_share_status _ccx_share_sub_to_entries(struct cc_subtitle *sub, ccx_sub_entr
 
 			entries->messages = realloc(entries->messages, ++entries->count * sizeof(CcxSubEntryMessage));
 			if (!entries->messages) {
-				fatal(EXIT_NOT_ENOUGH_MEMORY, "_ccx_share_sub_to_entry\n");
+				fatal(EXIT_NOT_ENOUGH_MEMORY, "Could not allocate memory in ccx_share\n");
 			}
 
 			unsigned int entry_index = entries->count - 1;
@@ -225,7 +225,7 @@ ccx_share_status _ccx_share_sub_to_entries(struct cc_subtitle *sub, ccx_sub_entr
 			}
 			entries->messages[entry_index].lines = (char **)malloc(entries->messages[entry_index].n_lines * sizeof(char *));
 			if (!entries->messages[entry_index].lines) {
-				fatal(EXIT_NOT_ENOUGH_MEMORY, "_ccx_share_sub_to_entry: entries->messages[entry_index].lines\n");
+				fatal(EXIT_NOT_ENOUGH_MEMORY, "Could not allocate memory: _ccx_share_sub_to_entry: entries->messages[entry_index].lines\n");
 			}
 
 			dbg_print(CCX_DMT_SHARE, "[share] Copying %u lines\n", entries->messages[entry_index].n_lines);
@@ -235,7 +235,7 @@ ccx_share_status _ccx_share_sub_to_entries(struct cc_subtitle *sub, ccx_sub_entr
 					entries->messages[entry_index].lines[j] =
 						(char *)malloc((strnlen((char *)data->characters[i], 32) + 1) * sizeof(char));
 					if (!entries->messages[entry_index].lines[j]) {
-						fatal(EXIT_NOT_ENOUGH_MEMORY, "_ccx_share_sub_to_entry: entries->messages[entry_index].lines[j]\n");
+						fatal(EXIT_NOT_ENOUGH_MEMORY, "Could not allocate memory: _ccx_share_sub_to_entry: entries->messages[entry_index].lines[j]\n");
 					}
 					strncpy(entries->messages[entry_index].lines[j], (char *)data->characters[i], 32);
 					entries->messages[entry_index].lines[j][strnlen((char *)data->characters[i], 32)] = '\0';

--- a/src/lib_ccx/es_functions.c
+++ b/src/lib_ccx/es_functions.c
@@ -335,7 +335,7 @@ static int read_seq_info(struct lib_cc_decode *ctx, struct bitstream *esstream)
 
 	// We only get here after seeing that start code
 	if (next_u32(esstream) != 0xB3010000) // LSB first (0x000001B3)
-		fatal(CCX_COMMON_EXIT_BUG_BUG, "read_seq_info: Impossible!");
+		fatal(CCX_COMMON_EXIT_BUG_BUG, "Failed to read the next sequence info, invalid byte!");
 
 	// If we get here esstream points to the start of a sequence_header_code
 	// should we run out of data in esstream this is where we want to restart
@@ -375,7 +375,7 @@ static int sequence_header(struct lib_cc_decode *ctx, struct bitstream *esstream
 
 	// We only get here after seeing that start code
 	if (read_u32(esstream) != 0xB3010000) // LSB first (0x000001B3)
-		fatal(CCX_COMMON_EXIT_BUG_BUG, "Impossible!");
+		fatal(CCX_COMMON_EXIT_BUG_BUG, "Failed to read the sequence header, invalid byte!");
 
 	unsigned hor_size = (unsigned) read_bits(esstream,12);
 	unsigned vert_size = (unsigned) read_bits(esstream,12);
@@ -514,7 +514,7 @@ static int read_gop_info(struct lib_cc_decode *ctx, struct bitstream *esstream, 
 
 	// We only get here after seeing that start code
 	if (next_u32(esstream) != 0xB8010000) // LSB first (0x000001B8)
-		fatal(CCX_COMMON_EXIT_BUG_BUG, "Impossible!");
+		fatal(CCX_COMMON_EXIT_BUG_BUG, "Failed to read the GOP info, invalid byte!");
 
 	// If we get here esstream points to the start of a group_start_code
 	// should we run out of data in esstream this is where we want to restart
@@ -551,7 +551,7 @@ static int gop_header(struct lib_cc_decode *ctx, struct bitstream *esstream, str
 
 	// We only get here after seeing that start code
 	if (read_u32(esstream) != 0xB8010000) // LSB first (0x000001B8)
-		fatal(CCX_COMMON_EXIT_BUG_BUG, "Impossible!");
+		fatal(CCX_COMMON_EXIT_BUG_BUG, "Failed to read the GOP header, invalid byte!");
 
 	unsigned drop_frame_flag = (unsigned) read_bits(esstream,1);
 	struct gop_time_code gtc;
@@ -683,7 +683,7 @@ static int read_pic_info(struct lib_cc_decode *ctx, struct bitstream *esstream, 
 
 	// We only get here after seeing that start code
 	if (next_u32(esstream) != 0x00010000) // LSB first (0x00000100)
-		fatal(CCX_COMMON_EXIT_BUG_BUG, "Impossible!");
+		fatal(CCX_COMMON_EXIT_BUG_BUG, "Failed to read the PIC info, invalid byte!");
 
 	// If we get here esstream points to the start of a group_start_code
 	// should we run out of data in esstream this is where we want to restart
@@ -819,7 +819,7 @@ static int pic_header(struct lib_cc_decode *ctx, struct bitstream *esstream)
 
 	// We only get here after seeing that start code
 	if (read_u32(esstream) != 0x00010000) // LSB first (0x00000100)
-		fatal(CCX_COMMON_EXIT_BUG_BUG, "Impossible!");
+		fatal(CCX_COMMON_EXIT_BUG_BUG, "Failed to read the PIC header, invalid byte!");
 
 	ctx->temporal_reference = (int) read_bits(esstream,10);
 	ctx->picture_coding_type = (enum ccx_frame_type) read_bits(esstream,3);
@@ -923,7 +923,7 @@ static int read_eau_info(struct lib_cc_decode* ctx, struct bitstream *esstream, 
 	unsigned char *tst = next_bytes(esstream, 4);
 	if (!tst || tst[0]!=0x00 || tst[1]!=0x00 || tst[2]!=0x01
 			|| (tst[3]!=0xB2 && tst[3]!=0xB5) ) // (0x000001 B2||B5)
-				fatal(CCX_COMMON_EXIT_BUG_BUG, "Impossible!");
+				fatal(CCX_COMMON_EXIT_BUG_BUG, "Failed to read the EAU info, invalid byte!");
 
 	// The following extension_and_user_data() function makes sure that
 	// user data is not evaluated twice. Should the function run out of

--- a/src/lib_ccx/es_userdata.c
+++ b/src/lib_ccx/es_userdata.c
@@ -165,7 +165,7 @@ int user_data(struct lib_cc_decode *ctx, struct bitstream *ustream, int udtype, 
 				read_bits(ustream,1); // TODO: Add syntax check */
 
 				if (ustream->bitsleft < 0)
-					fatal(CCX_COMMON_EXIT_BUG_BUG, "Oops!");
+					fatal(CCX_COMMON_EXIT_BUG_BUG, "Less than zero bits left in the ustream!");
 
 				// Field_number is either
 				//  0 .. forbiden
@@ -246,7 +246,7 @@ int user_data(struct lib_cc_decode *ctx, struct bitstream *ustream, int udtype, 
 				int proceed = 1;
 				unsigned char *cc_data = read_bytes(ustream, cc_count*3);
 				if (ustream->bitsleft < 0)
-					fatal(CCX_COMMON_EXIT_BUG_BUG, "Not enough for CC captions!");
+					fatal(CCX_COMMON_EXIT_BUG_BUG, "Not enough bits left in the ustream for CC captions!");
 
 				// Check for proper marker - This read makes sure that
 				// cc_count*3+1 bytes are read and available in cc_data.

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -434,7 +434,7 @@ void processhex (struct lib_ccx_ctx *ctx, char *filename)
 			continue;
 		bytes=(unsigned char *) malloc (byte_count);
 		if (!bytes)
-			fatal (EXIT_NOT_ENOUGH_MEMORY, "Out of memory.\n");
+			fatal (EXIT_NOT_ENOUGH_MEMORY, "Memory allocation failure trying to allocate bytes in general_loop.\n");
 		unsigned char *bytes=(unsigned char *) malloc (byte_count);
 		for (unsigned i=0;i<byte_count;i++)
 		{
@@ -842,7 +842,7 @@ void general_loop(struct lib_ccx_ctx *ctx)
 				break;
 #endif
 			default:
-				fatal(CCX_COMMON_EXIT_BUG_BUG, "Impossible stream_mode");
+				fatal(CCX_COMMON_EXIT_BUG_BUG, "Invalid or no stream_mode!");
 		}
 		if (ret == CCX_EOF)
 		{

--- a/src/lib_ccx/lib_ccx.c
+++ b/src/lib_ccx/lib_ccx.c
@@ -95,7 +95,7 @@ struct lib_ccx_ctx* init_libraries(struct ccx_s_options *opt)
 
 	struct lib_ccx_ctx *ctx = malloc(sizeof(struct lib_ccx_ctx));
 	if(!ctx)
-		ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "lib_ccx_ctx");
+		ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "Failed to allocate memory to lib_ccx_ctx in lib_ccx");
 	memset(ctx, 0, sizeof(struct lib_ccx_ctx));
 
 	if(opt->xmltv)
@@ -110,7 +110,7 @@ struct lib_ccx_ctx* init_libraries(struct ccx_s_options *opt)
 		memset(ctx->eit_current_events, 0, sizeof(int32_t)*(TS_PMT_MAP_SIZE+1));
 		memset(ctx->ATSC_source_pg_map, 0, sizeof(int16_t)*(0xffff));
 		if(!ctx->epg_buffers || !ctx->eit_programs || !ctx->eit_current_events || !ctx->ATSC_source_pg_map)
-			ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "lib_ccx_ctx");
+			ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "Failed to allocate memory in lib_ccx");
 	}
 	else
 	{
@@ -123,13 +123,13 @@ struct lib_ccx_ctx* init_libraries(struct ccx_s_options *opt)
 
 	struct ccx_decoder_608_report *report_608 = malloc(sizeof(struct ccx_decoder_608_report));
 	if (!report_608)
-		ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "report_608");
+		ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "Failed to allocate memory to report_608 in lib_ccx");
 	memset(report_608, 0, sizeof(struct ccx_decoder_608_report));
 
 	ccx_decoder_dtvcc_report *report_dtvcc = (ccx_decoder_dtvcc_report *)
 			malloc(sizeof(ccx_decoder_dtvcc_report));
 	if (!report_dtvcc)
-		ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "report_dtvcc");
+		ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "Failed to allocate memory to report_dtvcc in lib_ccx");
 	memset(report_dtvcc, 0, sizeof(ccx_decoder_dtvcc_report));
 
 	// Initialize some constants
@@ -271,7 +271,7 @@ struct lib_cc_decode *update_decoder_list(struct lib_ccx_ctx *ctx)
 		ctx->dec_global_setting->program_number = 0;
 		dec_ctx = init_cc_decode(ctx->dec_global_setting);
 		if (!dec_ctx)
-			fatal(EXIT_NOT_ENOUGH_MEMORY, "Not enough memory\n");
+			fatal(EXIT_NOT_ENOUGH_MEMORY, "Declaration of ctx does not exist in lib_ccx!");
 		list_add_tail( &(dec_ctx->list), &(ctx->dec_ctx_head) );
 	}
 	return dec_ctx;
@@ -306,7 +306,7 @@ struct lib_cc_decode *update_decoder_list_cinfo(struct lib_ccx_ctx *ctx, struct 
 		{
 			dec_ctx = init_cc_decode(ctx->dec_global_setting);
 			if (!dec_ctx)
-				fatal(EXIT_NOT_ENOUGH_MEMORY, "Not enough memory\n");
+				fatal(EXIT_NOT_ENOUGH_MEMORY, "Declaration of ctx does not exist in lib_ccx!");
 			list_add_tail( &(dec_ctx->list), &(ctx->dec_ctx_head) );
 		}
 	}
@@ -314,7 +314,7 @@ struct lib_cc_decode *update_decoder_list_cinfo(struct lib_ccx_ctx *ctx, struct 
 	{
 		dec_ctx = init_cc_decode(ctx->dec_global_setting);
 		if (!dec_ctx)
-			fatal(EXIT_NOT_ENOUGH_MEMORY, "Not enough memory\n");
+			fatal(EXIT_NOT_ENOUGH_MEMORY, "Declaration of ctx does not exist in lib_ccx!");
 		list_add_tail( &(dec_ctx->list), &(ctx->dec_ctx_head) );
 	}
 	return dec_ctx;

--- a/src/lib_ccx/myth.c
+++ b/src/lib_ccx/myth.c
@@ -744,7 +744,7 @@ goto skip; */
 	av.data=(unsigned char *) realloc (av.data,av.size);
 	if (av.data==NULL)
 	{
-		fatal (EXIT_NOT_ENOUGH_MEMORY, "Not enough memory, realloc() failed. Giving up.\n");
+		fatal (EXIT_NOT_ENOUGH_MEMORY, "Could not reallocate memory to av.data in myth.\n");
 	}
 	av.codec_id=codec_id;
 	av.type=type;
@@ -781,7 +781,7 @@ void myth_loop(struct lib_ccx_ctx *ctx)
 	desp_length = 65536;
 	desp = (unsigned char *) malloc (desp_length);
 	if (!desp)
-		fatal (EXIT_NOT_ENOUGH_MEMORY, "Not enough memory.\n");
+		fatal (EXIT_NOT_ENOUGH_MEMORY, "Could not allocate memory to desp in myth.\n");
 	saved=0;
 
 	memset(&dec_sub, 0, sizeof(dec_sub));
@@ -807,7 +807,7 @@ void myth_loop(struct lib_ccx_ctx *ctx)
 				desp_length=length*2; // *2, just to reduce possible future reallocs
 				desp=(unsigned char *) realloc (desp,desp_length); // 16, some extra
 				if (!desp)
-					fatal (EXIT_NOT_ENOUGH_MEMORY, "Not enough memory.\n");
+					fatal (EXIT_NOT_ENOUGH_MEMORY, "variable desp does not exist!.\n");
 			}
 			if (av.pts!=AV_NOPTS_VALUE)
 			{

--- a/src/lib_ccx/networking.c
+++ b/src/lib_ccx/networking.c
@@ -85,7 +85,7 @@ void connect_to_srv(const char *addr, const char *port, const char *cc_desc, con
 	if (NULL == addr)
 	{
 		mprint("Server address is not set\n");
-		fatal(EXIT_FAILURE, "Unable to connect\n");
+		fatal(EXIT_FAILURE, "Unable to connect, null address!\n");
 	}
 
 	if (NULL == port)
@@ -95,10 +95,10 @@ void connect_to_srv(const char *addr, const char *port, const char *cc_desc, con
 	mprint("Connecting to %s:%s\n", addr, port);
 
 	if ((srv_sd = tcp_connect(addr, port)) < 0)
-		fatal(EXIT_FAILURE, "Unable to connect\n");
+		fatal(EXIT_FAILURE, "Unable to connect!\n");
 
 	if (write_block(srv_sd, PASSWORD, pwd, pwd ? strlen(pwd) : 0) < 0)
-		fatal(EXIT_FAILURE, "Unable to connect\n");
+		fatal(EXIT_FAILURE, "Unable to connect, possible password error?\n");
 
 	if (write_block(srv_sd, CC_DESC, cc_desc, cc_desc ? strlen(cc_desc) : 0) < 0)
 		fatal(EXIT_FAILURE, "Unable to connect\n");
@@ -131,7 +131,7 @@ void net_send_header(const unsigned char *data, size_t len)
 		return;
 
 	if ((srv_header = malloc(len)) == NULL)
-		fatal(EXIT_FAILURE, "Not enough memory");
+		fatal(EXIT_FAILURE, "Could not allocate memory to srv_header in networking!");
 
 	memcpy(srv_header, data, len);
 	srv_header_len = len;

--- a/src/lib_ccx/spupng_encoder.c
+++ b/src/lib_ccx/spupng_encoder.c
@@ -19,7 +19,7 @@ void spupng_init_font()
 
 	/* de-interleave font image (puts all chars in row 0) */
 	if (!(t = (uint8_t*)malloc(ccfont2_width * ccfont2_height / 8)))
-		ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "Memory allocation failed");
+		ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "Could not allocate memory to t in spupng_encoder!");
 
 	for (p = t, i = 0; i < CCH; i++)
 		for (j = 0; j < ccfont2_height; p += ccfont2_width / 8, j += CCH)
@@ -34,7 +34,7 @@ struct spupng_t *spunpg_init(struct ccx_s_write *out)
 {
 	struct spupng_t *sp = (struct spupng_t *) malloc(sizeof(struct spupng_t));
 	if (NULL == sp)
-		ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "Memory allocation failed");
+		ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "Could not allocate memory to sp in spupng_encoder");
 
 	if (!initialized)
 	{
@@ -50,7 +50,7 @@ struct spupng_t *spunpg_init(struct ccx_s_write *out)
 	sp->dirname = (char *) malloc(
 			sizeof(char) * (strlen(out->filename) + 3));
 	if (NULL == sp->dirname)
-		ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "Memory allocation failed");
+		ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "Could not allocate memory to sp->dirname in spupng_encoder");
 
 	strcpy(sp->dirname, out->filename);
 	char* p = strrchr(sp->dirname, '.');
@@ -72,7 +72,7 @@ struct spupng_t *spunpg_init(struct ccx_s_write *out)
 	// enough to append /subNNNN.png
 	sp->pngfile = (char *) malloc(sizeof(char) * (strlen(sp->dirname) + 13));
 	if (NULL == sp->pngfile)
-		ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "Memory allocation failed");
+		ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "Memory allocation failed in png file creation in spupng_encoder");
 	sp->fileIndex = 0;
 	sprintf(sp->pngfile, "%s/sub%04d.png", sp->dirname, sp->fileIndex);
 


### PR DESCRIPTION
Lots of generic "Out of memory"s replaced with the specific file and variable that memory is needed in. A few more things too.