### PR TITLE
[IMPROVEMENT]Modify Autoconf scripts to generate mac compatible tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,7 @@ package_creators/*.pkg.tar.xz
 package_creators/*.rpm
 src/lib_ccx/ccx.pc
 windows/combase.pdb/
+src/**/.deps
+src/**/.dirstamp
+mac/ccextractorGUI
+linux/ccextractorGUI

--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -27,6 +27,8 @@
 - Fix: Forcing -noru to cause deduplication in ISDB
 - Fix: TS: Skip NULL packets 
 - Fix:  When NAL decoding fails, don't dump the whole decoded thing, limit to 160 bytes.
+- Fix: Modify Autoconf scripts to generate tarball for mac from `/package_creators/tarball.sh` 
+  and include GUI files in tarball
 
 
 

--- a/docs/README.TXT
+++ b/docs/README.TXT
@@ -38,6 +38,7 @@ Google Code-in 2016 students
 
 Google Summer of Code 2017 students
 - Diptanshu Jamgade
+- Mayank Gupta
 
 License
 -------

--- a/linux/Makefile.am
+++ b/linux/Makefile.am
@@ -269,7 +269,7 @@ ccextractor_SOURCES = \
 				../src/wrappers/wrapper.h
 				
 
-ccextractor_CFLAGS = -std=gnu99 -s  -Wno-write-strings -D_FILE_OFFSET_BITS=64 -DVERSION_FILE_PRESENT 
+ccextractor_CFLAGS = -std=gnu99 -Wno-write-strings -D_FILE_OFFSET_BITS=64 -DVERSION_FILE_PRESENT 
 
 ccextractor_CPPFLAGS =-I../src/lib_ccx/ -I../src/gpacmp4/ -I../src/libpng/ -I../src/zlib/ -I../src/zvbi/ -I../src/lib_hash/ -I../src/protobuf-c/ -I../src/utf8proc/ -I../src/
 
@@ -277,7 +277,12 @@ ccextractor_CPPFLAGS =-I../src/lib_ccx/ -I../src/gpacmp4/ -I../src/libpng/ -I../
 ccextractor_LDADD=-lm
 
 if SYS_IS_LINUX
-ccextractor_CFLAGS += -O3 -DGPAC_CONFIG_LINUX
+ccextractor_CFLAGS += -O3 -s -DGPAC_CONFIG_LINUX
+endif
+
+if SYS_IS_MAC
+ccextractor_CFLAGS += -DPAC_CONFIG_DARWIN -Dfopen64=fopen -Dopen64=open -Dlseek64=lseek
+ccextractor_LDADD += -liconv -lz 
 endif
 
 if HARDSUBX_IS_ENABLED
@@ -317,7 +322,7 @@ ccextractor_LDADD += $(TESS_LIB)
 ccextractor_LDADD += $(LEPT_LIB)
 endif
 
-EXTRA_DIST = ../src/gpacmp4/gpac/sync_layer.h ../src/lib_ccx/ccfont2.xbm ../src/utf8proc/utf8proc_data.c
+EXTRA_DIST = ../src/gpacmp4/gpac/sync_layer.h ../src/lib_ccx/ccfont2.xbm ../src/utf8proc/utf8proc_data.c fonts/ icon/
 
 #For GUI
 if BUILD_WITH_GUI
@@ -330,6 +335,7 @@ ccextractorGUI_SOURCES = \
 				../src/GUI/activity.h \
 				../src/GUI/terminal.c \
 				../src/GUI/preview.c \
+				../src/GUI/preview.h \
 				../src/GUI/ccx_cli_thread.c \
 				../src/GUI/ccx_cli_thread.h \
 				../src/GUI/command_builder.c \
@@ -354,8 +360,17 @@ ccextractorGUI_LDADD = ${glfw3_LIBS}
 
 if SYS_IS_LINUX
 ccextractorGUI_CFLAGS += -s -O3 -DUNIX
+ccextractorGUI_CFLAGS += ${glew_CFLAGS}
 ccextractorGUI_LDADD += ${glew_LIBS}
 ccextractorGUI_LDADD += -lX11 -lXinerama -lXcursor -lXi -lXrandr -lXxf86vm -lm -ldl -lpthread
+endif
+
+if SYS_IS_MAC
+ccextractorGUI_CFLAGS += -O3 -DUNIX
+ccextractorGUI_CFLAGS += ${glew_CFLAGS}
+ccextractorGUI_LDADD += ${glew_LIBS}
+ccextractorGUI_LDFLAGS = -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo
+ccextractorGUI_LDADD += -lglfw  -lm -L/usr/local/lib -lpthread
 endif
 
 if HARDSUBX_IS_ENABLED
@@ -363,6 +378,8 @@ if OCR_IS_ENABLED
 ccextractorGUI_CFLAGS += -DENABLE_OCR 
 endif
 endif
+
+EXTRA_DIST += ../icon/ ../fonts/
 
 endif
 

--- a/linux/configure.ac
+++ b/linux/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([CCExtractor], [0.85], [carlos@ccextractor.org])
+AC_INIT([CCExtractor], [0.86], [carlos@ccextractor.org])
 AC_CONFIG_AUX_DIR([build-conf])
 AC_CONFIG_SRCDIR([../src/ccextractor.c])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
@@ -113,6 +113,7 @@ AM_CONDITIONAL(FFMPEG_IS_ENABLED, [ test x$ffmpeg = xtrue ])
 AM_CONDITIONAL(TESSERACT_PRESENT, [ test ! -z  `pkg-config --libs-only-l --silence-errors tesseract` ])
 AM_CONDITIONAL(TESSERACT_PRESENT_RPI, [ test -d "/usr/include/tesseract" && test `ls -A /usr/include/tesseract | wc -l` -gt 0 ])
 AM_CONDITIONAL(SYS_IS_LINUX, [ test `uname -s` = "Linux"])
+AM_CONDITIONAL(SYS_IS_MAC, [ test `uname -s` = "Darwin"])
 AM_CONDITIONAL(BUILD_WITH_GUI, [test "x$with_gui" = "xyes"])
 
 AC_CONFIG_FILES([Makefile])

--- a/mac/Makefile.am
+++ b/mac/Makefile.am
@@ -269,12 +269,16 @@ ccextractor_SOURCES = \
 				../src/wrappers/wrapper.h
 				
 
-ccextractor_CFLAGS = -std=gnu99 -s  -Wno-write-strings -D_FILE_OFFSET_BITS=64 -DVERSION_FILE_PRESENT 
+ccextractor_CFLAGS = -std=gnu99 -Wno-write-strings -D_FILE_OFFSET_BITS=64 -DVERSION_FILE_PRESENT 
 
 ccextractor_CPPFLAGS =-I../src/lib_ccx/ -I../src/gpacmp4/ -I../src/libpng/ -I../src/zlib/ -I../src/zvbi/ -I../src/lib_hash/ -I../src/protobuf-c/ -I../src/utf8proc/ -I../src/
 
 
 ccextractor_LDADD=-lm
+
+if SYS_IS_LINUX
+ccextractor_CFLAGS += -O3 -s -DGPAC_CONFIG_LINUX
+endif
 
 if SYS_IS_MAC
 ccextractor_CFLAGS += -DPAC_CONFIG_DARWIN -Dfopen64=fopen -Dopen64=open -Dlseek64=lseek
@@ -283,16 +287,15 @@ endif
 
 if HARDSUBX_IS_ENABLED
 ccextractor_CFLAGS += -DENABLE_HARDSUBX
-AV_CPPFLAG= ${libavcodec_CFLAGS}
-AV_CPPFLAG+= ${libavformat_CFLAGS}
-AV_CPPFLAG+= ${libavutil_CFALGS}
-AV_CPPFLAG+= ${libswscale_CFLAGS}
+ccextractor_CPPFLAGS+= ${libavcodec_CFLAGS}
+ccextractor_CPPFLAGS+= ${libavformat_CFLAGS}
+ccextractor_CPPFLAGS+= ${libavutil_CFALGS}
+ccextractor_CPPFLAGS+= ${libswscale_CFLAGS}
 AV_LIB = ${libavcodec_LIBS}
 AV_LIB += ${libavformat_LIBS}
 AV_LIB += ${libavutil_LIBS}
 AV_LIB += ${libswscale_LIBS}
 ccextractor_LDADD += $(AV_LIB)
-ccextractor_CPPFLAGS+=$(AV_CPPFLAG)
 endif
 
 if OCR_IS_ENABLED
@@ -308,8 +311,8 @@ else
 #fix for raspberry pi not having a pkgconfig file for tesseract
 
 if TESSERACT_PRESENT_RPI
-ccextractor_LDADD += -ltesseract
-ccextractor_CPPFLAGS += -I/usr/include/tesseract
+TESS_LIB = -ltesseract
+TESS_CPPFLAG = -I/usr/include/tesseract
 endif
 endif
 
@@ -319,7 +322,7 @@ ccextractor_LDADD += $(TESS_LIB)
 ccextractor_LDADD += $(LEPT_LIB)
 endif
 
-EXTRA_DIST = ../src/gpacmp4/gpac/sync_layer.h ../src/lib_ccx/ccfont2.xbm ../src/utf8proc/utf8proc_data.c
+EXTRA_DIST = ../src/gpacmp4/gpac/sync_layer.h ../src/lib_ccx/ccfont2.xbm ../src/utf8proc/utf8proc_data.c fonts/ icon/
 
 #For GUI
 if BUILD_WITH_GUI
@@ -332,6 +335,7 @@ ccextractorGUI_SOURCES = \
 				../src/GUI/activity.h \
 				../src/GUI/terminal.c \
 				../src/GUI/preview.c \
+				../src/GUI/preview.h \
 				../src/GUI/ccx_cli_thread.c \
 				../src/GUI/ccx_cli_thread.h \
 				../src/GUI/command_builder.c \
@@ -350,12 +354,23 @@ ccextractorGUI_SOURCES = \
 
 ccextractorGUI_CFLAGS = -std=gnu99
 
+
 ccextractorGUI_LDADD = ${glfw3_LIBS}
+
+
+if SYS_IS_LINUX
+ccextractorGUI_CFLAGS += -s -O3 -DUNIX
+ccextractorGUI_CFLAGS += ${glew_CFLAGS}
+ccextractorGUI_LDADD += ${glew_LIBS}
+ccextractorGUI_LDADD += -lX11 -lXinerama -lXcursor -lXi -lXrandr -lXxf86vm -lm -ldl -lpthread
+endif
 
 if SYS_IS_MAC
 ccextractorGUI_CFLAGS += -O3 -DUNIX
-ccextractorgui_LDFLAGS = -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo
-ccextractorgui_LDADD += -lglfw  -lm -L/usr/local/lib -lpthread
+ccextractorGUI_CFLAGS += ${glew_CFLAGS}
+ccextractorGUI_LDADD += ${glew_LIBS}
+ccextractorGUI_LDFLAGS = -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo
+ccextractorGUI_LDADD += -lm -L/usr/local/lib -lpthread
 endif
 
 if HARDSUBX_IS_ENABLED
@@ -364,4 +379,7 @@ ccextractorGUI_CFLAGS += -DENABLE_OCR
 endif
 endif
 
+EXTRA_DIST += ../icon/ ../fonts/
+
 endif
+

--- a/mac/configure.ac
+++ b/mac/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([CCExtractor], [0.85], [carlos@ccextractor.org])
+AC_INIT([CCExtractor], [0.86], [carlos@ccextractor.org])
 AC_CONFIG_AUX_DIR([build-conf])
 AC_CONFIG_SRCDIR([../src/ccextractor.c])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
@@ -88,7 +88,7 @@ esac],[ffmpeg=false])
 
 AC_ARG_WITH([gui],
 AC_HELP_STRING([--with-gui], [Builds CCExtractor with GUI (requires GLFW and GLEW)]),
-[PKG_CHECK_MODULES([glfw3], [glfw3])],
+[PKG_CHECK_MODULES([glfw3], [glfw3]) && PKG_CHECK_MODULES([glew], [glew])],
 [with_gui=no])
 
 
@@ -112,6 +112,7 @@ AM_CONDITIONAL(OCR_IS_ENABLED, [ test x$ocr = xtrue || test x$hardsubx = xtrue ]
 AM_CONDITIONAL(FFMPEG_IS_ENABLED, [ test x$ffmpeg = xtrue ])
 AM_CONDITIONAL(TESSERACT_PRESENT, [ test ! -z  `pkg-config --libs-only-l --silence-errors tesseract`])
 AM_CONDITIONAL(TESSERACT_PRESENT_RPI, [ test -d "/usr/include/tesseract" && test `ls -A /usr/include/tesseract | wc -l` -gt 0 ])
+AM_CONDITIONAL(SYS_IS_LINUX, [ test `uname -s` = "Linux"])
 AM_CONDITIONAL(SYS_IS_MAC, [ test `uname -s` = "Darwin"])
 AM_CONDITIONAL(BUILD_WITH_GUI, [test "x$with_gui" = "xyes"])
 


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

Modified Autoconf scripts to enable tarball generation for macOS ( and non *NIX systems including macOS).
Also, modified scripts to include GUI resource files (icons and fonts) in tarball as well.
