### PR TITLE
C608 to WebVTT translation

### DIFF
--- a/src/lib_ccx/ccx_common_option.h
+++ b/src/lib_ccx/ccx_common_option.h
@@ -143,6 +143,7 @@ struct ccx_s_options // Options from user parameters
 	unsigned send_to_srv;
 	enum ccx_output_format write_format;                // 0=Raw, 1=srt, 2=SMI
 	int use_ass_instead_of_ssa;
+	int use_webvtt_styling;
 	LLONG debug_mask;                                   // dbg_print will use this mask to print or ignore different types
 	LLONG debug_mask_on_debug;                          // If we're using temp_debug to enable/disable debug "live", this is the mask when temp_debug=1
 	/* Networking */

--- a/src/lib_ccx/ccx_encoders_helpers.c
+++ b/src/lib_ccx/ccx_encoders_helpers.c
@@ -325,6 +325,15 @@ unsigned get_decoder_line_encoded(struct encoder_ctx *ctx, unsigned char *buffer
 	return (unsigned)(buffer - orig); // Return length
 }
 
+void get_sentence_borders(int *first, int *last, int line_num, struct eia608_screen *data) {
+	*first = 0;
+	*last = 32;
+	while (data->colors[line_num][*first] == COL_TRANSPARENT)
+		(*first)++;
+	while (data->colors[line_num][*last] == COL_TRANSPARENT)
+		(*last)--;
+}
+
 /*void delete_all_lines_but_current(ccx_decoder_608_context *context, struct eia608_screen *data, int row)
 {
 for (int i=0;i<15;i++)

--- a/src/lib_ccx/ccx_encoders_helpers.h
+++ b/src/lib_ccx/ccx_encoders_helpers.h
@@ -28,6 +28,7 @@ int clever_capitalize(struct encoder_ctx *context, int line_num, struct eia608_s
 void telx_correct_case(char *sub_line);
 unsigned get_decoder_line_encoded_for_gui(unsigned char *buffer, int line_num, struct eia608_screen *data);
 unsigned get_decoder_line_encoded(struct encoder_ctx *ctx, unsigned char *buffer, int line_num, struct eia608_screen *data);
+void get_sentence_borders(int *first, int *last, int line_num, struct eia608_screen *data);
 
 int string_cmp(const void *p1, const void *p2);
 int string_cmp_function(const void *p1, const void *p2, void *arg);

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -106,8 +106,6 @@ int write_xtimestamp_header(struct encoder_ctx *context)
 		write(context->out->fh, context->buffer, used);
 
 	}
-	// Add the additional CRLF to finish the header
-	write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 	context->wrote_webvtt_sync_header = 1; // Do it even if couldn't write the header, because it won't be possible anyway
 }
 

--- a/src/lib_ccx/dvb_subtitle_decoder.c
+++ b/src/lib_ccx/dvb_subtitle_decoder.c
@@ -1650,7 +1650,9 @@ int dvbsub_decode(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, co
 					enc_ctx->srt_counter = enc_ctx->prev->srt_counter; //for dvb subs we need to update the current srt counter because we always encode the previous subtitle (and the counter is increased for the previous context)
 					enc_ctx->prev_start = enc_ctx->prev->prev_start;
 					sub->prev->got_output = 0;
-
+					if (enc_ctx->write_format == CCX_OF_WEBVTT) {	// we already wrote header, but since we encoded last sub, we must prevent multiple headers in future
+						enc_ctx->wrote_webvtt_sync_header = 1;
+					}
 				}
 				memcpy(enc_ctx->prev, enc_ctx, sizeof(struct encoder_ctx)); //we save the current encoder context
 				memcpy(sub->prev, sub, sizeof(struct cc_subtitle)); //we save the current subtitle

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -180,9 +180,13 @@ void set_output_format (struct ccx_s_options *opt, const char *format)
 		opt->write_format = CCX_OF_SSA;
 		if (strcmp (format,"ass")==0)
 			opt->use_ass_instead_of_ssa = 1;
-	} else if (strcmp(format, "webvtt") == 0)
+	}
+	else if (strcmp(format, "webvtt")==0 || strcmp(format, "webvtt-full")==0) {
 		opt->write_format = CCX_OF_WEBVTT;
-	else if (strcmp (format,"sami")==0 || strcmp (format,"smi")==0)
+		if (strcmp(format, "webvtt-full")==0)
+			opt->use_webvtt_styling = 1;
+	}
+	else if (strcmp(format, "sami") == 0 || strcmp(format, "smi") == 0)
 		opt->write_format=CCX_OF_SAMI;
 	else if (strcmp (format,"transcript")==0 || strcmp (format,"txt")==0)
 	{
@@ -384,6 +388,7 @@ void print_usage (void)
 	mprint ("                      srt     -> SubRip (default, so not actually needed).\n");
 	mprint ("                      ass/ssa -> SubStation Alpha.\n");
 	mprint ("                      webvtt  -> WebVTT format\n");
+	mprint ("                      webvtt-full -> WebVTT format with styling\n");
 	mprint ("                      sami    -> MS Synchronized Accesible Media Interface.\n");
 	mprint ("                      bin     -> CC data in CCExtractor's own binary format.\n");
 	mprint ("                      raw     -> CC data in McPoodle's Broadcast format.\n");


### PR DESCRIPTION
Work in progress - translating CEA-608 subs to WebVTT

**Done:**

- Support of the raw old format without colors
- Added colors and fonts with segments (consecutive characters of the same font or color)

**Todo:**

- Replace current "webvtt" to "webvtt-raw" and "webvtt-full" to "webvtt" (???)
- Add XDS [metadata](https://dvcs.w3.org/hg/text-tracks/raw-file/default/608toVTT/608toVTT.html#metadata-xds) what **already** computed by CCExtractor and written on screen; and add it in file
- True positioning as in document
- Anything else missing from the [document](https://dvcs.w3.org/hg/text-tracks/raw-file/default/608toVTT/608toVTT.html)

@cfsmp3 Write your suggestions