### PR TITLE
Reopen: fixed memory leaks

### DIFF
--- a/src/gpacmp4/mp4.c
+++ b/src/gpacmp4/mp4.c
@@ -303,6 +303,7 @@ int processmp4 (struct lib_ccx_ctx *ctx,struct ccx_s_mp4Cfg *cfg, char *file)
 	if((f = gf_isom_open(file, GF_ISOM_OPEN_READ, NULL)) == NULL)
 	{
 		mprint("failed to open\n");
+		free(dec_ctx->xds_ctx);
 		return -2;
 	}
 
@@ -342,6 +343,7 @@ int processmp4 (struct lib_ccx_ctx *ctx,struct ccx_s_mp4Cfg *cfg, char *file)
 			if(process_xdvb_track(ctx, file, f, i + 1, &dec_sub) != 0)
 			{
 				mprint("error\n");
+				free(dec_ctx->xds_ctx);
 				return -3;
 			}
 			if(dec_sub.got_output)
@@ -368,6 +370,7 @@ int processmp4 (struct lib_ccx_ctx *ctx,struct ccx_s_mp4Cfg *cfg, char *file)
 			if(process_avc_track(ctx, file, f, i + 1, &dec_sub) != 0)
 			{
 				mprint("error\n");
+				free(dec_ctx->xds_ctx);
 				return -3;
 			}
 			if(dec_sub.got_output)
@@ -524,6 +527,8 @@ int processmp4 (struct lib_ccx_ctx *ctx,struct ccx_s_mp4Cfg *cfg, char *file)
 					}
 					atomStart += atomLength;
 				}
+				free(sample->data);
+				free(sample);
 
 				// End of change
 				int progress = (int) ((k*100) / num_samples);
@@ -538,6 +543,8 @@ int processmp4 (struct lib_ccx_ctx *ctx,struct ccx_s_mp4Cfg *cfg, char *file)
 			activity_progress(100, cur_sec/60, cur_sec%60);
 		}
 	}
+
+	free(dec_ctx->xds_ctx);
 
 	mprint("\nclosing media: ");
 


### PR DESCRIPTION
After updating GPAC library my code (from PR #478 from mp4.c) for fixing memory leaks was erased, but memory leaks still exist. I added it again. I think we should inform the GPAC guys about leaks in their code.