### PR TITLE
Prevent usage of stdin with MP4 files.

### DIFF
--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -239,6 +239,10 @@ int main(int argc, char *argv[])
 			case CCX_SM_MP4:
 				mprint ("\rAnalyzing data with GPAC (MP4 library)\n");
 				close_input_file(ctx); // No need to have it open. GPAC will do it for us
+				if (ctx->current_file == -1) // We don't have a file to open, must be stdin, and GPAC is incompatible with stdin
+				{
+					fatal (EXIT_INCOMPATIBLE_PARAMETERS, "MP4 requires an actual file, it's not possible to read from a stream, including stdin.\n");
+				}
 				tmp = processmp4(ctx, &ctx->mp4_cfg, ctx->inputfile[ctx->current_file]);
 				if (ccx_options.print_file_reports)
 					print_file_report(ctx);

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -2150,6 +2150,12 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		fatal (EXIT_INCOMPATIBLE_PARAMETERS, "Error: Parameter %s not understood.\n", argv[i]);
 		// Unrecognized switches are silently ignored
 	}
+	
+	if(opt->demux_cfg.auto_stream ==CCX_SM_MP4 && opt->input_source == CX_DS_STDIN)
+	{
+		fatal (EXIT_INCOMPATIBLE_PARAMETERS, "MP4 requires an actual file, it's not possible to read from a stream, including stdin.\n");
+	}
+	
 	if(opt->gui_mode_reports)
 	{
 		opt->no_progress_bar=1;

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -2151,7 +2151,7 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		// Unrecognized switches are silently ignored
 	}
 	
-	if(opt->demux_cfg.auto_stream ==CCX_SM_MP4 && opt->input_source == CX_DS_STDIN)
+	if(opt->demux_cfg.auto_stream ==CCX_SM_MP4 && opt->input_source == CCX_DS_STDIN)
 	{
 		fatal (EXIT_INCOMPATIBLE_PARAMETERS, "MP4 requires an actual file, it's not possible to read from a stream, including stdin.\n");
 	}


### PR DESCRIPTION
Since GPAC needs a file to be present, MP4 files used to crash on stdin. This PR restricts usage of stdin with MP4 files.

Closes #555 .