### PR TITLE
[IMPROVEMENT] Adding grayscale conversion for better OCR

### DIFF
--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -32,13 +32,12 @@ static int check_trans_tn_intensity(const void *p1, const void *p2, void *arg)
 		 *  Y = 0.2126 R + 0.7152 G + 0.0722 B
 		 */
 	tmp_i = (0.2126 * ti->palette[*tmp].red) + (0.7152 * ti->palette[*tmp].green) + (0.0722 * ti->palette[*tmp].blue);
-	act_i = (0.2126 * ti->palette[*act].red) + (0.7152 * ti->palette[*act].green) + (0.0722 * ti->palette[*act].blue);;
+	act_i = (0.2126 * ti->palette[*act].red) + (0.7152 * ti->palette[*act].green) + (0.0722 * ti->palette[*act].blue);
 
 	if (ti->t[*tmp] < ti->t[*act] || (ti->t[*tmp] == ti->t[*act] &&  tmp_i < act_i))
 		return -1;
 	else if (ti->t[*tmp] == ti->t[*act] &&  tmp_i == act_i)
 		return 0;
-
 
 	return 1;
 }
@@ -80,6 +79,7 @@ void delete_ocr (void** arg)
 	TessBaseAPIDelete(ctx->api);
 	freep(arg);
 }
+
 void* init_ocr(int lang_index)
 {
 	int ret = -1;
@@ -189,6 +189,7 @@ BOX* ignore_alpha_at_edge(png_byte *alpha, unsigned char* indata, int w, int h, 
 
 	return cropWindow;
 }
+
 char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* indata,int w, int h, struct image_copy *copy)
 {
 	PIX	*pix = NULL;
@@ -245,11 +246,14 @@ char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* i
 	char str[128] = "";
 	static int i = 0;
 	sprintf(str,"temp/file_c_%d.jpg",i);
-	pixWrite(str, color_pix_out, IFF_JFIF_JPEG);
+	printf("Writing file_c_%d.jpg\n", i);
+	pixWrite(str, pixConvertRGBToGray(cpix, 0.0, 0.0, 0.0), IFF_JFIF_JPEG);
 	i++;
 	}
 #endif
+	cpix = pixConvertRGBToGray(cpix, 0.0, 0.0, 0.0); // Abhinav95: Converting image to grayscale for OCR to avoid issues with transparency
 	TessBaseAPISetImage2(ctx->api, cpix);
+	color_pix_out = TessBaseAPIGetThresholdedImage(ctx->api);
 	tess_ret = TessBaseAPIRecognize(ctx->api, NULL);
 	if( tess_ret != 0)
 		printf("\nsomething messy\n");
@@ -496,6 +500,7 @@ char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* i
 
 	return text_out;
 }
+
 /*
  * @param alpha out
  * @param intensity in


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

Sometimes when DVB subtitle bitmaps involved transparent backgrounds, Tesseract OCR would fail to accurately recognize the text, which led to nonsensical outputs. This can be fixed by first converting the Leptonica pix used by Tesseract to a grayscale which solves the problems caused by the transparent elements.

This is a well documented problem on the Tesseract repository.