### PR TITLE
**[FIX]** Fix failing build with autoconf due to ccextractor.h

### DIFF
--- a/linux/Makefile.am
+++ b/linux/Makefile.am
@@ -4,6 +4,7 @@ AUTOMAKE_OPTIONS = foreign
 bin_PROGRAMS = ccextractor
 ccextractor_SOURCES = \
 				../src/ccextractor.c \
+				../src/ccextractor.h \
 				../src/gpacmp4/avc_ext.c \
 				../src/gpacmp4/avilib.c \
 				../src/gpacmp4/av_parsers.c \
@@ -265,7 +266,7 @@ ccextractor_SOURCES = \
 
 ccextractor_CFLAGS = -std=gnu99 -s  -Wno-write-strings -D_FILE_OFFSET_BITS=64 -DVERSION_FILE_PRESENT 
 
-ccextractor_CPPFLAGS =-I../src/lib_ccx/ -I../src/gpacmp4/ -I../src/libpng/ -I../src/zlib/ -I../src/zvbi/ -I../src/lib_hash/ -I../src/protobuf-c/ -I../src/utf8proc/
+ccextractor_CPPFLAGS =-I../src/lib_ccx/ -I../src/gpacmp4/ -I../src/libpng/ -I../src/zlib/ -I../src/zvbi/ -I../src/lib_hash/ -I../src/protobuf-c/ -I../src/utf8proc/ -I../src/
 
 
 ccextractor_LDADD=-lm


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Recently `ccextractor.h` was added in source but `Makefile.am` wasn't updated for the same due to which build with autoconf script was failing. This PR fixes the issue.