### PR TITLE
SMPTE-TT : Removed appearance of garbage value in color code.

### DIFF
--- a/src/lib_ccx/ccx_encoders_smptett.c
+++ b/src/lib_ccx/ccx_encoders_smptett.c
@@ -391,6 +391,7 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
 					    unsigned char *temp_pointer = strchr((context->subline),'#');     //locating color code
 
 					    unsigned char *color_code=malloc(7);
+					    *color_code = NULL;
 					    strncat(color_code,(context->subline) + (temp_pointer - (context->subline) + 1),6);     //obtained color code
 
 


### PR DESCRIPTION
Today we made Sample Platform's difference generator a little better and found out that for SMPTE-TT font color often contains garbage data.

![color](https://cloud.githubusercontent.com/assets/12415700/21751952/a545bf2e-d5f5-11e6-99ce-2a38f2db5086.PNG)

When I added that font color support, I left `color_code` variable uninitialized and hence this garbage value. This hopefully fixes this.