### PR TITLE
[FIX] Fix path to wrapper.h in Makefile.am

### DIFF
--- a/linux/Makefile.am
+++ b/linux/Makefile.am
@@ -266,7 +266,7 @@ ccextractor_SOURCES = \
 				../src/extractors/extractor.c \
 				../src/extractors/extractor.h \
 				../src/wrappers/wrapper.c \
-				../src/extractors/wrapper.h 
+				../src/wrappers/wrapper.h
 				
 
 ccextractor_CFLAGS = -std=gnu99 -s  -Wno-write-strings -D_FILE_OFFSET_BITS=64 -DVERSION_FILE_PRESENT 


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

I was trying to use the `package_creators/rpm.sh` script, but kept running into this error:


```
make  dist-gzip am__post_remove_distdir='@:'
make[2]: *** No rule to make target `src/extractors/wrapper.h', needed by `distdir'.  Stop.
make[2]: Entering directory `/mnt/build/ccextractor'
make[2]: Leaving directory `/mnt/build/ccextractor'
make[1]: *** [dist] Error 2
make[1]: Leaving directory `/mnt/build/ccextractor'
mv: cannot stat '*.gz': No such file or directory
mv: cannot stat '*.tar.gz': No such file or directory
error: File /mnt/build/ccextractor/package_creators/RPMBUILD/SOURCES/ccextractor-0.85.tar.gz: No such file or directory
Sorry, the package could not be created as rpmbuild failed with return code 1
```

I traced this back to commit 2eb5fd26de9e4011a2cea5f8ddc6d97efccaf1fc where it looks like some files were shuffled around and the Makefile.am wasn't updated correctly for the wrapper.h file. This fixes it.