### PR TITLE
Webvtt new fix

### DIFF
--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -95,7 +95,7 @@ static const char *smptett_header = "<?xml version=\"1.0\" encoding=\"UTF-8\" st
 			"  <body>\n"
 			"    <div>\n";
 
-static const char *webvtt_header[] = {"WEBVTT","\r\n","\r\n","STYLE","\r\n"};
+static const char *webvtt_header[] = {"WEBVTT","\r\n","\r\n","STYLE","\r\n",NULL};
 
 static const char *simple_xml_header = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<captions>\r\n";
 
@@ -448,21 +448,17 @@ static int write_subtitle_file_header(struct encoder_ctx *ctx, struct ccx_s_writ
 			ret = write_bom(ctx, out);
 			if (ret < 0)
 				return -1;
-			for(int i = 0; i < sizeof(webvtt_header)/sizeof(webvtt_header[0]);i++)
+			for(int i = 0; webvtt_header[i]!=NULL ;i++)
 			{
-				header_size += strlen(webvtt_header[i]);
-				if(ccx_options.enc_cfg.line_terminator_lf == 1 && strcmp(webvtt_header[i],"\r\n")==0)
-				{
-					header_size--;
-				}
+				header_size += strlen(webvtt_header[i]); // Find total size of the header
 			}
 			REQUEST_BUFFER_CAPACITY(ctx, header_size*3);
-			for(int i = 0; i < sizeof(webvtt_header)/sizeof(webvtt_header[0]);i++)
+			for(int i = 0; webvtt_header[i]!=NULL;i++)
 			{
-				if(ccx_options.enc_cfg.line_terminator_lf == 1 && strcmp(webvtt_header[i],"\r\n")==0)
+				if(ccx_options.enc_cfg.line_terminator_lf == 1 && strcmp(webvtt_header[i],"\r\n")==0) // If -lf parameter passed, write LF instead of CRLF
 				{
 					used = encode_line (ctx, ctx->buffer,(unsigned char *) "\n");
-				}
+				} 
 				else
 				{
 					used = encode_line (ctx, ctx->buffer,(unsigned char *) webvtt_header[i]);

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -96,7 +96,7 @@ static const char *smptett_header = "<?xml version=\"1.0\" encoding=\"UTF-8\" st
 			"    <div>\n";
 
 static const char *webvtt_header = "WEBVTT\r\n"
-		"Style:\n";
+		"\r\nSTYLE\r\n";
 
 static const char *simple_xml_header = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<captions>\r\n";
 

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -113,7 +113,7 @@ static const char *webvtt_inline_css = "/* default values */\n"
 		"}\n"
 		"::cue(c.bg_black.bg_semi-transparent) {\n"
 		"  background-color: rgba(0, 0, 0, 0.5);\n"
-		"}\n\r\n";
+		"}";
 
 static const char** webvtt_pac_row_percent[] = { "10", "15.33", "20.66", "26", "31.33", "36.66", "42",
 		"47.33", "52.66", "58", "63.33", "68.66", "74", "79.33", "84.66" };
@@ -227,6 +227,14 @@ int write_webvtt_header(struct encoder_ctx *context)
 		write (context->out->fh, outline_css_file, strlen(outline_css_file));
 	} else {
 		write(context->out->fh, webvtt_inline_css, strlen(webvtt_inline_css));
+		if(ccx_options.enc_cfg.line_terminator_lf == 1)
+		{
+			write(context->out->fh, "\n", 1);
+		}
+		else
+		{
+			write(context->out->fh,"\r\n",2);
+		}
 	}
 
 	write(context->out->fh, "##\n", 3);

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -113,7 +113,7 @@ static const char *webvtt_inline_css = "/* default values */\n"
 		"}\n"
 		"::cue(c.bg_black.bg_semi-transparent) {\n"
 		"  background-color: rgba(0, 0, 0, 0.5);\n"
-		"}\n";
+		"}\n\r\n";
 
 static const char** webvtt_pac_row_percent[] = { "10", "15.33", "20.66", "26", "31.33", "36.66", "42",
 		"47.33", "52.66", "58", "63.33", "68.66", "74", "79.33", "84.66" };

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -227,7 +227,7 @@ int write_webvtt_header(struct encoder_ctx *context)
 		write (context->out->fh, outline_css_file, strlen(outline_css_file));
 	} else {
 		write(context->out->fh, webvtt_inline_css, strlen(webvtt_inline_css));
-		if(ccx_options.enc_cfg.line_terminator_lf == 1)
+		if(ccx_options.enc_cfg.line_terminator_lf == 1) // If -lf parameter is set.
 		{
 			write(context->out->fh, "\n", 1);
 		}


### PR DESCRIPTION
Fixes #683 in a more consistent manner (no mixing of CRLF and LF), and obeys the -lf parameter.