### PR TITLE
Printing exact error for clean file.

### DIFF
--- a/src/lib_ccx/ccx_demuxer.c
+++ b/src/lib_ccx/ccx_demuxer.c
@@ -350,6 +350,7 @@ struct ccx_demuxer *init_demuxer(void *parent, struct demuxer_cfg *cfg)
 		if ((ctx->fh_out_elementarystream = fopen (cfg->out_elementarystream_filename,"wb"))==NULL)
 		{
 			print_error(CCX_COMMON_EXIT_FILE_CREATION_FAILED, "Unable to open clean file: %s\n", cfg->out_elementarystream_filename);
+			perror("Details : ");		//printing specific error - Permission Denied/ Wrong Path etc..
 			return NULL;
 		}
 	}


### PR DESCRIPTION
Removes ambiguity as of why unable to open clean file. Gives better aid in resolving the issue.

Example :  I have attached a console log below of 4 different runs. [fopenerror.txt](https://github.com/CCExtractor/ccextractor/files/648421/fopenerror.txt)


1. cf -output.txt 

> shouldn't work because I am working in directory which requires admin rights to create new files. Only displays : ###MESSAGE#Unable to open clean file: output.txt

2. -cf /out/output.txt

> same as above.

3. -cf d:/out/output.txt

> Directory d:/ doesn't require any admin right, but "out" doesn't exist. So again, only displays : ###MESSAGE#Unable to open clean file: output.txt

4. -cf d:/output.txt

> Works, because d:/ is both writable and exists.