### PR TITLE
Ability to extract Chapters from MP4 files.

### DIFF
--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -243,7 +243,14 @@ int main(int argc, char *argv[])
 				{
 					fatal (EXIT_INCOMPATIBLE_PARAMETERS, "MP4 requires an actual file, it's not possible to read from a stream, including stdin.\n");
 				}
-				tmp = processmp4(ctx, &ctx->mp4_cfg, ctx->inputfile[ctx->current_file]);
+				if(ccx_options.extract_chapters)
+				{
+					tmp = dumpchapters(ctx, &ctx->mp4_cfg, ctx->inputfile[ctx->current_file]);
+				}
+				else
+				{
+					tmp = processmp4(ctx, &ctx->mp4_cfg, ctx->inputfile[ctx->current_file]);
+				}
 				if (ccx_options.print_file_reports)
 					print_file_report(ctx);
 				if (!ret) ret = tmp;

--- a/src/lib_ccx/ccx_common_option.c
+++ b/src/lib_ccx/ccx_common_option.c
@@ -49,6 +49,7 @@ void init_options (struct ccx_s_options *options)
 	options->auto_myth = 2; // 2=auto
 	/* MP4 related stuff */
 	options->mp4vidtrack=0; // Process the video track even if a CC dedicated track exists.
+	options->extract_chapters=0; // By default don't extract chapters.
 	/* General stuff */
 	options->usepicorder = 0; // Force the use of pic_order_cnt_lsb in AVC/H.264 data streams
 	options->xmltv=0; // 1 = full output. 2 = live output. 3 = both

--- a/src/lib_ccx/ccx_common_option.h
+++ b/src/lib_ccx/ccx_common_option.h
@@ -115,6 +115,7 @@ struct ccx_s_options // Options from user parameters
 	int auto_myth;                    // Use myth-tv mpeg code? 0=no, 1=yes, 2=auto
 	/* MP4 related stuff */
 	unsigned mp4vidtrack;             // Process the video track even if a CC dedicated track exists.
+	int extract_chapters;		  // If 1, extracts chapters (if present), from MP4 files.
 	/* General settings */
 	int usepicorder;                  // Force the use of pic_order_cnt_lsb in AVC/H.264 data streams
 	int xmltv;                        // 1 = full output. 2 = live output. 3 = both

--- a/src/lib_ccx/ccx_mp4.h
+++ b/src/lib_ccx/ccx_mp4.h
@@ -4,4 +4,5 @@
 
 
 int processmp4 (struct lib_ccx_ctx *ctx,struct ccx_s_mp4Cfg *cfg, char *file);
+int dumpchapters(struct lib_ccx_ctx *ctx,struct ccx_s_mp4Cfg *cfg, char *file);
 #endif

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -490,6 +490,9 @@ void print_usage (void)
 	mprint ("  --webvtt-create-css: Create a separate file for CSS instead of inline.\n");
 	mprint ("\n");
 	mprint ("Options that affect what kind of output will be produced:\n");
+	mprint ("            -chapters: (Experimental) Produces a chapter file from MP4 files.\n");
+	mprint ("                       Note that this must only be used with MP4 files,\n");
+	mprint ("                       for other files it will simply generate subtitles file.\n");
 	mprint ("                 -bom: Append a BOM (Byte Order Mark) to output files.\n");
 	mprint ("                       Note that most text processing tools in linux will not\n");
 	mprint ("                       like BOM.\n");
@@ -1199,6 +1202,11 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 			}
 		}
 #endif
+		
+		if (strcmp(argv[i], "-chapters") == 0){
+			opt->extract_chapters= 1;
+			continue;
+		}
 
 		if (strcmp (argv[i],"-bi")==0 ||
 				strcmp (argv[i],"--bufferinput")==0)
@@ -2194,6 +2202,13 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 	if(opt->demux_cfg.auto_stream ==CCX_SM_MP4 && opt->input_source == CCX_DS_STDIN)
 	{
 		fatal (EXIT_INCOMPATIBLE_PARAMETERS, "MP4 requires an actual file, it's not possible to read from a stream, including stdin.\n");
+	}
+	
+	if(opt->extract_chapters)
+	{
+		mprint("Request to extract chapters recieved.\n");
+		mprint("Note that this must only be used with MP4 files,\n");
+		mprint("for other files it will simply generate subtitles file.\n\n");
 	}
 
 	if(opt->gui_mode_reports)


### PR DESCRIPTION
Various files such as MP4 may have *chapter markers* in them. They are also present in the audio books we purchase, for example, from Amazon. , CCExtractor should now be able to extract Chapter Markers too. 🙂 

Usage is simple. To extract chapter markers from a MP4 video file :
```
 ./ccextractor -chapters file.mp4
```

It will create file.txt with Chapter Markers in OGG format.

Example :

```

Opening file: chapters.mp4
Detected MP4 box with name: ftyp
Detected MP4 box with name: moov
File seems to be a MP4
Analyzing data with GPAC (MP4 library)
opening 'chapters.mp4': ok
Writing chapters into chapters.txt
Done, processing time = 0 seconds
Issues? Open a ticket here
https://github.com/CCExtractor/ccextractor/issues
saurabhshri@gsocdev3:~/gpac/bin/gcc/ccextractor/linux$ ls
build       build_hardsubx   ccextractor  chapter.mp4.txt  chapters.mp4.txt  description-pak  mekong.srt  pre-build.sh
saurabhshri@gsocdev3:~/gpac/bin/gcc/ccextractor/linux$ cat chapters.txt
CHAPTER01=00:00:00.000
CHAPTER01NAME=test1
CHAPTER02=00:01:30.000
CHAPTER02NAME=test2
CHAPTER03=00:03:00.000
CHAPTER03NAME=test3
CHAPTER04=00:04:30.000
CHAPTER04NAME=test4

```

Note : If -chapters is used with any other files than MP4, CCExtractor will simply extract subtitles from them.