### PR TITLE
A pointer was freed twice in file

### DIFF
--- a/src/gpacmp4/descriptors.c
+++ b/src/gpacmp4/descriptors.c
@@ -556,7 +556,6 @@ void gf_odf_avc_cfg_del(GF_AVCConfig *cfg)
 			if (sl->data) gf_free(sl->data);
 			gf_free(sl);
 		}
-		gf_list_del(cfg->pictureParameterSets);
 	}
 	gf_free(cfg);
 }


### PR DESCRIPTION
Double Free
Same pointer freed twice gf_list_del(cfg->pictureParameterSets) in lines 550 and 559