### PR TITLE
[IMPROVEMENT]: change rpm installation location from /usr/local/bin to /usr/bin

### DIFF
--- a/package_creators/ccextractor.spec
+++ b/package_creators/ccextractor.spec
@@ -17,20 +17,23 @@ CCExtractor is a software that extracts closed captions from videos of various f
 %setup -q
 
 %build
-./configure --enable-ocr --prefix="$pkgdir/usr/local"
+./configure --enable-ocr --prefix="$pkgdir/usr"
 make
 
 %install
-mkdir -p $RPM_BUILD_ROOT/usr/local/bin
-install ccextractor $RPM_BUILD_ROOT/usr/local/bin/ccextractor
+mkdir -p $RPM_BUILD_ROOT/usr/bin
+install ccextractor $RPM_BUILD_ROOT/usr/bin/ccextractor
 
 %files
 %defattr(-,root,root)
-/usr/local/bin/ccextractor
+/usr/bin/ccextractor
 
 %clean
 rm -rf $RPM_BUILD_ROOT
 
 %changelog
+* Thu Oct 5 2017 Jason Hancock <jason@jasonhancock.com>
+- Install to /usr/bin instead of /usr/local/bin
+
 * Fri Apr 14 2017 Carlos Fernandez <carlos@ccextractor.org>
 - Initial build


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Change the location that the binary gets installed from `/usr/local/bin` to `/usr/bin`