### PR TITLE
Memory optimization in HARDSUBX edit_distance

### DIFF
--- a/src/lib_ccx/hardsubx_utility.c
+++ b/src/lib_ccx/hardsubx_utility.c
@@ -27,31 +27,46 @@ int64_t convert_pts_to_s(int64_t pts, AVRational time_base)
 
 int edit_distance(char * word1, char * word2, int len1, int len2)
 {
-	int **matrix = (int **)malloc((len1 + 1) * sizeof(int *));
-	for (int i = 0; i < len1 + 1; i++)
+	// len2 <= len1
+	if (len2 > len1)
+	{
+		int tmp = len1;
+		len1 = len2;
+		len2 = tmp;
+
+		char * tmp_ptr = word1;
+		word1 = word2;
+		word2 = tmp_ptr;
+	}
+
+	int **matrix = (int **)malloc(2 * sizeof(int *));
+	for (int i = 0; i < 2; i++)
 		matrix[i] = (int *)malloc((len2 + 1) * sizeof(int));
 
-	int i,delete,insert,substitute,minimum;
-	for (i = 0; i <= len1; i++)matrix[i][0] = i;
+	int i, delete, insert, substitute, minimum;
 	for (i = 0; i <= len2; i++)matrix[0][i] = i;
 	for (i = 1; i <= len1; i++)
 	{
 		int j;
+		for (j = 0; j <= len2; j++)
+			matrix[i % 2][j] = 0;
+		matrix[i % 2][0] = i;
+
 		char c1;
-		c1 = word1[i-1];
+		c1 = word1[i - 1];
 		for (j = 1; j <= len2; j++)
 		{
 			char c2;
-			c2 = word2[j-1];
+			c2 = word2[j - 1];
 			if (c1 == c2)
 			{
-				matrix[i][j] = matrix[i-1][j-1];
+				matrix[i % 2][j] = matrix[(i - 1) % 2][j - 1];
 			}
-			else 
+			else
 			{
-				delete = matrix[i-1][j] + 1;
-				insert = matrix[i][j-1] + 1;
-				substitute = matrix[i-1][j-1] + 1;
+				delete = matrix[(i - 1) % 2][j] + 1;
+				insert = matrix[i % 2][j - 1] + 1;
+				substitute = matrix[(i - 1) % 2][j - 1] + 1;
 				minimum = delete;
 				if (insert < minimum)
 				{
@@ -61,13 +76,13 @@ int edit_distance(char * word1, char * word2, int len1, int len2)
 				{
 					minimum = substitute;
 				}
-				matrix[i][j] = minimum;
+				matrix[i % 2][j] = minimum;
 			}
 		}
 	}
 
-	int ret = matrix[len1][len2];
-	for (int i = 0; i < len1 + 1; i++)
+	int ret = matrix[len1 % 2][len2];
+	for (int i = 0; i < 2; i++)
 		free(matrix[i]);
 	free(matrix);
 	return ret;


### PR DESCRIPTION
I have made memory optimization in function edit_distance. This function is calls often in hardsubx, and works for `O(len^2)` time and `O(len^2)` memory. But in fact we can work with **two** massives with size len instead of **len**. With my commit it works now with massive with size of 2*min(len1,len2).
For example, in this two videos: https://abhinavshukla95.wordpress.com/2016/08/18/google-summer-of-code-work-product-submission/ We have maximum wasting of memory in first video 59x59 ints ans in second video 87x98 with example arguments. With my commit we can use memory of 2x59 ints and 2x87 ints respectively.