### PR TITLE
Fixes in CEA-708

### DIFF
--- a/src/lib_ccx/ccx_decoders_708.c
+++ b/src/lib_ccx/ccx_decoders_708.c
@@ -1068,8 +1068,8 @@ void dtvcc_handle_SPA_SetPenAttributes(ccx_dtvcc_service_decoder *decoder, unsig
 	int text_tag  = (data[1] >> 4) & 0xf;
 	int font_tag  = (data[2]     ) & 0x7;
 	int edge_type = (data[2] >> 3) & 0x7;
-	int underline = (data[2] >> 4) & 0x1;
-	int italic    = (data[2] >> 5) & 0x1;
+	int underline = (data[2] >> 6) & 0x1;
+	int italic    = (data[2] >> 7) & 0x1;
 
 	ccx_common_logging.debug_ftn(CCX_DMT_708, "       Pen size: [%d]     Offset: [%d]  Text tag: [%d]   Font tag: [%d]\n",
 			pen_size, offset, text_tag, font_tag);

--- a/src/lib_ccx/ccx_decoders_708.c
+++ b/src/lib_ccx/ccx_decoders_708.c
@@ -509,7 +509,7 @@ void _dtvcc_screen_print(ccx_dtvcc_ctx *dtvcc, ccx_dtvcc_service_decoder *decode
 	struct encoder_ctx *encoder = (struct encoder_ctx *) dtvcc->encoder;
 	int sn = decoder->tv->service_number;
 	ccx_dtvcc_writer_ctx *writer = &encoder->dtvcc_writers[sn - 1];
-	ccx_dtvcc_writer_output(writer, decoder->tv, encoder);
+	ccx_dtvcc_writer_output(writer, decoder, encoder);
 
 	_dtvcc_tv_clear(decoder);
 }

--- a/src/lib_ccx/ccx_decoders_708_output.c
+++ b/src/lib_ccx/ccx_decoders_708_output.c
@@ -90,6 +90,9 @@ void _dtvcc_write_row(ccx_dtvcc_writer_ctx *writer, dtvcc_tv_screen *tv, int row
 	int first, last;
 
 	_dtvcc_get_write_interval(tv, row_index, &first, &last);
+	ccx_dtvcc_symbol space = { ' ', 1 };
+	for (int j = 0; j < first; j++)
+		buf[buf_len++] = CCX_DTVCC_SYM(space);
 	for (int j = first; j <= last; j++)
 	{
 		if (CCX_DTVCC_SYM_IS_16(tv->chars[row_index][j]))
@@ -102,6 +105,8 @@ void _dtvcc_write_row(ccx_dtvcc_writer_ctx *writer, dtvcc_tv_screen *tv, int row
 			buf[buf_len++] = CCX_DTVCC_SYM(tv->chars[row_index][j]);
 		}
 	}
+	for (int i = last + 1; i < CCX_DECODER_608_SCREEN_WIDTH; i++)
+		buf[buf_len++] = CCX_DTVCC_SYM(space);
 
 	int fd = encoder->dtvcc_writers[tv->service_number - 1].fd;
 

--- a/src/lib_ccx/ccx_decoders_708_output.c
+++ b/src/lib_ccx/ccx_decoders_708_output.c
@@ -82,26 +82,26 @@ void _dtvcc_write_tag_close(dtvcc_tv_screen *tv, struct encoder_ctx *encoder, in
 	write(encoder->dtvcc_writers[tv->service_number - 1].fd, buf, buf_len);
 }
 
-void _dtvcc_write_row(ccx_dtvcc_writer_ctx *writer, dtvcc_tv_screen *tv, int row_index, struct encoder_ctx *encoder)
+void _dtvcc_write_row(ccx_dtvcc_writer_ctx *writer, ccx_dtvcc_service_decoder *decoder, int row_index, struct encoder_ctx *encoder)
 {
 	char *buf = (char *) encoder->buffer;
 	size_t buf_len = 0;
 	memset(buf, 0, INITIAL_ENC_BUFFER_CAPACITY * sizeof(char));
 	int first, last;
 
-	_dtvcc_get_write_interval(tv, row_index, &first, &last);
+	_dtvcc_get_write_interval(decoder->tv, row_index, &first, &last);
 	ccx_dtvcc_symbol space = { ' ', 1 };
 	for (int j = 0; j < first; j++)
 		buf[buf_len++] = CCX_DTVCC_SYM(space);
 	for (int j = first; j <= last; j++)
 	{
-		int size = utf16_to_utf8(tv->chars[row_index][j].sym, buf + buf_len);
+		int size = utf16_to_utf8(decoder->tv->chars[row_index][j].sym, buf + buf_len);
 		buf_len += size;
 	}
-	for (int i = last + 1; i < CCX_DECODER_608_SCREEN_WIDTH; i++)
+	for (int i = last + 1; i < decoder->windows[decoder->current_window].col_count; i++)
 		buf[buf_len++] = CCX_DTVCC_SYM(space);
 
-	int fd = encoder->dtvcc_writers[tv->service_number - 1].fd;
+	int fd = encoder->dtvcc_writers[decoder->tv->service_number - 1].fd;
 
 	if (writer->cd != (iconv_t) -1)
 	{
@@ -130,39 +130,39 @@ void _dtvcc_write_row(ccx_dtvcc_writer_ctx *writer, dtvcc_tv_screen *tv, int row
 	}
 }
 
-void ccx_dtvcc_write_srt(ccx_dtvcc_writer_ctx *writer, dtvcc_tv_screen *tv, struct encoder_ctx *encoder)
+void ccx_dtvcc_write_srt(ccx_dtvcc_writer_ctx *writer, ccx_dtvcc_service_decoder *decoder, struct encoder_ctx *encoder)
 {
-	if (_dtvcc_is_screen_empty(tv))
+	if (_dtvcc_is_screen_empty(decoder->tv))
 		return;
 
-	if (tv->time_ms_show + encoder->subs_delay < 0)
+	if (decoder->tv->time_ms_show + encoder->subs_delay < 0)
 		return;
 
 	char *buf = (char *) encoder->buffer;
 	memset(buf, 0, INITIAL_ENC_BUFFER_CAPACITY);
 
-	sprintf(buf, "%u%s", tv->cc_count, encoder->encoded_crlf);
-	print_mstime_buff(tv->time_ms_show + encoder->subs_delay,
+	sprintf(buf, "%u%s", decoder->tv->cc_count, encoder->encoded_crlf);
+	print_mstime_buff(decoder->tv->time_ms_show + encoder->subs_delay,
 				   "%02u:%02u:%02u,%03u", buf + strlen(buf));
 	sprintf(buf + strlen(buf), " --> ");
-	print_mstime_buff(tv->time_ms_hide + encoder->subs_delay,
+	print_mstime_buff(decoder->tv->time_ms_hide + encoder->subs_delay,
 				   "%02u:%02u:%02u,%03u", buf + strlen(buf));
 	sprintf(buf + strlen(buf),"%s", (char *) encoder->encoded_crlf);
 
-	write(encoder->dtvcc_writers[tv->service_number - 1].fd, buf, strlen(buf));
+	write(encoder->dtvcc_writers[decoder->tv->service_number - 1].fd, buf, strlen(buf));
 
 	for (int i = 0; i < CCX_DTVCC_SCREENGRID_ROWS; i++)
 	{
-		if (!_dtvcc_is_row_empty(tv, i))
+		if (!_dtvcc_is_row_empty(decoder->tv, i))
 		{
-			_dtvcc_write_tag_open(tv, encoder, i);
-			_dtvcc_write_row(writer, tv, i, encoder);
-			_dtvcc_write_tag_close(tv, encoder, i);
-			write(encoder->dtvcc_writers[tv->service_number - 1].fd,
+			_dtvcc_write_tag_open(decoder->tv, encoder, i);
+			_dtvcc_write_row(writer, decoder, i, encoder);
+			_dtvcc_write_tag_close(decoder->tv, encoder, i);
+			write(encoder->dtvcc_writers[decoder->tv->service_number - 1].fd,
 				  encoder->encoded_crlf, encoder->encoded_crlf_length);
 		}
 	}
-	write(encoder->dtvcc_writers[tv->service_number - 1].fd,
+	write(encoder->dtvcc_writers[decoder->tv->service_number - 1].fd,
 		  encoder->encoded_crlf, encoder->encoded_crlf_length);
 }
 
@@ -301,23 +301,23 @@ void ccx_dtvcc_write_sami(ccx_dtvcc_writer_ctx *writer, dtvcc_tv_screen *tv, str
 	write(encoder->dtvcc_writers[tv->service_number - 1].fd, buf, strlen(buf));
 }
 
-void _ccx_dtvcc_write(ccx_dtvcc_writer_ctx *writer, dtvcc_tv_screen *tv, struct encoder_ctx *encoder)
+void _ccx_dtvcc_write(ccx_dtvcc_writer_ctx *writer, ccx_dtvcc_service_decoder *decoder, struct encoder_ctx *encoder)
 {
 	switch (encoder->write_format)
 	{
 		case CCX_OF_NULL:
 			break;
 		case CCX_OF_SRT:
-			ccx_dtvcc_write_srt(writer, tv, encoder);
+			ccx_dtvcc_write_srt(writer, decoder, encoder);
 			break;
 		case CCX_OF_TRANSCRIPT:
-			ccx_dtvcc_write_transcript(writer, tv, encoder);
+			ccx_dtvcc_write_transcript(writer, decoder->tv, encoder);
 			break;
 		case CCX_OF_SAMI:
-			ccx_dtvcc_write_sami(writer, tv, encoder);
+			ccx_dtvcc_write_sami(writer, decoder->tv, encoder);
 			break;
 		default:
-			ccx_dtvcc_write_debug(tv);
+			ccx_dtvcc_write_debug(decoder->tv);
 			break;
 	}
 }
@@ -397,7 +397,7 @@ void ccx_dtvcc_writer_cleanup(ccx_dtvcc_writer_ctx *writer)
 		iconv_close(writer->cd);
 }
 
-void ccx_dtvcc_writer_output(ccx_dtvcc_writer_ctx *writer, dtvcc_tv_screen *tv, struct encoder_ctx *encoder)
+void ccx_dtvcc_writer_output(ccx_dtvcc_writer_ctx *writer, ccx_dtvcc_service_decoder *decoder, struct encoder_ctx *encoder)
 {
 	ccx_common_logging.debug_ftn(CCX_DMT_708, "[CEA-708] ccx_dtvcc_writer_output: "
 			"writing... [%s][%d]\n", writer->filename, writer->fd);
@@ -419,5 +419,5 @@ void ccx_dtvcc_writer_output(ccx_dtvcc_writer_ctx *writer, dtvcc_tv_screen *tv, 
 			write(writer->fd, UTF8_BOM, sizeof(UTF8_BOM));
 	}
 
-	_ccx_dtvcc_write(writer, tv, encoder);
+	_ccx_dtvcc_write(writer, decoder, encoder);
 }

--- a/src/lib_ccx/ccx_decoders_708_output.c
+++ b/src/lib_ccx/ccx_decoders_708_output.c
@@ -95,15 +95,8 @@ void _dtvcc_write_row(ccx_dtvcc_writer_ctx *writer, dtvcc_tv_screen *tv, int row
 		buf[buf_len++] = CCX_DTVCC_SYM(space);
 	for (int j = first; j <= last; j++)
 	{
-		if (CCX_DTVCC_SYM_IS_16(tv->chars[row_index][j]))
-		{
-			buf[buf_len++] = CCX_DTVCC_SYM_16_FIRST(tv->chars[row_index][j]);
-			buf[buf_len++] = CCX_DTVCC_SYM_16_SECOND(tv->chars[row_index][j]);
-		}
-		else
-		{
-			buf[buf_len++] = CCX_DTVCC_SYM(tv->chars[row_index][j]);
-		}
+		int size = utf16_to_utf8(tv->chars[row_index][j].sym, buf + buf_len);
+		buf_len += size;
 	}
 	for (int i = last + 1; i < CCX_DECODER_608_SCREEN_WIDTH; i++)
 		buf[buf_len++] = CCX_DTVCC_SYM(space);

--- a/src/lib_ccx/ccx_decoders_708_output.h
+++ b/src/lib_ccx/ccx_decoders_708_output.h
@@ -14,6 +14,6 @@ void ccx_dtvcc_writer_init(ccx_dtvcc_writer_ctx *writer,
 						   enum ccx_output_format write_format,
 						   struct encoder_cfg *cfg);
 void ccx_dtvcc_writer_cleanup(ccx_dtvcc_writer_ctx *writer);
-void ccx_dtvcc_writer_output(ccx_dtvcc_writer_ctx *writer, dtvcc_tv_screen *tv, struct encoder_ctx *encoder);
+void ccx_dtvcc_writer_output(ccx_dtvcc_writer_ctx *writer, ccx_dtvcc_service_decoder *decoder, struct encoder_ctx *encoder);
 
 #endif /*_CCX_DECODERS_708_OUTPUT_H_*/


### PR DESCRIPTION
#Getting started on improving
Closes #477 - result file [DancingQueen.p2.svc01.srt ](https://gist.github.com/Izaron/44c030eae8c6c1049ae6d3e6c6d0dd32)
There are 2 other issues in the list with Korean subtitles, but I do not know whether it is possible to close them
Now correctly displayed characters like ® 
There still characters missing in some lines in English subtitles