### PR TITLE
Fixed huge memory usage caused by OCR inits.

### DIFF
--- a/src/lib_ccx/ccx_demuxer.c
+++ b/src/lib_ccx/ccx_demuxer.c
@@ -302,6 +302,14 @@ struct ccx_demuxer *init_demuxer(void *parent, struct demuxer_cfg *cfg)
 	ctx->nb_program = 0;
 	ctx->multi_stream_per_prog = 0;
 
+	for (int i = 0; i < MAX_PROGRAM; i++)
+	{
+		ctx->pinfo[i].has_all_min_pts = 0;
+		memset(ctx->pinfo[i].got_important_streams_min_pts, UINT64_MAX, COUNT * sizeof(uint64_t));
+		ctx->pinfo[i].initialized_ocr = 0;
+		memset(ctx->pinfo[i].got_important_streams_min_pts, UINT64_MAX, COUNT * sizeof(uint64_t));
+	}
+
 	if(cfg->ts_forced_program  != -1)
 	{
 		ctx->pinfo[ctx->nb_program].pid = CCX_UNKNOWN;

--- a/src/lib_ccx/ccx_demuxer.c
+++ b/src/lib_ccx/ccx_demuxer.c
@@ -307,7 +307,6 @@ struct ccx_demuxer *init_demuxer(void *parent, struct demuxer_cfg *cfg)
 		ctx->pinfo[i].has_all_min_pts = 0;
 		memset(ctx->pinfo[i].got_important_streams_min_pts, UINT64_MAX, COUNT * sizeof(uint64_t));
 		ctx->pinfo[i].initialized_ocr = 0;
-		memset(ctx->pinfo[i].got_important_streams_min_pts, UINT64_MAX, COUNT * sizeof(uint64_t));
 	}
 
 	if(cfg->ts_forced_program  != -1)

--- a/src/lib_ccx/ccx_demuxer.h
+++ b/src/lib_ccx/ccx_demuxer.h
@@ -35,6 +35,7 @@ struct program_info
 {
 	int pid;
 	int program_number;
+	int initialized_ocr; // Avoid initializing the OCR more than once
 	uint8_t analysed_PMT_once:1;
 	uint8_t version;
 	uint8_t saved_section[1021];

--- a/src/lib_ccx/dvb_subtitle_decoder.h
+++ b/src/lib_ccx/dvb_subtitle_decoder.h
@@ -1,17 +1,17 @@
 /*
- * DVB subtitle decoding
- * Copyright (c) 2014 Anshul
- * License: LGPL
- *
- * This file is part of CCEXtractor
- * You should have received a copy of the GNU Lesser General Public
- * License along with CCExtractor; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
- *
- */
+* DVB subtitle decoding
+* Copyright (c) 2014 Anshul
+* License: LGPL
+*
+* This file is part of CCEXtractor
+* You should have received a copy of the GNU Lesser General Public
+* License along with CCExtractor; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*
+*/
 /**
- * @file dvbsub.c
- */
+* @file dvbsub.c
+*/
 
 #ifndef DVBSUBDEC_H
 #define DVBSUBDEC_H
@@ -24,62 +24,62 @@ extern "C"
 {
 #endif
 
-struct dvb_config
-{
-	unsigned char n_language;
-	unsigned int lang_index[MAX_LANGUAGE_PER_DESC];
-	/* subtitle type */
-	unsigned char sub_type[MAX_LANGUAGE_PER_DESC];
-	/* composition page id */
-	unsigned short composition_id[MAX_LANGUAGE_PER_DESC];
-	/* ancillary_page_id */
-	unsigned short ancillary_id[MAX_LANGUAGE_PER_DESC];
-};
+	struct dvb_config
+	{
+		unsigned char n_language;
+		unsigned int lang_index[MAX_LANGUAGE_PER_DESC];
+		/* subtitle type */
+		unsigned char sub_type[MAX_LANGUAGE_PER_DESC];
+		/* composition page id */
+		unsigned short composition_id[MAX_LANGUAGE_PER_DESC];
+		/* ancillary_page_id */
+		unsigned short ancillary_id[MAX_LANGUAGE_PER_DESC];
+	};
 
-/**
- * @param cfg Structure containg configuration
- *
- * @return DVB context kept as void* for abstraction
- *
- */
-void* dvbsub_init_decoder(struct dvb_config* cfg);
+	/**
+	* @param cfg Structure containg configuration
+	*
+	* @return DVB context kept as void* for abstraction
+	*
+	*/
+	void* dvbsub_init_decoder(struct dvb_config* cfg, int initialized_ocr);
 
-int dvbsub_close_decoder(void **dvb_ctx);
+	int dvbsub_close_decoder(void **dvb_ctx);
 
-/**
- * @param dvb_ctx    PreInitialized DVB context using DVB
- * @param buf        buffer containing segment data, first sync byte need to 0x0f.
- *                   does not include data_identifier and subtitle_stream_id.
- * @param buf_size   size of buf buffer
- * @param sub        output subtitle data
- *
- * @return           -1 on error
- */
-int dvbsub_decode(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, const unsigned char *buf, int buf_size, struct cc_subtitle *sub);
+	/**
+	* @param dvb_ctx    PreInitialized DVB context using DVB
+	* @param buf        buffer containing segment data, first sync byte need to 0x0f.
+	*                   does not include data_identifier and subtitle_stream_id.
+	* @param buf_size   size of buf buffer
+	* @param sub        output subtitle data
+	*
+	* @return           -1 on error
+	*/
+	int dvbsub_decode(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, const unsigned char *buf, int buf_size, struct cc_subtitle *sub);
 
-/**
- * @func parse_dvb_description
- *
- * data pointer to this function should be after description length and description tag is parsed
- *
- * @param cfg preallocated dvb_config structure where parsed description will be stored,Not to be NULL
- *
- * @return return -1 if invalid data found other wise 0 if everything goes well
- * errno is set is to EINVAL if invalid data is found
- */
-int parse_dvb_description(struct dvb_config* cfg, unsigned char*data,
+	/**
+	* @func parse_dvb_description
+	*
+	* data pointer to this function should be after description length and description tag is parsed
+	*
+	* @param cfg preallocated dvb_config structure where parsed description will be stored,Not to be NULL
+	*
+	* @return return -1 if invalid data found other wise 0 if everything goes well
+	* errno is set is to EINVAL if invalid data is found
+	*/
+	int parse_dvb_description(struct dvb_config* cfg, unsigned char*data,
 		unsigned int len);
 
-/*
- * @func dvbsub_set_write the output structure in dvb
- * set ccx_s_write structure in dvb_ctx
- *
- * @param dvb_ctx context of dvb which was returned by dvbsub_init_decoder
- *
- * @param out output context returned by init_write
- *
- */
-void dvbsub_set_write(void *dvb_ctx, struct ccx_s_write *out);
+	/*
+	* @func dvbsub_set_write the output structure in dvb
+	* set ccx_s_write structure in dvb_ctx
+	*
+	* @param dvb_ctx context of dvb which was returned by dvbsub_init_decoder
+	*
+	* @param out output context returned by init_write
+	*
+	*/
+	void dvbsub_set_write(void *dvb_ctx, struct ccx_s_write *out);
 
 #ifdef __cplusplus
 }

--- a/src/lib_ccx/ts_info.c
+++ b/src/lib_ccx/ts_info.c
@@ -159,7 +159,7 @@ static void* init_private_data(enum ccx_code_type codec)
 	case CCX_CODEC_TELETEXT:
 		return telxcc_init();
 	case CCX_CODEC_DVB:
-		return dvbsub_init_decoder(NULL);
+		return dvbsub_init_decoder(NULL, 0);
 	default:
 		return NULL;
 	}

--- a/src/lib_ccx/ts_tables.c
+++ b/src/lib_ccx/ts_tables.c
@@ -74,6 +74,8 @@ int update_pinfo(struct ccx_demuxer *ctx, int pid, int program_number)
 	ctx->pinfo[ctx->nb_program].analysed_PMT_once = CCX_FALSE;
 	ctx->pinfo[ctx->nb_program].name[0] = '\0';
 	ctx->pinfo[ctx->nb_program].pcr_pid = -1;
+	ctx->pinfo[ctx->nb_program].has_all_min_pts = 0;
+	memset(ctx->pinfo[ctx->nb_program].got_important_streams_min_pts, UINT64_MAX, COUNT * sizeof(uint64_t));
 	ctx->nb_program++;
 
 	return CCX_OK;


### PR DESCRIPTION
- Fixed memory usage and slow speed caused by too many OCR initializations.
(Now there's only one OCR init per program)