### PR TITLE
Fix for bad WTV timings (#452)

### DIFF
--- a/src/lib_ccx/wtv_functions.c
+++ b/src/lib_ccx/wtv_functions.c
@@ -411,6 +411,7 @@ LLONG get_data(struct lib_ccx_ctx *ctx, struct wtv_chunked_buffer *cb, struct de
 			dbg_print(CCX_DMT_PARSE, "TIME: %ld\n", time);
 			if (time != -1 && time != WTV_CC_TIMESTAMP_MAGIC) { // Ignore -1 timestamps
 				set_current_pts(dec_ctx->timing, time_to_pes_time(time));
+				dec_ctx->timing->pts_set=1;
 				frames_since_ref_time = 0;
 				set_fts(dec_ctx->timing);
 			}


### PR DESCRIPTION
This quick fix should correct the change introduced in dd8923b2e4b4af08b3322811af4f8d7aad953e0e that broke (some?) WTV timings. Reported in #452.