### PR TITLE
Fixed -stdin option in Windows

### DIFF
--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -993,7 +993,9 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		}
 		if (strcmp (argv[i], "-")==0 || strcmp(argv[i], "-stdin") == 0)
 		{
-
+#ifdef WIN32
+			setmode(fileno(stdin), O_BINARY);
+#endif
 			opt->input_source=CCX_DS_STDIN;
 			if (!opt->live_stream) opt->live_stream=-1;
 			continue;


### PR DESCRIPTION
[Issue](https://github.com/CCExtractor/ccextractor/issues/349)
Using: "ccextractor -stdin [args] < file" or "type file | ccextractor -stdin [args]"
In Linux all was ok because on this platform 'stdin', 'stdout' and 'stderr' are binary by default.
What the difference between O_TEXT and O_BINARY in Windows: in Windows, the 'stdin' default (O_TEXT) behaviour is to treat byte 0x1a as an end of input and close the input, 0x0a (LF) as a new line and convert it to the two bytes 0x0d, 0x0a (CR+LF). There may be other transformations.

Also I have new [issue](https://github.com/CCExtractor/ccextractor/issues/555).