### PR TITLE
[FEATURE] Arch Linux installation script (create .pkg.tar.xz archive or install directly)

### DIFF
--- a/package_creators/PKGBUILD
+++ b/package_creators/PKGBUILD
@@ -1,0 +1,22 @@
+pkgname=ccextractor
+pkgver=0.85
+pkgrel=1
+pkgdesc="A closed captions and teletext subtitles extractor for video streams."
+arch=('i686' 'x86_64')
+url="http://www.ccextractor.org"
+license=('GPL')
+depends=('gcc-libs' 'tesseract')
+source=(
+   $pkgname-$pkgver.tar.gz
+)
+
+build() {
+  cd "$srcdir/$pkgname-$pkgver"
+  ./configure --prefix="$pkgdir/usr/local" --CC=gcc
+  make -j4
+}
+
+package() {
+  cd "$srcdir/$pkgname-$pkgver"
+  make install
+}

--- a/package_creators/PKGBUILD
+++ b/package_creators/PKGBUILD
@@ -12,7 +12,7 @@ source=(
 
 build() {
   cd "$srcdir/$pkgname-$pkgver"
-  ./configure --prefix="$pkgdir/usr/local" --CC=gcc
+  CC=gcc ./configure --prefix="$pkgdir/usr/local"
   make -j4
 }
 

--- a/package_creators/arch.sh
+++ b/package_creators/arch.sh
@@ -2,7 +2,11 @@
 
 ./tarball.sh
 makepkg -g >> PKGBUILD
-makepkg -sic
-rm ./*.tar.gz
-rm ./*.pkg.tar.xz
+makepkg -sc
+rm -f ./*.tar.gz
 sed -i '$ d' PKGBUILD
+read -p "Do you wish to install ccextractor? [Y/n] " yn
+case $yn in
+    [Nn]* ) exit;;
+    * ) sudo pacman -U ./*.pkg.tar.xz; rm -f ./*.pkg.tar.xz;;
+esac

--- a/package_creators/arch.sh
+++ b/package_creators/arch.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+./tarball.sh
+makepkg -g >> PKGBUILD
+makepkg -sic
+rm ./*.tar.gz
+rm ./*.pkg.tar.xz
+sed -i '$ d' PKGBUILD


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Add installation script for Arch Linux based distributions.

Steps to test this out (on an Arch Linux based distribution):
$ cd package_creators/
$ ./arch.sh

There is an option to do 2 things (install directly or create the .pkg.tar.xz archive for distribution purposes without installing on host machine).

Tested on
Kernel : Linux 4.4.48-1-MANJARO (x86_64)
C Library : GNU C Library version 2.24 (stable)
Default C Compiler : GNU C Compiler version 6.3.1 20170109 (GCC)
Distribution : Manjaro Linux

Resolves sub-part of Issue #678 