### PR TITLE
[FEATURE] Scripts to generate CCExtractor Man-page .

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,6 @@ windows/enc_temp_folder/*
 src/cmake-build-debug/
 src/.idea
 
-
 #Autotools
 linux/config.h
 linux/config.log
@@ -95,3 +94,6 @@ src/zvbi/.dirstamp
 
 # Arch
 package_creators/*.pkg.tar.xz
+
+# Manual Pager
+manpage/*.1

--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -3,7 +3,7 @@
 - Fix: Prevent the OCR being initialized more than once (happened on multiprogram and
   PAT changes)
 - New: Added build/installation script for .pkg.tar.xz (Arch Linux).
-  
+- New: Added Manpage generation script for Linux and Mac.
 
 0.85b (2017-1-26)
 -----------------

--- a/linux/Makefile.am
+++ b/linux/Makefile.am
@@ -310,7 +310,14 @@ ccextractor_LDADD += $(TESS_LIB)
 ccextractor_LDADD += $(LEPT_LIB)
 endif
 
-EXTRA_DIST = ../src/gpacmp4/gpac/sync_layer.h ../src/lib_ccx/ccfont2.xbm ../src/utf8proc/utf8proc_data.c
+EXTRA_DIST = ../src/gpacmp4/gpac/sync_layer.h ../src/lib_ccx/ccfont2.xbm ../src/utf8proc/utf8proc_data.c ../manpage/mangen.sh
 
+install-exec-hook:
+	${SHELL} ../manpage/mangen.sh
+	mv ../manpage/ccextractor.1 /usr/local/man/man1
+	gzip -f /usr/local/man/man1/ccextractor.1
+	mandb -q
 
+uninstall-hook:
+	rm /usr/local/man/man1/ccextractor.1.gz
 

--- a/manpage/mangen.sh
+++ b/manpage/mangen.sh
@@ -21,10 +21,10 @@ then
     echo "CCExtractor binary not found, please wait while it's being built."
     ./build 2> /dev/null 1>/dev/null
 fi
-help2man --section=1 --output=ccextractor.man ./ccextractor
-mv ccextractor.man ../manpage/
+help2man --section=1 --output=ccextractor.1 ./ccextractor
+mv ccextractor.1 ../manpage/
 cd ../manpage
-sed -i -e 's/Syntax:/.SH SYNOPSIS/g' ccextractor.man
+sed -i -e 's/Syntax:/.SH SYNOPSIS/g' ccextractor.1
 sed -i '/.SS "File name related options:"/i \
-.SH OPTIONS' ccextractor.man
+.SH OPTIONS' ccextractor.1
 echo "Manpage generation successful!"

--- a/manpage/mangen.sh
+++ b/manpage/mangen.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+
+#Checks for help2man
+if [[ $(help2man 2>&1) == *"not found"* ]]
+then
+    echo "ERROR: 'help2man' package not found. Please install it and try again."
+    exit 0
+fi
+
+#Manual Pager Generation
+unamestr=`uname -s`
+if [[ "$unamestr" == 'Linux' ]]; then
+    cd ../linux
+elif [[ "$unamestr" == 'Darwin' ]]; then
+    cd ../mac
+fi
+ccx=`./ccextractor 2>&1`
+if [[ $ccx != *"no input files"* ]]
+then
+    echo "CCExtractor binary not found, please wait while it's being built."
+    ./build 2> /dev/null 1>/dev/null
+fi
+help2man --section=1 --output=ccextractor.man ./ccextractor
+mv ccextractor.man ../manpage/
+cd ../manpage
+sed -i -e 's/Syntax:/.SH SYNOPSIS/g' ccextractor.man
+sed -i '/.SS "File name related options:"/i \
+.SH OPTIONS' ccextractor.man
+echo "Manpage generation successful!"

--- a/package_creators/tarball.sh
+++ b/package_creators/tarball.sh
@@ -8,6 +8,7 @@ cp linux/pre-build.sh .
 cp linux/configure.ac .
 cp linux/Makefile.am .
 sed -i -e 's:../src:src:g' Makefile.am
+sed -i -e 's:../manpage:manpage:g' Makefile.am
 sed -i -e 's:../src:src:g' configure.ac
 sed -i -e 's:../.git:.git:g' pre-build.sh
 sed -i -e 's:../src:src:g' pre-build.sh


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Added scripts to generate CCExtractor man-page using `ccextractor --help`. Also updated other scripts accordingly to include `ccextractor.man` while installing or creating packages.
Fixes sub part of issue #678 

**EDIT**
Removed the scripts, added `--man` parameter to CCExtractor itself. 
Squashed the commits. 
Though it incurs a small size dependency `help2man` tool but it generates fairly good manpage as compared to writing output of `print_usage` directly to file and then changing the formatting of text (Adding sections like NAME, SYNOPSIS, TITLE) manually.
Though the task can be done without the tool but the text formatting using C would be more lines of code to maintain whenever the contents of `print_usage()` are changed.