### PR TITLE
Added configurable curl post url

### DIFF
--- a/src/lib_ccx/ccx_common_option.h
+++ b/src/lib_ccx/ccx_common_option.h
@@ -46,7 +46,9 @@ struct encoder_cfg
 	int trim_subs; // "    Remove spaces at sides?    "
 	int sentence_cap ; // FIX CASE? = Fix case?
 	int splitbysentence; // Split text into complete sentences and prorate time?
+#ifdef WITH_LIBCURL
 	char *curlposturl; // If out=curl, where do we send the data to?
+#endif
 
 	int with_semaphore; // Write a .sem file on file open and delete it on close?
 	/* Credit stuff */

--- a/src/lib_ccx/ccx_encoders_curl.c
+++ b/src/lib_ccx/ccx_encoders_curl.c
@@ -68,8 +68,12 @@ int write_cc_bitmap_as_libcurl(struct cc_subtitle *sub, struct encoder_ctx *cont
 			curl_free (urlencoded);
 			mprint("%s", curlline);
 
-			curl_easy_setopt(curl, CURLOPT_URL, "127.0.0.1:3000/frame/");
+			char *result = malloc(strlen(ccx_options.curlposturl) + strlen("/frame/") + 1);
+			strcpy(result, ccx_options.curlposturl);
+			strcat(result, "/frame/");
+			curl_easy_setopt(curl, CURLOPT_URL, result);
 			curl_easy_setopt(curl, CURLOPT_POSTFIELDS, curlline);
+			free(result);
 
 			res = curl_easy_perform(curl);
 			/* Check for errors */


### PR DESCRIPTION
To compile with WITH_LIBCURL add in linux/build "-DWITH_LIBCURL" in BLD_FLAGS and "-l curl" in BLD_LINKER.

After code research, I added support for configurable cURL post URL. Already implemented options is "-out=curl" and "-curlposturl [URL]".
It was quite simple, because I used a global variable `ccx_options`.

But there are problem areas. My suggestions:

1. How much reasonable this line in code architecture? [Line](https://github.com/CCExtractor/ccextractor/blob/master/src/lib_ccx/params.c#L2246). The same variable belongs to two objects, one of which belongs to another.
2. It may be worthwhile to make the default curl post url? Instead of [line](https://github.com/CCExtractor/ccextractor/blob/master/src/lib_ccx/params.c#L2212). Maybe we need to look at the most frequent URL in tutorials about local servers.
3. In one of my example videos after ``` Done, processing time = 44 seconds This is beta software. Report issues to carlos at ccextractor org... ```
I get `*** Error in './ccextractor': free(): invalid pointer: 0x00007f49893e9c18 ***` and backtrace. And it happens in current master. I can explore it if you want. Sample video - [Link](https://drive.google.com/file/d/0B0DIrRkpdn12MmZBckw0N3cwNnc/view)

Please, write what you think about it, thanks!