### PR TITLE
CEA-708 subtitle counter

### DIFF
--- a/src/lib_ccx/ccx_decoders_708_output.c
+++ b/src/lib_ccx/ccx_decoders_708_output.c
@@ -19,10 +19,12 @@ int _dtvcc_is_screen_empty(dtvcc_tv_screen *tv, struct encoder_ctx *encoder)
 	for (int i = 0; i < CCX_DTVCC_SCREENGRID_ROWS; i++)
 	{
 		if (!_dtvcc_is_row_empty(tv, i))
+		{
+			// we will write subtitle 
+			encoder->cea_708_counter++;
 			return 0;
+		}
 	}
-	// we will write subtitle 
-	encoder->cea_708_counter++;
 	return 1;
 }
 

--- a/src/lib_ccx/ccx_decoders_708_output.c
+++ b/src/lib_ccx/ccx_decoders_708_output.c
@@ -200,7 +200,7 @@ void ccx_dtvcc_write_srt(ccx_dtvcc_writer_ctx *writer, ccx_dtvcc_service_decoder
 	char *buf = (char *) encoder->buffer;
 	memset(buf, 0, INITIAL_ENC_BUFFER_CAPACITY);
 
-	sprintf(buf, "%u%s", tv->cc_count, encoder->encoded_crlf);
+	sprintf(buf, "%u%s", encoder->cea_708_counter, encoder->encoded_crlf);
 	print_mstime_buff(tv->time_ms_show + encoder->subs_delay,
 				   "%02u:%02u:%02u,%03u", buf + strlen(buf));
 	sprintf(buf + strlen(buf), " --> ");


### PR DESCRIPTION
Fixed bug with uncorrect srt numbers - [histw-false.srt](http://paste.ubuntu.com/23793294/), [histw-true.srt](http://paste.ubuntu.com/23793345/)
We had a "disappearing subtitles", but in fact we had uncorrect numbering in tv->cc_count and decoder->tv->cc_count, because we increase these values before output function calling, but the output sometimes failed, because the window does not exist, so we can't use this value as counter. I used encoder->cea_708_counter as global correct counter for CEA-708.