### PR TITLE
Fixed -unixts option

### DIFF
--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -1080,7 +1080,8 @@ int encode_sub(struct encoder_ctx *context, struct cc_subtitle *sub)
 
 				if (utc_refvalue != UINT64_MAX)
 				{
-					data->start_time += utc_refvalue * 1000;
+					if (data->start_time != -1)
+						data->start_time += utc_refvalue * 1000;
 					data->end_time += utc_refvalue * 1000;
 				}
 

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -1077,6 +1077,13 @@ int encode_sub(struct encoder_ctx *context, struct cc_subtitle *sub)
 				}
 
 				data->end_time = data->end_time + context->subs_delay;
+
+				if (utc_refvalue != UINT64_MAX)
+				{
+					data->start_time += utc_refvalue * 1000;
+					data->end_time += utc_refvalue * 1000;
+				}
+
 				switch (context->write_format)
 				{
 					case CCX_OF_SRT:


### PR DESCRIPTION
Issue #430 

![default](https://cloud.githubusercontent.com/assets/5406399/21101390/65a1c2fa-c092-11e6-9e5d-45d5382aad2a.png)

This is not a bug - this function is **only** realised for Teletext files
I radically enabled it for all subtitles
Checked on the .bin file, works well