### PR TITLE
Added Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ windows/x64/**
 
 # Ctags
 *.tags*
+
+# Vagrant
+.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,16 @@
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/xenial64"
+
+  # Uncomment this line if you want to sync other folders
+  # config.vm.synced_folder "/home/user/video", "/video"
+
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo apt-get install -y gcc
+    sudo apt-get install -y libcurl4-gnutls-dev
+    sudo apt-get install -y tesseract-ocr
+    sudo apt-get install -y tesseract-ocr-dev
+    sudo apt-get install -y libleptonica-dev
+  SHELL
+
+end
+


### PR DESCRIPTION
Added Vagrantfile

### Installation

- Install [vagrant](https://www.vagrantup.com/downloads.html)
- Install [VirtualBox](https://www.virtualbox.org/wiki/Download_Old_Builds). **Warning**: use version **5.0**! As newer versions are not supported by vagrant at the moment
- Go to project folder and run `vagrant up`

### Using
Run `vagrant ssh` in project folder to connect to the box.

![default](https://cloud.githubusercontent.com/assets/5406399/21139087/b44152d2-c14a-11e6-8b3c-36ee60fe97a4.png)

If you want to exit, run `logout`
By default, the project folder is synchronized (that is available in your computer, and in a virtual machine). The project folder is located in /vagrant

![default](https://cloud.githubusercontent.com/assets/5406399/21139153/fb5608f2-c14a-11e6-91bd-1413812d62b8.png)

Lets build the project

![default](https://cloud.githubusercontent.com/assets/5406399/21139235/4b6c0c9c-c14b-11e6-9fed-d58ea569b854.png)

Now virtual environment and computer both have built CCExtractor in folder `linux`. Even if your computer does not have curl, tesseract, leptonica, gcc.

You can uncomment the line in Vagrantfile to synchronize other folders. After changing Vagrantfile you need run `vagrant reload --provision` if you have virtual box launched, or `vagrant up` if box closed. To shutdonw the box run `vagrant halt`.
I synchronized folder /home/izaron/video as /video in the virtual box and have extracted subtitles.

![default](https://cloud.githubusercontent.com/assets/5406399/21139417/3b22dfcc-c14c-11e6-9006-7bff3b60fbcf.png)

You can edit the source code of both the box and the computer and build it in the box.

![default](https://cloud.githubusercontent.com/assets/5406399/21139589/1339bae8-c14d-11e6-8244-da4efdfc059c.png)
