### PR TITLE
[FIX] Fixed --sentencecap for teletext samples

### DIFF
--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -522,10 +522,12 @@ void telx_case_fix (struct TeletextCtx *context)
 				context->new_sentence = 1;
 				break;
 			default:
-				if (context->new_sentence)
+				if (context->new_sentence && i!=0 && context->page_buffer_cur[i-1]!='\n')
 					context->page_buffer_cur[i] = cctoupper(context->page_buffer_cur[i]);
-				else
+
+				else if(!context->new_sentence && i!=0 && context->page_buffer_cur[i-1] != '\n')
 					context->page_buffer_cur[i] = cctolower(context->page_buffer_cur[i]);
+
 				context->new_sentence = 0;
 				break;
 		}
@@ -793,6 +795,9 @@ void process_page(struct TeletextCtx *ctx, teletext_page_t *page, struct cc_subt
 	}
 	time_reported=0;
 
+	if (ctx->sentence_cap)
+		telx_case_fix(ctx);
+
 	switch (tlt_config.write_format)
 	{
 		case CCX_OF_TRANSCRIPT:
@@ -838,8 +843,6 @@ void process_page(struct TeletextCtx *ctx, teletext_page_t *page, struct cc_subt
 			}
 			break;
 		default:
-			if (ctx->sentence_cap)
-				telx_case_fix(ctx);
 			add_cc_sub_text(sub, ctx->page_buffer_cur, page->show_timestamp,
 				page->hide_timestamp + 1, NULL, "TLT", CCX_ENC_UTF_8);
 	}


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [X] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Fixes #829
--sentencecap works for the given teletext sample.