### PR TITLE
Fixed FPS switching

### DIFF
--- a/src/lib_ccx/avc_functions.c
+++ b/src/lib_ccx/avc_functions.c
@@ -919,10 +919,9 @@ void slice_header (struct lib_cc_decode *ctx, unsigned char *heabuf, unsigned ch
 			bottom_field_flag = u(&q1,1);
 			dvprint("bottom_field_flag=     % 4llX\n", bottom_field_flag);
 
-			// TODO - Do this right.
 			// When bottom_field_flag is set the video is interlaced,
 			// override current_fps.
-			current_fps = framerates_values[7];
+			current_fps = framerates_values[ctx->current_frame_rate];
 		}
 	}
 


### PR DESCRIPTION
Fixed FPS switching
[Issue #431 ](https://github.com/CCExtractor/ccextractor/issues/431)
I tested it also on another video, which also had this bug. See this value write [https://github.com/CCExtractor/ccextractor/blob/master/src/lib_ccx/es_functions.c#L435](https://github.com/CCExtractor/ccextractor/blob/master/src/lib_ccx/es_functions.c#L435) I did the same and it works