### PR TITLE
Fix webvtt formatting

### DIFF
--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -96,7 +96,7 @@ static const char *smptett_header = "<?xml version=\"1.0\" encoding=\"UTF-8\" st
 			"    <div>\n";
 
 static const char *webvtt_header = "WEBVTT\r\n"
-		"Style:\n";
+		"\r\nSTYLE\r\n";
 
 static const char *simple_xml_header = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<captions>\r\n";
 

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -113,7 +113,7 @@ static const char *webvtt_inline_css = "/* default values */\n"
 		"}\n"
 		"::cue(c.bg_black.bg_semi-transparent) {\n"
 		"  background-color: rgba(0, 0, 0, 0.5);\n"
-		"}\n";
+		"}\n\r\n";
 
 static const char** webvtt_pac_row_percent[] = { "10", "15.33", "20.66", "26", "31.33", "36.66", "42",
 		"47.33", "52.66", "58", "63.33", "68.66", "74", "79.33", "84.66" };


### PR DESCRIPTION
The lack of CRLF after the header led to an invalid webvtt format.

Should fix #680 