### PR TITLE
[IMPROVEMENT] Add templates for issues and PR's

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributors Guide
+
+Please read and understand the contribution guide before creating an issue or pull request. We would like to thank [udemy](https://github.com/nishad/udemy-dl/blob/master/.github/CONTRIBUTING.md) for their contributor's guide, upon which we based ours.
+
+## Etiquette
+
+This project is open source, and as such, we (the maintainers) give our **free time** to build, maintain and **provide user support** for the CCExtractor program. We make the code freely available in the hope that it will be of use to other developers and users. It would be extremely unfair for us to suffer abuse or anger for our hard work.
+
+Please be considerate towards the developers and other users when raising issues or presenting pull requests.
+
+It's the duty of the maintainer to ensure that all submissions to the project are of sufficient quality to benefit the project. Many developers have different skillsets, strengths, and weaknesses. Respect the decision of the maintainers, and do not be upset or abusive if your submission is not used.
+
+## Viability
+
+When requesting or submitting new features, first consider whether it might be useful to others. Open source projects are used by many developers, who may have entirely different needs to your own. Think about whether or not your feature is likely to be used by other users of the project.
+
+## Procedure
+
+**Before filing an issue**:
+
+- Attempt to replicate the problem, to ensure that it wasn't a coincidental incident.
+- Check to make sure your feature suggestion isn't already present within the project.
+- Check the pull requests tab to ensure that the bug doesn't have a fix in progress.
+- Check the pull requests tab to ensure that the feature isn't already in progress.
+
+**Before submitting a pull request**:
+
+- Ensure that your submission is [viable](#viability) for the project.
+- Check the codebase to ensure that your feature doesn't already exist.
+- Check the pull requests to ensure that another person hasn't already submitted the feature or fix.
+
+## Technical requirements
+
+- Before Submitting your Pull Request, merge `master` with your new branch and fix any conflicts. (Make sure you don't break anything in development!)
+- Commit Unix line endings.
+- Make sure to reasonably test your code. We have a sample platform that runs a test-suite for you, but it only covers a general set of tests.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,36 @@
+Please prefix your issue with one of the following: [BUG], [PROPOSAL], [QUESTION].
+
+CCExtractor version (using the --version parameter preferably) : **X.X**
+
+**In raising this issue, I confirm the following (please check boxes, eg [X]):**
+
+- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
+- [ ] I have checked that the bug-fix I am reporting can be replicated, or that the feature I am suggesting isn't already present.
+- [ ] I have checked that the issue I'm posting isn't already reported.
+- [ ] I have checked that the issue I'm porting isn't already solved and no duplicates exist in [closed issues](https://github.com/CCExtractor/ccextractor/issues?q=is%3Aissue+is%3Aclosed) and in [opened issues](https://github.com/CCExtractor/ccextractor/issues)
+- [ ] I have checked the pull requests tab for existing solutions/implementations to my issue/suggestion.
+- [ ] I have used the latest available version of CCExtractor to verify this issue exists.
+
+**My familiarity with the project is as follows (check one, eg [X]):**
+
+- [ ] I have never used CCExtractor.
+- [ ] I have used CCExtractor just a couple of times.
+- [ ] I absolutely love CCExtractor, but have not contributed previously.
+- [ ] I am an active contributor to CCExtractor.
+
+**Necessary information**
+- Is this a regression (did it work before)? [ ] NO | [ ] YES - *please specify the last known working version*
+- What platform did you use? [ ] Windows - [ ] Linux - [ ] Mac
+- What where the used arguments? `-autoprogram`
+
+**Video links**
+
+Please make the affected input file available for us (no screenshots, those don't help!). Public links to Dropbox, Google Drive, etc, are all fine. If it is not possible to make it available publicly, send us a private invitation (both Dropbox and Google Drive allow that). In this case we will download the file and upload it to the private developer repository.
+
+Do *not* upload your file to any location that will require us to sign up or endure a wait list, slow downloads, etc. If your upload expires make sure you keep it active somehow (replace links if needed). Keep in mind that while we go over all tickets some may take a few days, and it's important we have the file available when we actually need it.
+
+**Additional information**
+
+{issue content here, replace this line with your issue content}
+
+PS: Make sure you set an alert in GitHub so you get notifications about your ticket. We may need to ask questions and we do everything inside GitHub's system.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.
+
+**In raising this pull request, I confirm the following (please check boxes):**
+
+- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
+- [ ] I have checked that another pull request for this purpose does not exist.
+- [ ] I have considered, and confirmed that this submission will be valuable to others.
+- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
+- [ ] I give this submission freely, and claim no ownership to its content.
+
+**My familiarity with the project is as follows (check one):**
+
+- [ ] I have never used CCExtractor.
+- [ ] I have used CCExtractor just a couple of times.
+- [ ] I absolutely love CCExtractor, but have not contributed previously.
+- [ ] I am an active contributor to CCExtractor.
+
+---
+
+{pull request content here}

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ CCExtractor has been invited to Summer of Code 2017! Another summer of coding fu
 
 If you are a student currently enrolled in university most likely you are eligible to participate. Read more at:  
 - [Google Summer of Code official website ](https://summerofcode.withgoogle.com/)
-- [CCExtractor's main GSoC page] (https://www.ccextractor.org?id=public:gsoc:ideas_page_for_summer_of_code_2017)
+- [CCExtractor's main GSoC page](https://www.ccextractor.org?id=public:gsoc:ideas_page_for_summer_of_code_2017)
 
 
 ## Installation and Usage
 
-Downloads for precompiled binaries and source code can be found [on our website](http://www.ccextractor.org?id=public:general:downloads).
+Downloads for precompiled binaries and source code can be found [on our website](https://www.ccextractor.org?id=public:general:downloads).
 
 Extracting subtitles is relatively simple. Just run the following command:
 
@@ -26,8 +26,8 @@ This will extract the subtitles.
 
 More usage information can be found on our website:
 
-- [Using the command line tool](http://www.ccextractor.org/doku.php?id=public:general:command_line_usage)
-- [Using the Windows GUI](http://www.ccextractor.org/doku.php?id=public:general:win_gui_usage) 
+- [Using the command line tool](https://www.ccextractor.org/doku.php?id=public:general:command_line_usage)
+- [Using the Windows GUI](https://www.ccextractor.org/doku.php?id=public:general:win_gui_usage) 
 
 
 ## Compiling
@@ -75,28 +75,18 @@ Open the windows/ccextractor.sln file with Visual Studio (2015 at least), and bu
 
 ## Support
 
-By far the best way to get support is by opening a support ticket at our [issue tracker](https://github.com/CCExtractor/ccextractor/issues). 
+By far the best way to get support is by opening an issue at our [issue tracker](https://github.com/CCExtractor/ccextractor/issues). 
 
-When creating a ticket:
+When you create a new issue, please fill in the needed details in the provided template. That makes it easier for us to help you more efficiently.
 
-- Make sure you are using the latest CCExtractor version.
-- If it's a new issue (for example a video file that a previous CCExtractor version processed fine but now causes a crash), mention the last version you know was working.
-- If the issue is about a specific file, make that file available for us. Don't just send us the output from CCExtractor, as we can't do anything about a screenshot that shows a crash. We need the input that actually causes it. You can upload the file to Dropbox, Google Drive, etc, and make it public so you get a download link to add to your ticket.
-- If you cannot make the file public for any (reasonable) reason you can send us a private invitation (both Dropbox and Google Drive allow that). In this case we will download the file and upload it to the private developer repository.
-- Do not upload your file to any location that will require us to sign up or endure a wait list, slow downloads, etc.
-- If your upload expires make sure you keep it active somehow (replace links if needed). Keep in mind that while we go over all tickets some may take a few days, and it's important we have the file available when we actually need it.
-- Make sure you set an alert in GitHub so you get notifications about your ticket. We may need to ask questions and we do everything inside GitHub's system.
-- Please use English. 
-- It goes without saying, we like polite people.
+You can also [contact us by email or chat with the team in Slack](https://www.ccextractor.org/doku.php?id=public:general:support). 
 
-You can also [contact us by email or chat with the team in Slack](http://www.ccextractor.org/doku.php?id=public:general:support). 
-    
 ## Contributing
 
-You can contribute to the project by forking it, modifying the code, and making a pull request to the repository. 
+You can contribute to the project by forking it, modifying the code, and making a pull request to the repository. We have some rules, outlined in the [contributor's guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
 
 ## News & Other Information
 
 News about releases and modifications to the code can be found in the `CHANGES.TXT` file. 
 
-For more information visit the CCExtractor website: [http://www.ccextractor.org](http://www.ccextractor.org)
+For more information visit the CCExtractor website: [https://www.ccextractor.org](https://www.ccextractor.org)


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

This pull request adds the next things to the repository:
- A contributors guide
- A template for new issues
- A template for new pull requests

It also updates the readme to reference to the contributors guide, as well as updating all links to the ccextractor homepage with http*s*