### PR TITLE
Fixes for teletext in .bin files (-unixts param, proper return code, -ucla param).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ windows/libs/tesseract/**
 # Mac
 .DS_Store
 windows/enc_temp_folder/*
+
+#CMake
+src/cmake-build-debug/
+src/.idea

--- a/src/lib_ccx/ccx_encoders_transcript.c
+++ b/src/lib_ccx/ccx_encoders_transcript.c
@@ -201,11 +201,11 @@ int write_cc_subtitle_as_transcript(struct cc_subtitle *sub, struct encoder_ctx 
 
 			if (context->transcript_settings->showCC)
 			{
-				if (context->in_fileformat == 1)
+				if (!context->ucla || !strcmp(sub->mode, "TLT"))
+					fdprintf(context->out->fh, sub->info);				
+				else if (context->in_fileformat == 1)
 					//TODO, data->my_field == 1 ? data->channel : data->channel + 2); // Data from field 2 is CC3 or 4
 					fdprintf(context->out->fh, "CC?|");
-				else if (!context->ucla || !strcmp(sub->mode, "TLT"))
-					fdprintf(context->out->fh, sub->info);
 			}
 			if (context->transcript_settings->showMode)
 			{

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -1181,6 +1181,7 @@ int rcwt_loop(struct lib_ccx_ctx *ctx)
 			{
 				encode_sub(enc_ctx, dec_sub);
 				dec_sub->got_output = 0;
+				caps=1;
 			}
 			continue;
 		}

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -1293,14 +1293,18 @@ void tlt_read_rcwt(void *codec, unsigned char *buf, struct cc_subtitle *sub)
 	struct TeletextCtx *ctx = codec;
 
 	data_unit_t id = buf[0];
-	uint64_t t;
-	memcpy(&t, &buf[1], sizeof(uint64_t));
+
+	memcpy(&(ctx->last_timestamp), &buf[1], sizeof(uint64_t));
+
+	if(utc_refvalue != UINT64_MAX)
+	{
+		ctx->last_timestamp+= utc_refvalue * 1000;
+	}
+
 	teletext_packet_payload_t *pl = (teletext_packet_payload_t *)&buf[9];
 
-	ctx->last_timestamp = t;
-
 	ctx->tlt_packet_counter++;
-	process_telx_packet(ctx, id, pl, t, sub);
+	process_telx_packet(ctx, id, pl, ctx->last_timestamp, sub);
 }
 
 int tlt_print_seen_pages(struct lib_cc_decode *dec_ctx)


### PR DESCRIPTION
Earlier even when captions were extracted, the return code was 10 and there was prompt no captions found.

Also, teletext page should now appear correctly instead of `cc?`. 
-unixts param works for teletext for .bin

Earlier : 

```
19700101000041.940|19700101000045.000|CC?||The whole forest is disappearing underground!
19700101000045.100|19700101000048.080|CC?||<font color="#00ffff">Disappearing? Are you sure, Mofy?</font>
19700101000048.180|19700101000052.040|CC?||I've just seen it! I couldn't believe my eyes.
19700101000052.140|19700101000054.280|CC?||Mogu, your bag!

```

Now :

```
20170123191246.100|20170123191249.080|801|<font color="#00ffff">Disappearing? Are you sure, Mofy?</font>
20170123191249.180|20170123191253.040|801|I've just seen it! I couldn't believe my eyes.
20170123191253.140|20170123191255.280|801|Mogu, your bag!

```

Earlier : 

```
Creating DUP
Notice: Teletext page with possible subtitles detected: 801
- No teletext page specified, first received suitable page is 801, not guaranteed

Done, processing time = 0 seconds

Teletext decoder: 2944 packets processed

No captions were found in input.
Issues? Open a ticket here
https://github.com/CCExtractor/ccextractor/issues


```
Now :
```
Creating DUP
Notice: Teletext page with possible subtitles detected: 801
- No teletext page specified, first received suitable page is 801, not guaranteed

Done, processing time = 0 seconds

Teletext decoder: 2944 packets processed
Issues? Open a ticket here
https://github.com/CCExtractor/ccextractor/issues

```

Fixes #667 . :)