### PR TITLE
Windows update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,8 @@ linux/ccextractor
 linux/depend
 windows/Debug/**
 windows/Release/**
-windows/Release-OCR/**
-windows/Debug-OCR/**
+windows/Release-Full/**
+windows/Debug-Full/**
 windows/x64/**
 windows/ccextractor.VC.db
 build/

--- a/windows/ccextractor.sln
+++ b/windows/ccextractor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Express 2013 for Windows Desktop
+VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ccextractor", "ccextractor.vcxproj", "{0F0063C4-BCBC-4379-A6D5-84A5669C940A}"
 EndProject
@@ -9,30 +9,30 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
-		Debug-OCR|Win32 = Debug-OCR|Win32
-		Debug-OCR|x64 = Debug-OCR|x64
+		Debug-Full|Win32 = Debug-Full|Win32
+		Debug-Full|x64 = Debug-Full|x64
 		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
-		Release-OCR|Win32 = Release-OCR|Win32
-		Release-OCR|x64 = Release-OCR|x64
+		Release-Full|Win32 = Release-Full|Win32
+		Release-Full|x64 = Release-Full|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Debug|Win32.ActiveCfg = Debug|Win32
 		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Debug|Win32.Build.0 = Debug|Win32
 		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Debug|x64.ActiveCfg = Debug|x64
 		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Debug|x64.Build.0 = Debug|x64
-		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Debug-OCR|Win32.ActiveCfg = Debug-OCR|Win32
-		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Debug-OCR|Win32.Build.0 = Debug-OCR|Win32
-		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Debug-OCR|x64.ActiveCfg = Debug-OCR|x64
-		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Debug-OCR|x64.Build.0 = Debug-OCR|x64
+		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Debug-Full|Win32.ActiveCfg = Debug-Full|Win32
+		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Debug-Full|Win32.Build.0 = Debug-Full|Win32
+		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Debug-Full|x64.ActiveCfg = Debug-Full|x64
+		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Debug-Full|x64.Build.0 = Debug-Full|x64
 		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Release|Win32.ActiveCfg = Release|Win32
 		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Release|Win32.Build.0 = Release|Win32
 		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Release|x64.ActiveCfg = Release|x64
 		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Release|x64.Build.0 = Release|x64
-		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Release-OCR|Win32.ActiveCfg = Release-OCR|Win32
-		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Release-OCR|Win32.Build.0 = Release-OCR|Win32
-		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Release-OCR|x64.ActiveCfg = Release-OCR|x64
-		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Release-OCR|x64.Build.0 = Release-OCR|x64
+		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Release-Full|Win32.ActiveCfg = Release-Full|Win32
+		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Release-Full|Win32.Build.0 = Release-Full|Win32
+		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Release-Full|x64.ActiveCfg = Release-Full|x64
+		{0F0063C4-BCBC-4379-A6D5-84A5669C940A}.Release-Full|x64.Build.0 = Release-Full|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/windows/ccextractor.vcxproj
+++ b/windows/ccextractor.vcxproj
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug-OCR|Win32">
-      <Configuration>Debug-OCR</Configuration>
+    <ProjectConfiguration Include="Debug-Full|Win32">
+      <Configuration>Debug-Full</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug-OCR|x64">
-      <Configuration>Debug-OCR</Configuration>
+    <ProjectConfiguration Include="Debug-Full|x64">
+      <Configuration>Debug-Full</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
@@ -17,12 +17,12 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Release-OCR|Win32">
-      <Configuration>Release-OCR</Configuration>
+    <ProjectConfiguration Include="Release-Full|Win32">
+      <Configuration>Release-Full</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Release-OCR|x64">
-      <Configuration>Release-OCR</Configuration>
+    <ProjectConfiguration Include="Release-Full|x64">
+      <Configuration>Release-Full</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
@@ -297,19 +297,19 @@
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-OCR|Win32'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Full|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v120_xp</PlatformToolset>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-OCR|x64'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Full|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-OCR|Win32'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Full|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v120_xp</PlatformToolset>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-OCR|x64'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Full|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
@@ -328,16 +328,16 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-OCR|Win32'" Label="PropertySheets">
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Full|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-OCR|x64'" Label="PropertySheets">
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Full|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-OCR|Win32'" Label="PropertySheets">
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-Full|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-OCR|x64'" Label="PropertySheets">
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release-Full|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -354,29 +354,29 @@
     <LinkIncremental>true</LinkIncremental>
     <TargetName>ccextractorwin</TargetName>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-OCR|Win32'">
-    <OutDir>Debug-OCR\</OutDir>
-    <IntDir>Debug-OCR\</IntDir>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Full|Win32'">
+    <OutDir>Debug-Full\</OutDir>
+    <IntDir>Debug-Full\</IntDir>
     <LinkIncremental>true</LinkIncremental>
-    <TargetName>ccextractorwinocr</TargetName>
+    <TargetName>ccextractorwinfull</TargetName>
     <IncludePath>$(ProjectDir)\libs\include;$(IncludePath)</IncludePath>
     <LibraryPath>$(ProjectDir)\libs\lib;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-OCR|x64'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Full|x64'">
     <LinkIncremental>true</LinkIncremental>
     <TargetName>ccextractorwin</TargetName>
     <IncludePath>$(ProjectDir)\libs\include;$(IncludePath)</IncludePath>
     <LibraryPath>$(ProjectDir)\libs\lib;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-OCR|Win32'">
-    <OutDir>Release-OCR\</OutDir>
-    <IntDir>Release-OCR\</IntDir>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Full|Win32'">
+    <OutDir>Release-Full\</OutDir>
+    <IntDir>Release-Full\</IntDir>
     <LinkIncremental>false</LinkIncremental>
-    <TargetName>ccextractorwinocr</TargetName>
+    <TargetName>ccextractorwinfull</TargetName>
     <IncludePath>$(ProjectDir)\libs\include;$(IncludePath)</IncludePath>
     <LibraryPath>$(ProjectDir)\libs\lib;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)</LibraryPath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-OCR|x64'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-Full|x64'">
     <LinkIncremental>false</LinkIncremental>
     <TargetName>ccextractorwin</TargetName>
     <IncludePath>$(ProjectDir)\libs\include;$(IncludePath)</IncludePath>
@@ -431,7 +431,7 @@
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-OCR|Win32'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Full|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>../src/utf8proc;../src/win_spec_incld;../src/gpacmp4;../src/libpng;../src/zlib;../src;../src/lib_ccx;../src/zvbi;../src/protobuf-c;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -454,10 +454,15 @@
     </Link>
     <PostBuildEvent>
       <Command>xcopy /y $(ProjectDir)libs\lib\liblept172.dll $(ProjectDir)$(OutDir)
-xcopy /y $(ProjectDir)libs\lib\libtesseract304d.dll $(ProjectDir)$(OutDir)</Command>
+xcopy /y $(ProjectDir)libs\lib\libtesseract304d.dll $(ProjectDir)$(OutDir)
+xcopy /y $(ProjectDir)libs\lib\avcodec-57.dll $(ProjectDir)$(OutDir)
+xcopy /y $(ProjectDir)libs\lib\avformat-57.dll $(ProjectDir)$(OutDir)
+xcopy /y $(ProjectDir)libs\lib\avutil-55.dll $(ProjectDir)$(OutDir)
+xcopy /y $(ProjectDir)libs\lib\swresample-2.dll $(ProjectDir)$(OutDir)
+xcopy /y $(ProjectDir)libs\lib\swscale-4.dll $(ProjectDir)$(OutDir)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-OCR|x64'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Full|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>../src/utf8proc;../src/win_spec_incld;../src/gpacmp4;../src/libpng;../src/zlib;../src;../src/lib_ccx;../src/zvbi;../src/protobuf-c;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -480,7 +485,7 @@ xcopy /y $(ProjectDir)libs\lib\libtesseract304d.dll $(ProjectDir)$(OutDir)</Comm
 xcopy /y $(ProjectDir)libs\lib\libtesseract304d.dll $(ProjectDir)$(OutDir)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-OCR|Win32'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-Full|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>../src/win_iconv;../src/lib_hash;../src/protobuf-c;../src/utf8proc;../src/win_spec_incld;../src/gpacmp4;../src/libpng;../src/zlib;../src;../src/lib_ccx;../src/zvbi;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -501,13 +506,18 @@ xcopy /y $(ProjectDir)libs\lib\libtesseract304d.dll $(ProjectDir)$(OutDir)</Comm
     </Link>
     <PostBuildEvent>
       <Command>xcopy /y $(ProjectDir)libs\lib\liblept172.dll $(ProjectDir)$(OutDir)
-xcopy /y $(ProjectDir)libs\lib\libtesseract304d.dll $(ProjectDir)$(OutDir)</Command>
+xcopy /y $(ProjectDir)libs\lib\libtesseract304.dll $(ProjectDir)$(OutDir)
+xcopy /y $(ProjectDir)libs\lib\avcodec-57.dll $(ProjectDir)$(OutDir)
+xcopy /y $(ProjectDir)libs\lib\avformat-57.dll $(ProjectDir)$(OutDir)
+xcopy /y $(ProjectDir)libs\lib\avutil-55.dll $(ProjectDir)$(OutDir)
+xcopy /y $(ProjectDir)libs\lib\swresample-2.dll $(ProjectDir)$(OutDir)
+xcopy /y $(ProjectDir)libs\lib\swscale-4.dll $(ProjectDir)$(OutDir)</Command>
     </PostBuildEvent>
     <PreBuildEvent>
       <Command>pre-build.bat</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-OCR|x64'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-Full|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>../src/utf8proc;../src/win_spec_incld;../src/gpacmp4;../src/libpng;../src/zlib;../src;../src/lib_ccx;../src/zvbi;../src/protobuf-c;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/windows/ccextractor.vcxproj.filters
+++ b/windows/ccextractor.vcxproj.filters
@@ -449,69 +449,6 @@
     <ClCompile Include="..\src\lib_ccx\telxcc.c">
       <Filter>Source Files\ccx_decoders</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\activity.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\asf_functions.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\avc_functions.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\cc_bitstream.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\configuration.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\es_functions.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\es_userdata.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\file_functions.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\general_loop.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\myth.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\networking.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\ocr.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\output.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\params.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\params_dump.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\sequencing.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\stream_functions.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\ts_functions.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\ts_tables.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\utility.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\wtv_functions.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\src\lib_ccx\ccx_common_char_encoding.c">
       <Filter>Source Files\ccx_common</Filter>
     </ClCompile>
@@ -533,21 +470,9 @@
     <ClCompile Include="..\src\lib_ccx\spupng_encoder.c">
       <Filter>Source Files\ccx_encoders</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\lib_ccx.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\src\lib_ccx\ccx_common_option.c">
       <Filter>Source Files\ccx_common</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\ts_tables_epg.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\ccx_demuxer.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\ts_info.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\src\lib_ccx\ccx_decoders_708_encoding.c">
       <Filter>Source Files\ccx_decoders</Filter>
     </ClCompile>
@@ -565,9 +490,6 @@
     </ClCompile>
     <ClCompile Include="..\src\lib_ccx\ccx_dtvcc.c">
       <Filter>Source Files\ccx_decoders</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\win_iconv\win_iconv.c">
-      <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\src\lib_ccx\ccx_encoders_sami.c">
       <Filter>Source Files\ccx_encoders</Filter>
@@ -602,9 +524,6 @@
     <ClCompile Include="..\src\zvbi\sampling_par.c">
       <Filter>Source Files\zvbi</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\ccx_gxf.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\src\lib_ccx\ccx_decoders_vbi.c">
       <Filter>Source Files\ccx_decoders</Filter>
     </ClCompile>
@@ -625,9 +544,6 @@
     </ClCompile>
     <ClCompile Include="..\src\protobuf-c\protobuf-c.c">
       <Filter>Source Files\protobuf-c</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\dvd_subtitle_decoder.c">
-      <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\src\lib_ccx\ccx_encoders_transcript.c">
       <Filter>Source Files\ccx_encoders</Filter>
@@ -788,23 +704,107 @@
     <ClCompile Include="..\src\gpacmp4\gpac_ogg.c">
       <Filter>Source Files\gpacmp4</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\hardsubx.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\hardsubx_decoder.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\hardsubx_classifier.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\hardsubx_imgops.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\src\lib_ccx\hardsubx_utility.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\src\lib_ccx\ffmpeg_intgr.c">
       <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\cc_bitstream.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\avc_functions.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\asf_functions.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\activity.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\utility.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\ts_tables_epg.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\ts_tables.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\ts_info.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\ts_functions.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\stream_functions.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\sequencing.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\params_dump.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\params.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\output.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\ocr.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\networking.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\myth.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\lib_ccx.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\hardsubx_utility.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\hardsubx_imgops.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\hardsubx_decoder.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\hardsubx_classifier.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\hardsubx.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\general_loop.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\file_functions.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\es_userdata.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\es_functions.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\dvd_subtitle_decoder.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\configuration.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\ccx_gxf.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\ccx_demuxer.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\lib_ccx\wtv_functions.c">
+      <Filter>Source Files\lib_ccx</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\win_iconv\win_iconv.c">
+      <Filter>Source Files\win_iconv</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I did not rename (Debug|Release) to (Debug|Release)-Simple since it looks ugly/redundant in my opinion. I think we should save it.
Added ffmpeg dll-s copy in the folders after build (I missed it in last PR).
Fixed a mess in the filters.
Before PR all configuration already target the platform 120_xp.
"Official" .zip file with all the required dependencies (all .dll files from windows/libs/lib) - https://www.dropbox.com/s/h6oij6r3dzmyqki/ccextractor-dll.zip?dl=0