### PR TITLE
[FIX] Use proper newlines while printing SRT from bitmaps.

### DIFF
--- a/src/lib_ccx/ccx_encoders_srt.c
+++ b/src/lib_ccx/ccx_encoders_srt.c
@@ -109,11 +109,11 @@ int write_cc_bitmap_as_srt(struct cc_subtitle *sub, struct encoder_ctx *context)
 			millis_to_time (ms_start,&h1,&m1,&s1,&ms1);
 			millis_to_time (ms_end-1,&h2,&m2,&s2,&ms2); // -1 To prevent overlapping with next line.
 			context->srt_counter++;
-			sprintf(timeline, "%u\r\n", context->srt_counter);
+			sprintf(timeline, "%u%s", context->srt_counter, context->encoded_crlf);
 			used = encode_line(context, context->buffer,(unsigned char *) timeline);
 			write(context->out->fh, context->buffer, used);
-			sprintf (timeline, "%02u:%02u:%02u,%03u --> %02u:%02u:%02u,%03u\r\n",
-				h1,m1,s1,ms1, h2,m2,s2,ms2);
+			sprintf (timeline, "%02u:%02u:%02u,%03u --> %02u:%02u:%02u,%03u%s",
+				h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
 			used = encode_line(context, context->buffer,(unsigned char *) timeline);
             write (context->out->fh, context->buffer, used);
 			len = strlen(str);


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

Probably fixes #767 .
