### PR TITLE
[FEATURE] Histogram in one-minute increments of the number of lines in a subtitle file.

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 0.86
 -----------------
+- New: Added a histogram in one-minute increments of the number of lines in a subtitle.
 - New: Added Autoconf build scripts for CCExtractor to generate makefiles (mac).
 - New: Added Autoconf build scripts for CCExtractor to generate makefiles (linux).
 - New: Added .rpm package generation script.

--- a/src/lib_ccx/ccx_encoders_srt.c
+++ b/src/lib_ccx/ccx_encoders_srt.c
@@ -95,8 +95,11 @@ int write_cc_bitmap_as_srt(struct cc_subtitle *sub, struct encoder_ctx *context)
 	int i = 0;
 	char *str;
 
-	ms_start = sub->start_time;
-	ms_end = sub->end_time;
+	ms_start = sub->start_time + context->subs_delay;
+	ms_end = sub->end_time + context->subs_delay;
+
+    if (ms_start<0) // Drop screens that because of subs_delay start too early
+        return 0;
 
 	if(sub->nb_data == 0 )
 		return 0;

--- a/tools/histogram.py
+++ b/tools/histogram.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python
+# Author   : Harry Yu
+# Email    : harryyunull@gmail.com
+# Link     : https://github.com/harrynull
+
+Version = "1.0.0"
+
+import sys
+import time
+import datetime
+from io import open
+
+class Line:
+    def __init__(self, lines):
+        lines = [line.replace("\n", "").strip() for line in lines]
+        self.id = int(lines[0]) # the first line is the number of the subtile
+        self.start_time, self.end_time = lines[1].split(" --> ")
+        self.content = lines[2:]
+        
+def time_to_minute(time):
+    time_tuple = datetime.datetime.strptime(time[:-4], '%H:%M:%S').timetuple()
+    return time_tuple.tm_hour*60+time_tuple.tm_min
+
+def read_srt_file(filename):
+    lines = []
+    with open(filename, encoding = "utf-8") as file:
+        raw_lines = []
+        for line in file:
+            if line == "\n" or line == "\r\n":
+                lines.append(Line(raw_lines))
+                raw_lines = []
+            else:
+                raw_lines.append(line)
+    return lines
+
+def main():
+    if len(sys.argv)<2:
+        print("{0}: missing file name.\nUse {0} /path/to/srt/file".format(sys.argv[0]))
+        exit()
+    elif len(sys.argv)>2:
+        print("{0}: too many arguments:\nUse {0} /path/to/srt/file".format(sys.argv[0]))
+        exit()
+        
+    print("histogram.py %s Made by Harry Yu" % Version)
+    print("Histogram for %s\n" % sys.argv[1])
+    
+    # Read subtitles from file
+    lines = read_srt_file(sys.argv[1])
+
+    # Count how many subtitles per minute.
+    subtitle_per_minute = {}
+    for line in lines:
+        start_time = time_to_minute(line.start_time)
+        end_time = time_to_minute(line.end_time)
+        for i in range(start_time, end_time + 1):
+            subtitle_per_minute[i]=subtitle_per_minute.get(i, 0) + 1
+            
+    # Print the result
+    for i in range(0, max(subtitle_per_minute.keys())):
+        print("Minute %d\t%d\t%s"%(i,subtitle_per_minute.get(i, 0),"+"*subtitle_per_minute.get(i, 0)))
+    
+    print("\nTotal subtitles: %d"%sum(subtitle_per_minute.values()))
+    
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [X] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

A histogram in one-minute increments of the number of lines in a subtitle file.
It is tested in Python 3.5.4 and Python 2.7.12.