### PR TITLE
[FIX] Fix crash when image passed into OCR is empty

### DIFF
--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -257,7 +257,13 @@ char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* i
 	color_pix_out = TessBaseAPIGetThresholdedImage(ctx->api);
 	if (tess_ret = TessBaseAPIRecognize(ctx->api, NULL)) {
 		mprint("\nIn ocr_bitmap: Failed to perform OCR. Skipped.\n");
-		goto ocr_failed;
+
+		pixDestroy(&pix);
+		pixDestroy(&cpix);
+		pixDestroy(&color_pix);
+		pixDestroy(&color_pix_out);
+		
+		return NULL;
 	}
 
 	text_out = TessBaseAPIGetUTF8Text(ctx->api);
@@ -498,7 +504,6 @@ char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* i
 	// End Color Detection
 
 	// boxDestroy(crop_points);
-ocr_failed:
 
 	pixDestroy(&pix);
 	pixDestroy(&cpix);


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [X] I am an active contributor to CCExtractor.

---

Fix crash problem mentioned in #840 .
Possibly I will fix other bugs mentioned in that issue in this pr, or I'll open another PR if you want to merge it first.