### PR TITLE
Fixed Teletext related issues (+DVB) and added other stuff

### DIFF
--- a/src/lib_ccx/ccx_demuxer.c
+++ b/src/lib_ccx/ccx_demuxer.c
@@ -9,6 +9,9 @@ static void ccx_demuxer_reset(struct ccx_demuxer *ctx)
 	ctx->startbytes_pos=0;
 	ctx->startbytes_avail=0;
 	memset (ctx->PIDs_seen, 0, 65536*sizeof (int));
+	memset(ctx->min_pts, UINT64_MAX, 65536 * sizeof(uint64_t));
+	memset(ctx->found_stream_ids, 0, MAX_NUM_OF_STREAMIDS * sizeof(uint8_t));
+	memset(ctx->got_first_pts, UINT64_MAX, 3 * sizeof(uint64_t));
 	memset (ctx->PIDs_programs, 0, 65536*sizeof (struct PMT_entry *));
 }
 

--- a/src/lib_ccx/ccx_demuxer.h
+++ b/src/lib_ccx/ccx_demuxer.h
@@ -10,6 +10,7 @@
 /* Report information */
 #define SUB_STREAMS_CNT 10
 #define MAX_PID 65536
+#define MAX_NUM_OF_STREAMIDS 51
 #define MAX_PSI_PID 8191
 #define TS_PMT_MAP_SIZE 128
 #define MAX_PROGRAM 128
@@ -36,6 +37,7 @@ struct program_info
 	 * -1 pid represent that pcr_pid is not available
 	 */
 	int16_t pcr_pid;
+	LLONG min_pts; //global min_pts for a program (relative to all of its streams)
 };
 
 struct cap_info
@@ -108,6 +110,13 @@ struct ccx_demuxer
 
 	struct PSI_buffer *PID_buffers[MAX_PSI_PID];
 	int PIDs_seen[MAX_PID];
+	uint64_t min_pts[MAX_PID];
+	uint64_t got_first_pts[3]; //0 is pvs1 (private stream 1), 1 is audio and 2 is video
+
+	/*51 possible stream ids in total, 0xbd is private stream, 0xbe is padding stream, 
+	0xbf private stream 2, 0xc0 - 0xdf audio, 0xe0 - 0xef video 
+	(stream ids range from 0xbd to 0xef so 0xef - 0xbd + 1 = 51)*/
+	uint8_t found_stream_ids[MAX_NUM_OF_STREAMIDS]; 
 
 	struct PMT_entry *PIDs_programs[MAX_PID];
 	struct ccx_demux_report freport;

--- a/src/lib_ccx/dvb_subtitle_decoder.c
+++ b/src/lib_ccx/dvb_subtitle_decoder.c
@@ -1613,7 +1613,7 @@ int dvbsub_decode(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, co
 			if (ccx_options.dvb_debug_traces_to_stdout)
 			{
 				//debug traces
-				mprint("DVBSUB - PTS: %d, ", dec_ctx->timing->current_pts);
+				mprint("DVBSUB - PTS: %" PRId64 ", ", dec_ctx->timing->current_pts);
 				mprint("FTS: %d, ", dec_ctx->timing->fts_now);
 				mprint("SEGMENT TYPE: %d, ", segment_type);
 				mprint("SEGMENT LENGTH: %d", segment_length);

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -16,7 +16,6 @@
 #include "ffmpeg_intgr.h"
 #include "ccx_gxf.h"
 #include "dvd_subtitle_decoder.h"
-#include "teletext.h"
 
 
 int end_of_file=0; // End of file?
@@ -633,7 +632,6 @@ void delete_datalist(struct demuxer_data *list)
 
 	}
 }
-
 int process_data(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, struct demuxer_data *data_node)
 {
 	size_t got; // Means 'consumed' from buffer actually
@@ -810,6 +808,10 @@ int general_loop(struct lib_ccx_ctx *ctx)
 	int ret;
 	int caps = 0;
 
+	uint64_t min_pts = UINT64_MAX;
+	int got_pts = 0;
+	int set_pts = 0;
+
 	stream_mode = ctx->demux_ctx->get_stream_mode(ctx->demux_ctx);
 
 	if(stream_mode == CCX_SM_TRANSPORT && ctx->write_format == CCX_OF_NULL)
@@ -856,6 +858,21 @@ int general_loop(struct lib_ccx_ctx *ctx)
 			if(!datalist)
 				break;
 		}
+		//this part is for getting the min_pts of every possible stream ID (optional)
+		/*if (!got_pts && (ctx->demux_ctx->got_first_pts[0] || ctx->demux_ctx->got_first_pts[1] || ctx->demux_ctx->got_first_pts[2])) //it means we got the first pts for video, audio and sub :)
+		{
+			for (int i = 0; i < 65536; i++) // we parse the array with the min_pts for each stream
+			{
+				if (ctx->demux_ctx->min_pts[i] != UINT64_MAX) //PTS is 33 bit, array is 64 so we set the default value tu UINT64_MAX instead of 0 because PTS can also be 0
+				{
+					//printf("Got pts: %" PRId64 " for PID %d\n", ctx->demux_ctx->min_pts[i], i);
+					if (ctx->demux_ctx->min_pts[i] < min_pts)
+						min_pts = ctx->demux_ctx->min_pts[i];
+				}
+			}
+			ctx->demux_ctx->pinfo->min_pts = min_pts;
+			got_pts = 1;
+		}*/
 		if (!datalist)
 			continue;
 		position_sanity_check(ctx->demux_ctx);
@@ -878,15 +895,45 @@ int general_loop(struct lib_ccx_ctx *ctx)
 			enc_ctx = update_encoder_list_cinfo(ctx, cinfo);
 			dec_ctx = update_decoder_list_cinfo(ctx, cinfo);
 			dec_ctx->dtvcc->encoder = (void *)enc_ctx; //WARN: otherwise cea-708 will not work
-			if (!data_node) //If there's no DVB data, we still need to capture the first PTS no matter the buffer data type in order to have the arbitrary value
+
+			if (!set_pts && dec_ctx->codec == CCX_CODEC_TELETEXT) //even if there's no sub data, we still need to set the min_pts
 			{
-				set_current_pts(dec_ctx->timing, datalist->pts);
-				set_fts(dec_ctx->timing);
-				continue;
+				if (!got_pts && (ctx->demux_ctx->got_first_pts[0] != UINT64_MAX || ctx->demux_ctx->got_first_pts[1] != UINT64_MAX || ctx->demux_ctx->got_first_pts[2] != UINT64_MAX)) //it means we got the first pts for either sub, audio or video :)
+				{
+					/*we don't need to parse the entire min_pts array since 
+					we are only interested in sub, audio and video stream pts
+					and we have got_first_pts array for that*/
+					for (int i = 0; i < 3; i++)
+					{
+						if (ctx->demux_ctx->got_first_pts[i] != UINT64_MAX) //PTS is 33 bit, array is 64 so we set the default value to UINT64_MAX instead of 0 because a PTS can also be 0
+						{
+							//printf("Got pts: %" PRId64 " for PID %d\n", ctx->demux_ctx->min_pts[i], i);
+							if (ctx->demux_ctx->got_first_pts[i] < min_pts)
+								min_pts = ctx->demux_ctx->got_first_pts[i];
+						}
+					}
+					ctx->demux_ctx->pinfo->min_pts = min_pts; //we set the program's min_pts (not exactly perfect since we would need to parse the entire min_pts array to get the real min_pts for the program, but for now it's a good approximation)
+					got_pts = 1;
+				}
+				set_pts = 1;
+			}
+			if (!set_pts && dec_ctx->codec == CCX_CODEC_DVB) //DVB will always have to be in sync with video (no matter the min_pts of the other streams)
+			{
+				if (!got_pts && ctx->demux_ctx->got_first_pts[2] != UINT64_MAX) //it means we got the first pts for video
+				{
+					min_pts = ctx->demux_ctx->got_first_pts[2];
+					set_current_pts(dec_ctx->timing, min_pts);
+					set_fts(dec_ctx->timing);
+					got_pts = 1;
+				}
+				set_pts = 1;
 			}
 
 			if (enc_ctx)
 				enc_ctx->timing = dec_ctx->timing;
+
+			if (!data_node) //no sub data, no need to process non-existing data
+				continue;
 
 			if(data_node->pts != CCX_NOPTS)
 			{
@@ -898,7 +945,7 @@ int general_loop(struct lib_ccx_ctx *ctx)
 				}
 				else
 					pts = data_node->pts;
-				set_current_pts(dec_ctx->timing, pts);
+				set_current_pts(dec_ctx->timing, pts); 
 				set_fts(dec_ctx->timing);
 			}
 
@@ -917,6 +964,8 @@ int general_loop(struct lib_ccx_ctx *ctx)
 				}
 				isdb_set_global_time(dec_ctx, tstamp);
 			}
+			if (data_node->bufferdatatype == CCX_TELETEXT && dec_ctx->private_data) //if we have teletext subs, we set the min_pts here
+				set_tlt_delta(dec_ctx, min_pts);
 			ret = process_data(enc_ctx, dec_ctx, data_node);
 			if (enc_ctx->srt_counter || dec_ctx->saw_caption_block || ret == 1)
 				caps = 1;
@@ -941,15 +990,53 @@ int general_loop(struct lib_ccx_ctx *ctx)
 					ignore_other_sib_stream(program_iter, cinfo->pid);
 					data_node = get_data_stream(datalist, cinfo->pid);
 				}
+
+				if (!set_pts && dec_ctx->codec == CCX_CODEC_TELETEXT) //even if there's no sub data, we still need to set the min_pts
+				{
+					if (!got_pts && (ctx->demux_ctx->got_first_pts[0] != UINT64_MAX || ctx->demux_ctx->got_first_pts[1] != UINT64_MAX || ctx->demux_ctx->got_first_pts[2] != UINT64_MAX)) //it means we got the first pts for either sub, audio or video :)
+					{
+						/*we don't need to parse the entire min_pts array since
+						we are only interested in sub, audio and video stream pts
+						and we have got_first_pts array for that*/
+						for (int i = 0; i < 3; i++)
+						{
+							if (ctx->demux_ctx->got_first_pts[i] != UINT64_MAX) //PTS is 33 bit, array is 64 so we set the default value to UINT64_MAX instead of 0 because a PTS can also be 0
+							{
+								//printf("Got pts: %" PRId64 " for PID %d\n", ctx->demux_ctx->min_pts[i], i);
+								if (ctx->demux_ctx->got_first_pts[i] < min_pts)
+									min_pts = ctx->demux_ctx->got_first_pts[i];
+							}
+						}
+						ctx->demux_ctx->pinfo->min_pts = min_pts; //we set the program's min_pts (not exactly perfect since we would need to parse the entire min_pts array to get the real min_pts for the program, but for now it's a good approximation)
+						got_pts = 1;
+					}
+					set_pts = 1;
+				}
+				if (!set_pts && dec_ctx->codec == CCX_CODEC_DVB) //DVB will always have to be in sync with video (no matter the min_pts of the other streams)
+				{
+					if (!got_pts && ctx->demux_ctx->got_first_pts[2] != UINT64_MAX) //it means we got the first pts for video
+					{
+						min_pts = ctx->demux_ctx->got_first_pts[2];
+						set_current_pts(dec_ctx->timing, min_pts);
+						set_fts(dec_ctx->timing);
+						got_pts = 1;
+					}
+					set_pts = 1;
+				}
+
+				if (enc_ctx)
+					dec_ctx->timing = enc_ctx->timing;
+
 				if(!data_node)
 					continue;
+
 				enc_ctx = update_encoder_list_cinfo(ctx, cinfo);
 				dec_ctx = update_decoder_list_cinfo(ctx, cinfo);
 				dec_ctx->dtvcc->encoder = (void *)enc_ctx; //WARN: otherwise cea-708 will not work
-				if (enc_ctx)
-					dec_ctx->timing = enc_ctx->timing;
+				
 				if(data_node->pts != CCX_NOPTS)
 					set_current_pts(dec_ctx->timing, data_node->pts);
+
 				process_data(enc_ctx, dec_ctx, data_node);
 			}
 		}

--- a/src/lib_ccx/ts_functions.c
+++ b/src/lib_ccx/ts_functions.c
@@ -697,6 +697,75 @@ long ts_readstream(struct ccx_demuxer *ctx, struct demuxer_data **data)
 			continue;
 		}
 
+		//PTS calculation
+		if (ctx->got_first_pts[0] == UINT64_MAX || ctx->got_first_pts[1] == UINT64_MAX || ctx->got_first_pts[2] == UINT64_MAX) //if we didn't already get the first PTS of the important streams
+		{
+			if (payload.pesstart) //if there is PES Header data in the payload and we didn't get the first pts of that stream
+			{
+				if (ctx->min_pts[payload.pid] == UINT64_MAX) //check if we don't have the min_pts of that packet's pid
+				{
+					//Write the PES Header to console
+					uint64_t pes_prefix;
+					uint8_t pes_stream_id;
+					uint16_t pes_packet_length;
+					uint8_t optional_pes_header_included = NO;
+					uint16_t optional_pes_header_length = 0;
+					uint64_t pts = 0;
+
+					// Packetized Elementary Stream (PES) 32-bit start code
+					pes_prefix = (payload.start[0] << 16) | (payload.start[1] << 8) | payload.start[2];
+					pes_stream_id = payload.start[3];
+
+					// check for PES header
+					if (pes_prefix == 0x000001)
+					{
+						//if we didn't already have this stream id with its first pts then calculate 
+						if (pes_stream_id != ctx->found_stream_ids[pes_stream_id - 0xbd])
+						{
+							pes_packet_length = 6 + ((payload.start[4] << 8) | payload.start[5]); // 5th and 6th byte of the header define the length of the rest of the packet (+6 is for the prefix, stream ID and packet length)
+
+							/*if (pes_packet_length == 6)
+							{
+								// great, there is only a header and no extension + payload
+								return;
+							}*/
+
+							// optional PES header marker bits (10.. ....)
+							if ((payload.start[6] & 0xc0) == 0x80)
+							{
+								optional_pes_header_included = YES;
+								optional_pes_header_length = payload.start[8];
+							}
+
+							if (optional_pes_header_included == YES && optional_pes_header_length > 0 && (payload.start[7] & 0x80) > 0)
+							{
+								//get associated PTS as it exists
+								pts = (payload.start[9] & 0x0e);
+								pts <<= 29;
+								pts |= (payload.start[10] << 22);
+								pts |= ((payload.start[11] & 0xfe) << 14);
+								pts |= (payload.start[12] << 7);
+								pts |= ((payload.start[13] & 0xfe) >> 1);
+
+								//keep in mind we already checked if we have this stream id
+								ctx->found_stream_ids[pes_stream_id - 0xbd] = pes_stream_id; //add it
+								ctx->min_pts[payload.pid] = pts; //and add its packet pts (we still have this array in case someone wants the global PTS for all stream_id not only for pvs1, audio and video)
+
+								/*we already checked if we got that packet's pts
+								but we still need to check if we got the min_pts of the stream type
+								because we might have multiple audio streams for example*/
+								if (pes_stream_id == 0xbd && ctx->got_first_pts[0] == UINT64_MAX) //private stream 1 
+									ctx->got_first_pts[0] = pts;
+								if (pes_stream_id >= 0xC0 && pes_stream_id <= 0xDF && ctx->got_first_pts[1] == UINT64_MAX) //audio
+									ctx->got_first_pts[1] = pts;
+								if (pes_stream_id >= 0xE0 && pes_stream_id <= 0xEF && ctx->got_first_pts[2] == UINT64_MAX) //video
+									ctx->got_first_pts[2] = pts;
+							}
+						}
+					}
+				}
+			}
+		}
 		switch (ctx->PIDs_seen[payload.pid])
 		{
 			case 0: // First time we see this PID
@@ -729,7 +798,6 @@ long ts_readstream(struct ccx_demuxer *ctx, struct demuxer_data **data)
 				break;
 		}
 
-
 		if (payload.pid==1003 && !ctx->hauppauge_warning_shown && !ccx_options.hauppauge_mode)
 		{
 			// TODO: Change this very weak test for something more decent such as size.
@@ -753,15 +821,15 @@ long ts_readstream(struct ccx_demuxer *ctx, struct demuxer_data **data)
 
 		}
 
-        // Skip packets with no payload.  This also fixes the problems
-        // with the continuity counter not being incremented in empty
-        // packets.
-        if ( !payload.length )
-        {
-                dbg_print(CCX_DMT_VERBOSE, "Packet (pid %u) skipped - no payload.\n",
-                        payload.pid);
-                continue;
-        }
+		// Skip packets with no payload.  This also fixes the problems
+		// with the continuity counter not being incremented in empty
+		// packets.
+		if ( !payload.length )
+		{
+				dbg_print(CCX_DMT_VERBOSE, "Packet (pid %u) skipped - no payload.\n",
+						payload.pid);
+				continue;
+		}
 
 		cinfo = get_cinfo(ctx, payload.pid);
 		if(cinfo == NULL)
@@ -802,7 +870,6 @@ long ts_readstream(struct ccx_demuxer *ctx, struct demuxer_data **data)
 			}
 			continue;
 		}
-
 
 		// Video PES start
 		if (payload.pesstart)

--- a/src/lib_ccx/ts_tables.c
+++ b/src/lib_ccx/ts_tables.c
@@ -586,6 +586,9 @@ int parse_PAT (struct ccx_demuxer *ctx)
 		dinit_cap(ctx);
 		clear_PMT_array(ctx);
 		memset (ctx->PIDs_seen,0,sizeof (int) *65536); // Forget all we saw
+		memset(ctx->min_pts, UINT64_MAX, 65536 * sizeof(uint64_t));
+		memset(ctx->found_stream_ids, 0, MAX_NUM_OF_STREAMIDS * sizeof(uint8_t));
+		memset(ctx->got_first_pts, UINT64_MAX, 3 * sizeof(uint64_t));
 		if (!tlt_config.user_page) // If the user didn't select a page...
 			tlt_config.page=0; // ..forget whatever we detected.
 


### PR DESCRIPTION
- Implemented -pesheader dump parameter for teletext packets too
- Fixed Teletext timing
- Implemented method for getting global minimum PTS of all 51 possible stream ids and minimum PTS for subtitles, video and audio only.
- Almost fixed DVB timing (now it's in sync with video only)
- Fixed Teletext subtitle duplication (Closes #492)
- Fixed Teletext zero length subtitles (Closes #562)