### PR TITLE
C608 to WebVTT translation - Part 2

### DIFF
--- a/src/lib_ccx/ccx_common_option.h
+++ b/src/lib_ccx/ccx_common_option.h
@@ -81,6 +81,7 @@ struct ccx_s_options // Options from user parameters
 	int extract;                                               // Extract 1st, 2nd or both fields
 	int no_rollup;
 	int noscte20;
+	int webvtt_create_css;
 	int cc_channel;                                            // Channel we want to dump in srt mode
 	int buffer_input;
 	int nofontcolor;

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -935,7 +935,7 @@ struct encoder_ctx *init_encoder(struct encoder_cfg *opt)
 
 	ctx->capacity=INITIAL_ENC_BUFFER_CAPACITY;
 	ctx->srt_counter = 0;
-	ctx->wrote_webvtt_sync_header = 0;
+	ctx->wrote_webvtt_header = 0;
 
 	ctx->program_number = opt->program_number;
 	ctx->send_to_srv = opt->send_to_srv;

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -95,7 +95,8 @@ static const char *smptett_header = "<?xml version=\"1.0\" encoding=\"UTF-8\" st
 			"  <body>\n"
 			"    <div>\n";
 
-static const char *webvtt_header = "WEBVTT\r\n";
+static const char *webvtt_header = "WEBVTT\r\n"
+		"Style:\n";
 
 static const char *simple_xml_header = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<captions>\r\n";
 
@@ -456,7 +457,7 @@ static int write_subtitle_file_header(struct encoder_ctx *ctx, struct ccx_s_writ
 				mprint("WARNING: Unable to write complete Buffer \n");
 				return -1;
 			}
-			ret = write(out->fh, ctx->encoded_crlf, ctx->encoded_crlf_length);
+
 			break;
 		case CCX_OF_SAMI: // This header brought to you by McPoodle's CCASDI
 			//fprintf_encoded (wb->fh, sami_header);

--- a/src/lib_ccx/ccx_encoders_common.h
+++ b/src/lib_ccx/ccx_encoders_common.h
@@ -45,8 +45,8 @@ struct encoder_ctx
 	/* keep count of srt subtitle*/
 	unsigned int srt_counter;
 
-	/* Did we write the WebVTT sync header already? */
-	unsigned int wrote_webvtt_sync_header;
+	/* Did we write the WebVTT header already? */
+	unsigned int wrote_webvtt_header;
 
 	/* Input outputs */
 	/* Flag giving hint that output is send to server through network */

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -6,6 +6,115 @@
 #include "ocr.h"
 
 
+static const char *webvtt_outline_css = "@import(%s)\n";
+
+static const char *webvtt_inline_css = "/* default values */\n"
+		"::cue {\n"
+		"  line-height: 5.33vh;\n"
+		"  font-size: 4.1vh;\n"
+		"  font-family: monospace;\n"
+		"  font-style: normal;\n"
+		"  font-weight: normal;\n"
+		"  background-color: black;\n"
+		"  color: white;\n"
+		"}\n"
+		"/* special cue parts */\n"
+		"::cue(c.transparent) {\n"
+		"  color: transparent;\n"
+		"}\n"
+		"/* need to set this before changing color, otherwise the color is lost */\n"
+		"::cue(c.semi-transparent) {\n"
+		"  color: rgba(0, 0, 0, 0.5);\n"
+		"}\n"
+		"/* need to set this before changing color, otherwise the color is lost */\n"
+		"::cue(c.opaque) {\n"
+		"  color: rgba(0, 0, 0, 1);\n"
+		"}\n"
+		"::cue(c.blink) {\n"
+		"  text-decoration: blink;\n"
+		"}\n"
+		"::cue(c.white) {\n"
+		"  color: white;\n"
+		"}\n"
+		"::cue(c.red) {\n"
+		"  color: red;\n"
+		"}\n"
+		"::cue(c.green) {\n"
+		"  color: lime;\n"
+		"}\n"
+		"::cue(c.blue) {\n"
+		"  color: blue;\n"
+		"}\n"
+		"::cue(c.cyan) {\n"
+		"  color: cyan;\n"
+		"}\n"
+		"::cue(c.yellow) {\n"
+		"  color: yellow;\n"
+		"}\n"
+		"::cue(c.magenta) {\n"
+		"  color: magenta;\n"
+		"}\n"
+		"::cue(c.bg_transparent) {\n"
+		"  background-color: transparent;\n"
+		"}\n"
+		"/* need to set this before changing color, otherwise the color is lost */\n"
+		"::cue(c.bg_semi-transparent) {\n"
+		"  background-color: rgba(0, 0, 0, 0.5);\n"
+		"}\n"
+		"/* need to set this before changing color, otherwise the color is lost */\n"
+		"::cue(c.bg_opaque) {\n"
+		"  background-color: rgba(0, 0, 0, 1);\n"
+		"}\n"
+		"::cue(c.bg_white) {\n"
+		"  background-color: white;\n"
+		"}\n"
+		"::cue(c.bg_green) {\n"
+		"  background-color: lime;\n"
+		"}\n"
+		"::cue(c.bg_blue) {\n"
+		"  background-color: blue;\n"
+		"}\n"
+		"::cue(c.bg_cyan) {\n"
+		"  background-color: cyan;\n"
+		"}\n"
+		"::cue(c.bg_red) {\n"
+		"  background-color: red;\n"
+		"}\n"
+		"::cue(c.bg_yellow) {\n"
+		"  background-color: yellow;\n"
+		"}\n"
+		"::cue(c.bg_magenta) {\n"
+		"  background-color: magenta;\n"
+		"}\n"
+		"::cue(c.bg_black) {\n"
+		"  background-color: black;\n"
+		"}\n"
+		"/* Examples of combined colors */\n"
+		"::cue(c.bg_white.bg_semi-transparent) {\n"
+		"  background-color: rgba(255, 255, 255, 0.5);\n"
+		"}\n"
+		"::cue(c.bg_green.bg_semi-transparent) {\n"
+		"  background-color: rgba(0, 256, 0, 0.5);\n"
+		"}\n"
+		"::cue(c.bg_blue.bg_semi-transparent) {\n"
+		"  background-color: rgba(0, 0, 255, 0.5);\n"
+		"}\n"
+		"::cue(c.bg_cyan.bg_semi-transparent) {\n"
+		"  background-color: rgba(0, 255, 255, 0.5);\n"
+		"}\n"
+		"::cue(c.bg_red.bg_semi-transparent) {\n"
+		"  background-color: rgba(255, 0, 0, 0.5);\n"
+		"}\n"
+		"::cue(c.bg_yellow.bg_semi-transparent) {\n"
+		"  background-color: rgba(255, 255, 0, 0.5);\n"
+		"}\n"
+		"::cue(c.bg_magenta.bg_semi-transparent) {\n"
+		"  background-color: rgba(255, 0, 255, 0.5);\n"
+		"}\n"
+		"::cue(c.bg_black.bg_semi-transparent) {\n"
+		"  background-color: rgba(0, 0, 0, 0.5);\n"
+		"}\n";
+
 /* The timing here is not PTS based, but output based, i.e. user delay must be accounted for
 if there is any */
 int write_stringz_as_webvtt(char *string, struct encoder_ctx *context, LLONG ms_start, LLONG ms_end)
@@ -93,6 +202,32 @@ int write_xtimestamp_header(struct encoder_ctx *context)
 {
 	if (context->wrote_webvtt_sync_header) // Already done
 		return 1;
+
+	if (ccx_options.webvtt_create_css)
+	{
+		char *basefilename = get_basename(context->first_input_file);
+		char *css_file_name = (char*)malloc((strlen(basefilename) + 4) * sizeof(char));		// strlen(".css") == 4
+		sprintf(css_file_name, "%s.css", basefilename);
+
+		FILE *f = fopen(css_file_name, "wb");
+		if (f == NULL)
+		{
+			mprint("Warning: Error creating the file %s\n", css_file_name);
+			return -1;
+		}
+		fprintf(f, webvtt_inline_css);
+		fclose(f);
+
+		char* outline_css_file = (char*)malloc((strlen(css_file_name) + strlen(webvtt_outline_css)) * sizeof(char));
+		sprintf(outline_css_file, webvtt_outline_css, css_file_name);
+		write (context->out->fh, outline_css_file, strlen(outline_css_file));
+	} else {
+		write(context->out->fh, webvtt_inline_css, strlen(webvtt_inline_css));
+	}
+
+	write(context->out->fh, "##\n", 3);
+	write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
+
 	if (context->timing->sync_pts2fts_set)
 	{
 		char header_string[200];
@@ -106,6 +241,7 @@ int write_xtimestamp_header(struct encoder_ctx *context)
 		write(context->out->fh, context->buffer, used);
 
 	}
+
 	context->wrote_webvtt_sync_header = 1; // Do it even if couldn't write the header, because it won't be possible anyway
 }
 

--- a/src/lib_ccx/dvb_subtitle_decoder.c
+++ b/src/lib_ccx/dvb_subtitle_decoder.c
@@ -1651,7 +1651,7 @@ int dvbsub_decode(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, co
 					enc_ctx->prev_start = enc_ctx->prev->prev_start;
 					sub->prev->got_output = 0;
 					if (enc_ctx->write_format == CCX_OF_WEBVTT) {	// we already wrote header, but since we encoded last sub, we must prevent multiple headers in future
-						enc_ctx->wrote_webvtt_sync_header = 1;
+						enc_ctx->wrote_webvtt_header = 1;
 					}
 				}
 				memcpy(enc_ctx->prev, enc_ctx, sizeof(struct encoder_ctx)); //we save the current encoder context

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -486,6 +486,7 @@ void print_usage (void)
 	mprint ("                       you prefer your own reference. Note: Current this only\n");
 	mprint ("                       affects Teletext in timed transcript with -datets.\n");
 	mprint ("           --noscte20: Ignore SCTE-20 data if present.\n");
+	mprint ("  --webvtt-create-css: Create a separate file for CSS instead of inline.\n");
 	mprint ("\n");
 	mprint ("Options that affect what kind of output will be produced:\n");
 	mprint ("                 -bom: Append a BOM (Byte Order Mark) to output files.\n");
@@ -1477,6 +1478,11 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		if (strcmp (argv[i],"--noscte20")==0)
 		{
 			opt->noscte20 = 1;
+			continue;
+		}
+		if (strcmp (argv[i],"--webvtt-create-css")==0)
+		{
+			opt->webvtt_create_css = 1;
 			continue;
 		}
 		if (strcmp (argv[i],"-noru")==0 ||


### PR DESCRIPTION
Last PR: https://github.com/CCExtractor/ccextractor/pull/599

What is done

- Fixed minor bugs
- Added "webvtt-full" and "--webvtt-create-css" parameter
- Added CSS settings inline and outline for styling
- Added recognition of the segments in text where it is necessary to add `<c.color>`, `<i>` or `<u>` and closing tags
- Added positioning of the caption lines. One line now is one cue as says in docs 
  > It is recommended to create a separate WebVTT cue when a different PAC is used for lines of captions that are on screen at the same time
