### PR TITLE
[FIX] Fix PTS and Length in preview section (Teletext subtitles)

### DIFF
--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -1492,6 +1492,9 @@ int tlt_process_pes_packet(struct lib_cc_decode *dec_ctx, uint8_t *buffer, uint1
 		pts |= ((buffer[13] & 0xfe) >> 1);
 		t = (uint32_t) (pts / 90);
 
+		set_current_pts(dec_ctx->timing, pts);
+		set_fts(dec_ctx->timing);
+
 		if (ccx_options.pes_header_to_stdout)
 		{
 			//printf("# Associated PTS: %d \n", pts);


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [X] I am an active contributor to CCExtractor.

---

PTS and FTS were not being updated when processing Teletext packets - Fixes #698
