### PR TITLE
Fixed lept msg severity in linux

### DIFF
--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -16,7 +16,7 @@ License: GPL 2.0
 CURL *curl;
 CURLcode res;
 #endif
-#ifdef ENABLE_OCR
+#if defined(ENABLE_OCR) && defined(_WIN32)
 #define LEPT_MSG_SEVERITY L_SEVERITY_NONE
 #endif
 
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
 	{
 		exit(ret);
 	}
-#ifdef ENABLE_OCR
+#if defined(ENABLE_OCR) && defined(_WIN32)
 	setMsgSeverity(LEPT_MSG_SEVERITY);
 #endif
 #ifdef ENABLE_HARDSUBX


### PR DESCRIPTION
"Info" spam messages from leptonica surprisingly is Windows problem only (I saw it a few issues, but before I thought that in Linux as well). In Linux this is not, so we must not redefine msg severity. Moreover, in Linux for some reason "L_SEVERITY_NONE" is not defined (maybe it was necessary to compile leptonica from the current master? While on windows used 1.74), so I think it's better to leave it on Windows