### PR TITLE
[IMPROVEMENT] function header in "get_more_data" functions were standarlized.

### DIFF
--- a/src/lib_ccx/ccx_gxf.c
+++ b/src/lib_ccx/ccx_gxf.c
@@ -1685,7 +1685,7 @@ int ccx_gxf_probe(unsigned char *buf, int len)
 
 }
 
-int ccx_gxf_get_more_data(struct ccx_demuxer *ctx, struct demuxer_data **ppdata)
+int ccx_gxf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 {
 	int ret;
 	struct demuxer_data *data;
@@ -1708,7 +1708,7 @@ int ccx_gxf_get_more_data(struct ccx_demuxer *ctx, struct demuxer_data **ppdata)
 		data = *ppdata;
 	}
 
-	ret = read_packet(ctx, data);
+	ret = read_packet(ctx->demux_ctx, data);
 	return ret;
 }
 

--- a/src/lib_ccx/ccx_gxf.h
+++ b/src/lib_ccx/ccx_gxf.h
@@ -2,8 +2,9 @@
 #define CCX_GXF
 
 #include "ccx_demuxer.h"
+#include "lib_ccx.h"
 
 int ccx_gxf_probe(unsigned char *buf, int len);
-int ccx_gxf_get_more_data(struct ccx_demuxer *ctx, struct demuxer_data **data);
+int ccx_gxf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **data);
 struct ccx_gxf *ccx_gxf_init(struct ccx_demuxer *arg);
 #endif

--- a/src/lib_ccx/ffmpeg_intgr.c
+++ b/src/lib_ccx/ffmpeg_intgr.c
@@ -188,7 +188,7 @@ int ff_get_ccframe(void *arg, unsigned char*data, int maxlen)
 	return len;
 }
 
-int ffmpeg_get_more_data(struct ccx_demuxer *ctx, struct demuxer_data **ppdata)
+int ffmpeg_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 {
 	struct demuxer_data *data;
 	int ret = 0;
@@ -211,7 +211,7 @@ int ffmpeg_get_more_data(struct ccx_demuxer *ctx, struct demuxer_data **ppdata)
 
 	do
 	{
-		int len = ff_get_ccframe(ctx->ffmpeg_ctx, data->buffer, BUFSIZE);
+		int len = ff_get_ccframe(ctx->demux_ctx->ffmpeg_ctx, data->buffer, BUFSIZE);
 		if(len == AVERROR(EAGAIN))
 		{
 			continue;

--- a/src/lib_ccx/ffmpeg_intgr.h
+++ b/src/lib_ccx/ffmpeg_intgr.h
@@ -14,5 +14,5 @@
  */
 void *init_ffmpeg(const char *path);
 
-int ffmpeg_get_more_data(struct ccx_demuxer *ctx, struct demuxer_data **ppdata);
+int ffmpeg_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata);
 #endif

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -865,7 +865,7 @@ int general_loop(struct lib_ccx_ctx *ctx)
 				ret = general_get_more_data(ctx, &datalist);
 				break;
 			case CCX_SM_TRANSPORT:
-				ret = ts_get_more_data(ctx->demux_ctx, &datalist);
+				ret = ts_get_more_data(ctx, &datalist);
 				break;
 			case CCX_SM_PROGRAM:
 				ret = ps_get_more_data(ctx, &datalist);
@@ -877,11 +877,11 @@ int general_loop(struct lib_ccx_ctx *ctx)
 				ret = wtv_get_more_data(ctx, &datalist);
 				break;
 			case CCX_SM_GXF:
-				ret = ccx_gxf_get_more_data(ctx->demux_ctx, &datalist);
+				ret = ccx_gxf_get_more_data(ctx, &datalist);
 				break;
 #ifdef ENABLE_FFMPEG
 			case CCX_SM_FFMPEG:
-				ret = ffmpeg_get_more_data(ctx->demux_ctx, &datalist);
+				ret = ffmpeg_get_more_data(ctx, &datalist);
 				break;
 #endif
 			default:

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -891,8 +891,6 @@ int general_loop(struct lib_ccx_ctx *ctx)
 		if (ret == CCX_EOF)
 		{
 			end_of_file = 1;
-			if(!datalist)
-				break;
 		}
 		if (!datalist)
 			continue;

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -883,10 +883,8 @@ int general_loop(struct lib_ccx_ctx *ctx)
     }
 
 	end_of_file = 0;
-	while (!end_of_file && is_decoder_processed_enough(ctx) == CCX_FALSE)
+	while (!terminate_asap && !end_of_file && is_decoder_processed_enough(ctx) == CCX_FALSE)
 	{
-		if (terminate_asap)
-			break;
 		// GET MORE DATA IN BUFFER
 		position_sanity_check(ctx->demux_ctx);
 		ret = get_more_data(ctx, &datalist);

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -226,7 +226,7 @@ int read_video_pes_header (struct ccx_demuxer *ctx, struct demuxer_data *data, u
 void init_ts(struct ccx_demuxer *ctx);
 int ts_readpacket(struct ccx_demuxer* ctx, struct ts_payload *payload);
 long ts_readstream(struct ccx_demuxer *ctx, struct demuxer_data **data);
-int ts_get_more_data(struct ccx_demuxer *ctx, struct demuxer_data **data);
+int ts_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **data);
 int write_section(struct ccx_demuxer *ctx, struct ts_payload *payload, unsigned char*buf, int size,  struct program_info *pinfo);
 void ts_buffer_psi_packet(struct ccx_demuxer *ctx);
 int parse_PMT (struct ccx_demuxer *ctx, unsigned char *buf, int len,  struct program_info *pinfo);

--- a/src/lib_ccx/ts_functions.c
+++ b/src/lib_ccx/ts_functions.c
@@ -1032,12 +1032,12 @@ long ts_readstream(struct ccx_demuxer *ctx, struct demuxer_data **data)
 
 
 // TS specific data grabber
-int ts_get_more_data(struct ccx_demuxer *ctx, struct demuxer_data **data)
+int ts_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **data)
 {
 	int ret = CCX_OK;
 
 	do {
-		ret = ts_readstream(ctx, data);
+		ret = ts_readstream(ctx->demux_ctx, data);
 	} while(ret == CCX_EAGAIN);
 
 	return ret;


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

This PR makes the CCExtractor more standardized, avoid future bugs and allow us to remove the unnecessary *switch (stream_mode)* inside the *while* loop in general_loop().
