### PR TITLE
Fixed DVB to SAMI extraction.

### DIFF
--- a/src/lib_ccx/ccx_encoders_sami.c
+++ b/src/lib_ccx/ccx_encoders_sami.c
@@ -123,46 +123,45 @@ int write_cc_bitmap_as_sami(struct cc_subtitle *sub, struct encoder_ctx *context
 	struct cc_bitmap* rect;
 	LLONG ms_start, ms_end;
 
-	ms_start = sub->start_time;
+ 	ms_start = sub->start_time;
 	ms_end = sub->end_time;
 
 	if(sub->nb_data == 0 )
 		return 0;
+
 	rect = sub->data;
 
 	if ( sub->flags & SUB_EOD_MARKER )
 		context->prev_start =  sub->start_time;
 
+	char *token = NULL;
+	char *buf = (char*)context->buffer;
+	sprintf(buf,
+		"<SYNC start=%llu><P class=\"UNKNOWNCC\">\r\n"
+		, (unsigned long long)ms_start);
+	write(context->out->fh, buf, strlen(buf));
 	for (int i = sub->nb_data - 1; i >= 0; i--)
 	{
 		if (rect[i].ocr_text && *(rect[i].ocr_text))
 		{
 			if (context->prev_start != -1 || !(sub->flags & SUB_EOD_MARKER))
 			{
-				char *token = NULL;
-				char *buf = (char*)context->buffer;
-				sprintf(buf,
-				"<SYNC start=%llu><P class=\"UNKNOWNCC\">\r\n"
-				, (unsigned long long)ms_start);
-				write(context->out->fh, buf, strlen(buf));
 				token = strtok(rect[i].ocr_text, "\r\n");
-				while (token)
-				{
-					sprintf(buf, "%s", token);
-					token = strtok(NULL, "\r\n");
-					if (token)
-						strcat(buf, "<br>\n");
-					else
-						strcat(buf, "\n");
-					write(context->out->fh, buf, strlen(buf));
-				}
-				sprintf(buf,
-				"<SYNC start=%llu><P class=\"UNKNOWNCC\">&nbsp;</P></SYNC>\r\n\r\n"
-				, (unsigned long long)ms_end);
+				sprintf(buf, "%s", token);
+				token = strtok(NULL, "\r\n");
 				write(context->out->fh, buf, strlen(buf));
+				if (i != 0)
+					write(context->out->fh, context->encoded_br, context->encoded_br_length);
+				write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 			}
 		}
 	}
+	sprintf(buf, "</P></SYNC>\r\n");
+	write(context->out->fh, buf, strlen(buf));
+	sprintf(buf,
+		"<SYNC start=%llu><P class=\"UNKNOWNCC\">&nbsp;</P></SYNC>\r\n\r\n"
+		, (unsigned long long)ms_end);
+	write(context->out->fh, buf, strlen(buf));
 #endif
 
 	sub->nb_data = 0;


### PR DESCRIPTION
Fixed the extraction of DVB subtitles to SAMI format. There was a problem when a subtitle had multiple lines but program interpreted them as different subtitles with same timing.
(Last commit fixed a problem where program skipped subtitles when extracting DVB to SAMI and TTML.)