### PR TITLE
Mac Build : Added missing directory for protobuf-c.

### DIFF
--- a/mac/build.command
+++ b/mac/build.command
@@ -1,7 +1,7 @@
 #!/bin/bash
 cd `dirname $0`
 BLD_FLAGS="-std=gnu99 -Wno-write-strings -DGPAC_CONFIG_DARWIN -D_FILE_OFFSET_BITS=64 -DVERSION_FILE_PRESENT -Dfopen64=fopen -Dopen64=open -Dlseek64=lseek"
-BLD_INCLUDE="-I../src/ -I../src/lib_ccx  -I../src/gpacmp4 -I../src/lib_hash -I../src/libpng -I../src/utf8proc -I../src/zlib -I../src/zvbi"
+BLD_INCLUDE="-I../src/ -I../src/lib_ccx  -I../src/gpacmp4 -I../src/lib_hash -I../src/libpng -I../src/utf8proc -I../src/protobuf-c -I../src/zlib -I../src/zvbi"
 SRC_CCX="$(find ../src/lib_ccx -name '*.c')"
 SRC_GPAC="$(find ../src/gpacmp4 -name '*.c')"
 SRC_LIB_HASH="$(find ../src/lib_hash -name '*.c')"


### PR DESCRIPTION
Issue fixed : https://github.com/CCExtractor/ccextractor/issues/536