### PR TITLE
Propose the use of clang-format.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+UseTab: Always
+IndentWidth: 8
+BreakBeforeBraces: Allman
+AllowShortIfStatementsOnASingleLine: false
+IndentCaseLabels: false
+ColumnLimit: 80

--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,4 @@
 UseTab: Always
-IndentWidth: 8
 BreakBeforeBraces: Allman
 AllowShortIfStatementsOnASingleLine: false
 IndentCaseLabels: false


### PR DESCRIPTION
Clang-format is an automatic code formatting tool.

It would greatly ease the creation of consistent code: it follows exactly the rules in the .clang-format file. Style changes would be as easily applied as editing the .clang-format file and re-running the clang-format command:
```Bash
clang-format src/lib_ccx/*.c src/lib_ccx/*.h src/ccextractor.c -i
```

The file that I'm proposing is a draft that can be easily customized by the maintainers to fit the code style they wanted for the project: I attempted to configure it such that it was similar to what the style appeared to be before.

`clang-format` is definitely a command line tool that works on macOS and Ubuntu, and to the best of my knowledge, it's also available as a Visual Studio plugin on Windows.