### PR TITLE
Fixed bug with -udp address

### DIFF
--- a/src/lib_ccx/networking.c
+++ b/src/lib_ccx/networking.c
@@ -976,12 +976,7 @@ int start_upd_srv(const char *addr_str, unsigned port)
 	struct sockaddr_in servaddr;
 	servaddr.sin_family = AF_INET;
 	servaddr.sin_port = htons(port);
-#ifndef _WIN32
-	if (IN_MULTICAST(addr))
-		servaddr.sin_addr.s_addr = htonl(addr);
-	else
-#endif
-		servaddr.sin_addr.s_addr = htonl(INADDR_ANY);
+	servaddr.sin_addr.s_addr = htonl(IN_MULTICAST(addr) ? INADDR_ANY : addr);
 
 	if (bind(sockfd, (struct sockaddr *)&servaddr, sizeof(servaddr)) != 0)
 	{


### PR DESCRIPTION
Last PR #547 
[Issue](https://github.com/CCExtractor/ccextractor/issues/378)

I read something in the Internet about multicasting, unicasting, sockets in C, sample programs.
It's strange, but it seems that in the code simply mixed up the lines.
Tons of materials say that we should use `INADDR_ANY` in multicasts, and `addr` in unicasts, but the code is upside down, so if we give multicast address, it will works as unicast, and vice versa.
I fixed it and checked in Windows - works good, this part does not depend on the platform.