### PR TITLE
Corrected filename.

### DIFF
--- a/linux/pre-build.sh
+++ b/linux/pre-build.sh
@@ -30,5 +30,5 @@ echo "#define CCX_CCEXTRACTOR_COMPILE_REAL_H" >> ../src/lib_ccx/compile_info_rea
 echo "#define GIT_COMMIT \"$commit\"" >> ../src/lib_ccx/compile_info_real.h
 echo "#define COMPILE_DATE \"$builddate\"" >> ../src/lib_ccx/compile_info_real.h
 echo "#endif" >> ../src/lib_ccx/compile_info_real.h
-echo "Stored all in compile.h"
+echo "Stored all in compile_info_real.h"
 echo "Done."

--- a/mac/pre-build.sh
+++ b/mac/pre-build.sh
@@ -30,5 +30,5 @@ echo "#define CCX_CCEXTRACTOR_COMPILE_REAL_H" >> ../src/lib_ccx/compile_info_rea
 echo "#define GIT_COMMIT \"$commit\"" >> ../src/lib_ccx/compile_info_real.h
 echo "#define COMPILE_DATE \"$builddate\"" >> ../src/lib_ccx/compile_info_real.h
 echo "#endif" >> ../src/lib_ccx/compile_info_real.h
-echo "Stored all in compile.h"
+echo "Stored all in compile_info_real.h"
 echo "Done."


### PR DESCRIPTION
The filename pointed to, was ```compile.h``` which doesn't exist. Actual storing occurs in ```compile_info_real.h``` as correctly written in windows ```pre-build.bat``` ```echo stored all in compile_info_real.h```.