### PR TITLE
[IMPROVEMENT] Modify rpm.sh package script to preserve the source rpm

### DIFF
--- a/package_creators/rpm.sh
+++ b/package_creators/rpm.sh
@@ -27,4 +27,5 @@ if [ $retval -ne 0 ]; then
 fi
 cd ../..
 cp RPMBUILD/RPMS/x86_64/*.rpm .
+cp RPMBUILD/SRPMS/*.rpm .
 rm -rf RPMBUILD


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

The `rpm.sh` script should preserve the source RPM in addition to the binary RPM as some organizations are required to keep them for things like GPL compliance.