### PR TITLE
Fixed -udp ignoring interface

### DIFF
--- a/src/lib_ccx/networking.c
+++ b/src/lib_ccx/networking.c
@@ -976,12 +976,7 @@ int start_upd_srv(const char *addr_str, unsigned port)
 	struct sockaddr_in servaddr;
 	servaddr.sin_family = AF_INET;
 	servaddr.sin_port = htons(port);
-#ifndef _WIN32
-	if (IN_MULTICAST(addr))
-		servaddr.sin_addr.s_addr = htonl(addr);
-	else
-#endif
-		servaddr.sin_addr.s_addr = htonl(INADDR_ANY);
+	servaddr.sin_addr.s_addr = htonl(addr);
 
 	if (bind(sockfd, (struct sockaddr *)&servaddr, sizeof(servaddr)) != 0)
 	{


### PR DESCRIPTION
Use netstat for checking: `sudo netstat -ntupl | grep ccextractor`
We must use our address instead of INADDR_ANY