### PR TITLE
[FIX][gpacmp4/avilib.c]: Fix redefinition of VERSION and PACKAGE

### DIFF
--- a/src/gpacmp4/avilib.c
+++ b/src/gpacmp4/avilib.c
@@ -32,8 +32,7 @@
 #include <gpac/internal/avilib.h>
 
 
-#define PACKAGE "GPAC/avilib"
-#define VERSION GPAC_FULL_VERSION
+#define GPAC_PACKAGE "GPAC/avilib"
 
 #define INFO_LIST
 
@@ -1452,7 +1451,7 @@ static int avi_close_output_file(avi_t *AVI)
 	//OUTLONG(MAX_INFO_STRLEN);
 	memset(id_str, 0, MAX_INFO_STRLEN);
 
-	sprintf(id_str, "%s-%s", PACKAGE, VERSION);
+	sprintf(id_str, "%s-%s", GPAC_PACKAGE, GPAC_FULL_VERSION);
 	real_id_len = id_len = (u32)strlen(id_str) + 1;
 	if (id_len & 1) id_len++;
 


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---
This PR fixed these compiler warnings:

../src/gpacmp4/avilib.c:35:0: warning: "PACKAGE" redefined
 #define PACKAGE "GPAC/avilib"

<command-line>:0:0: note: this is the location of the previous definition
../src/gpacmp4/avilib.c:36:0: warning: "VERSION" redefined
 #define VERSION GPAC_FULL_VERSION
