### PR TITLE
[Fix] Fix DVB bug (Multiple-line subtitle; Missing last line)

### DIFF
--- a/src/lib_ccx/dvb_subtitle_decoder.c
+++ b/src/lib_ccx/dvb_subtitle_decoder.c
@@ -27,33 +27,33 @@
 #include "ccx_decoders_common.h"
 #include "ocr.h"
 
-#define DVBSUB_PAGE_SEGMENT	 0x10
+#define DVBSUB_PAGE_SEGMENT     0x10
 #define DVBSUB_REGION_SEGMENT   0x11
-#define DVBSUB_CLUT_SEGMENT	 0x12
+#define DVBSUB_CLUT_SEGMENT     0x12
 #define DVBSUB_OBJECT_SEGMENT   0x13
 #define DVBSUB_DISPLAYDEFINITION_SEGMENT 0x14
 #define DVBSUB_DISPLAY_SEGMENT  0x80
 
 #define SCALEBITS 10
 #define ONE_HALF  (1 << (SCALEBITS - 1))
-#define FIX(x)	((int) ((x) * (1<<SCALEBITS) + 0.5))
+#define FIX(x)    ((int) ((x) * (1<<SCALEBITS) + 0.5))
 
 #define YUV_TO_RGB1_CCIR(cb1, cr1)\
 {\
-	cb = (cb1) - 128;\
-	cr = (cr1) - 128;\
-	r_add = FIX(1.40200*255.0/224.0) * cr + ONE_HALF;\
-	g_add = - FIX(0.34414*255.0/224.0) * cb - FIX(0.71414*255.0/224.0) * cr + \
-			ONE_HALF;\
-	b_add = FIX(1.77200*255.0/224.0) * cb + ONE_HALF;\
+    cb = (cb1) - 128;\
+    cr = (cr1) - 128;\
+    r_add = FIX(1.40200*255.0/224.0) * cr + ONE_HALF;\
+    g_add = - FIX(0.34414*255.0/224.0) * cb - FIX(0.71414*255.0/224.0) * cr + \
+            ONE_HALF;\
+    b_add = FIX(1.77200*255.0/224.0) * cb + ONE_HALF;\
 }
 
 #define YUV_TO_RGB2_CCIR(r, g, b, y1)\
 {\
-	y = ((y1) - 16) * FIX(255.0/219.0);\
-	r = cm[(y + r_add) >> SCALEBITS];\
-	g = cm[(y + g_add) >> SCALEBITS];\
-	b = cm[(y + b_add) >> SCALEBITS];\
+    y = ((y1) - 16) * FIX(255.0/219.0);\
+    r = cm[(y + r_add) >> SCALEBITS];\
+    g = cm[(y + g_add) >> SCALEBITS];\
+    b = cm[(y + b_add) >> SCALEBITS];\
 }
 
 #define times4(x) x, x, x, x
@@ -213,8 +213,8 @@ typedef struct GetBitContext
 /**
  * Initialize GetBitContext.
  * @param buffer bitstream buffer, must be FF_INPUT_BUFFER_PADDING_SIZE bytes
- *	      larger than the actual read bits because some optimized bitstream
- *	      readers read 32 or 64 bit at once and could read over the end
+ *        larger than the actual read bits because some optimized bitstream
+ *        readers read 32 or 64 bit at once and could read over the end
  * @param bit_size the size of the buffer in bits
  * @return 0 on success, AVERROR_INVALIDDATA if the buffer_size would overflow.
  */
@@ -415,11 +415,11 @@ static void delete_regions(DVBSubContext *ctx)
 
 /**
  * @param composition_id composition-page_id found in Subtitle descriptors
- *					     associated with	 subtitle stream in the	PMT
- *					     it could be -1 if not found in PMT.
+ *                       associated with     subtitle stream in the    PMT
+ *                       it could be -1 if not found in PMT.
  * @param ancillary_id ancillary-page_id found in Subtitle descriptors
- *					   associated with	 subtitle stream in the	PMT.
- *					   it could be -1 if not found in PMT.
+ *                     associated with     subtitle stream in the    PMT.
+ *                       it could be -1 if not found in PMT.		
  *
  * @return DVB context kept as void* for abstraction
  *
@@ -1567,13 +1567,13 @@ static int write_dvb_sub(struct lib_cc_decode *dec_ctx, struct cc_subtitle *sub)
 	return 0;
 }
 /**
- * @param dvb_ctx   PreInitialized DVB context using DVB
- * @param buf       buffer containing segment data, first sync byte need to 0x0f.
- *	                does not include data_identifier and subtitle_stream_id.
- * @param buf_size  size of buf buffer
- * @param sub		output subtitle data
+ * @param dvb_ctx    PreInitialized DVB context using DVB
+ * @param buf        buffer containing segment data, first sync byte need to 0x0f.
+ *                   does not include data_identifier and subtitle_stream_id.
+ * @param buf_size   size of buf buffer
+ * @param sub        output subtitle data
  *
- * @return		   -1 on error
+ * @return           -1 on error
  */
 int dvbsub_decode(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, const unsigned char *buf, int buf_size, struct cc_subtitle *sub)
 {
@@ -1648,11 +1648,9 @@ int dvbsub_decode(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, co
 						segment_length);
 				break;
 			case DVBSUB_DISPLAY_SEGMENT: //when we get a display segment, we save the current page
-
 				if (enc_ctx->write_previous) //this condition is used for the first subtitle - write_previous will be 0 first so we don't encode a non-existing previous sub
 				{
 					sub->prev->end_time = (dec_ctx->timing->current_pts - dec_ctx->timing->min_pts) / (MPEG_CLOCK_FREQ / 1000); //we set the end time of the previous sub the current pts
-					
 					encode_sub(enc_ctx->prev, sub->prev); //we encode it
 					enc_ctx->srt_counter = enc_ctx->prev->srt_counter; //for dvb subs we need to update the current srt counter because we always encode the previous subtitle (and the counter is increased for the previous context)
 					enc_ctx->prev_start = enc_ctx->prev->prev_start;
@@ -1661,8 +1659,6 @@ int dvbsub_decode(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, co
 						enc_ctx->wrote_webvtt_header = 1;
 					}
 				}
-
-				//write_dvb_sub(dec_ctx, sub);
 				/* copy previous encoder context*/
 				free_encoder_context(enc_ctx->prev);
 				enc_ctx->prev = NULL;  
@@ -1681,7 +1677,6 @@ int dvbsub_decode(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, co
 				sub->prev->start_time = (dec_ctx->timing->current_pts - dec_ctx->timing->min_pts) / (MPEG_CLOCK_FREQ / 1000); //we set the start time of the previous sub the current pts
 				
 				write_dvb_sub(dec_ctx->prev, sub->prev); //we write the current dvb sub to update decoder context
-				
 				enc_ctx->write_previous = 1; //we update our boolean value so next time the program reaches this block of code, it encodes the previous sub
 				got_segment |= 16;
 				break;

--- a/src/lib_ccx/dvb_subtitle_decoder.c
+++ b/src/lib_ccx/dvb_subtitle_decoder.c
@@ -27,33 +27,33 @@
 #include "ccx_decoders_common.h"
 #include "ocr.h"
 
-#define DVBSUB_PAGE_SEGMENT     0x10
+#define DVBSUB_PAGE_SEGMENT	 0x10
 #define DVBSUB_REGION_SEGMENT   0x11
-#define DVBSUB_CLUT_SEGMENT     0x12
+#define DVBSUB_CLUT_SEGMENT	 0x12
 #define DVBSUB_OBJECT_SEGMENT   0x13
 #define DVBSUB_DISPLAYDEFINITION_SEGMENT 0x14
 #define DVBSUB_DISPLAY_SEGMENT  0x80
 
 #define SCALEBITS 10
 #define ONE_HALF  (1 << (SCALEBITS - 1))
-#define FIX(x)    ((int) ((x) * (1<<SCALEBITS) + 0.5))
+#define FIX(x)	((int) ((x) * (1<<SCALEBITS) + 0.5))
 
 #define YUV_TO_RGB1_CCIR(cb1, cr1)\
 {\
-    cb = (cb1) - 128;\
-    cr = (cr1) - 128;\
-    r_add = FIX(1.40200*255.0/224.0) * cr + ONE_HALF;\
-    g_add = - FIX(0.34414*255.0/224.0) * cb - FIX(0.71414*255.0/224.0) * cr + \
-            ONE_HALF;\
-    b_add = FIX(1.77200*255.0/224.0) * cb + ONE_HALF;\
+	cb = (cb1) - 128;\
+	cr = (cr1) - 128;\
+	r_add = FIX(1.40200*255.0/224.0) * cr + ONE_HALF;\
+	g_add = - FIX(0.34414*255.0/224.0) * cb - FIX(0.71414*255.0/224.0) * cr + \
+			ONE_HALF;\
+	b_add = FIX(1.77200*255.0/224.0) * cb + ONE_HALF;\
 }
 
 #define YUV_TO_RGB2_CCIR(r, g, b, y1)\
 {\
-    y = ((y1) - 16) * FIX(255.0/219.0);\
-    r = cm[(y + r_add) >> SCALEBITS];\
-    g = cm[(y + g_add) >> SCALEBITS];\
-    b = cm[(y + b_add) >> SCALEBITS];\
+	y = ((y1) - 16) * FIX(255.0/219.0);\
+	r = cm[(y + r_add) >> SCALEBITS];\
+	g = cm[(y + g_add) >> SCALEBITS];\
+	b = cm[(y + b_add) >> SCALEBITS];\
 }
 
 #define times4(x) x, x, x, x
@@ -213,8 +213,8 @@ typedef struct GetBitContext
 /**
  * Initialize GetBitContext.
  * @param buffer bitstream buffer, must be FF_INPUT_BUFFER_PADDING_SIZE bytes
- *        larger than the actual read bits because some optimized bitstream
- *        readers read 32 or 64 bit at once and could read over the end
+ *	      larger than the actual read bits because some optimized bitstream
+ *	      readers read 32 or 64 bit at once and could read over the end
  * @param bit_size the size of the buffer in bits
  * @return 0 on success, AVERROR_INVALIDDATA if the buffer_size would overflow.
  */
@@ -415,11 +415,11 @@ static void delete_regions(DVBSubContext *ctx)
 
 /**
  * @param composition_id composition-page_id found in Subtitle descriptors
- *                       associated with     subtitle stream in the    PMT
- *                       it could be -1 if not found in PMT.
+ *					     associated with	 subtitle stream in the	PMT
+ *					     it could be -1 if not found in PMT.
  * @param ancillary_id ancillary-page_id found in Subtitle descriptors
- *                     associated with     subtitle stream in the    PMT.
- *                       it could be -1 if not found in PMT.
+ *					   associated with	 subtitle stream in the	PMT.
+ *					   it could be -1 if not found in PMT.
  *
  * @return DVB context kept as void* for abstraction
  *
@@ -1460,16 +1460,16 @@ static int write_dvb_sub(struct lib_cc_decode *dec_ctx, struct cc_subtitle *sub)
 	DVBSubRegion *region;
 	DVBSubRegionDisplay *display;
 	DVBSubCLUT *clut;
-    DVBSubDisplayDefinition *display_def;
-    struct cc_bitmap *rect = NULL;
+	DVBSubDisplayDefinition *display_def;
+	struct cc_bitmap *rect = NULL;
 	uint32_t *clut_table;
 	int offset_x=0, offset_y=0;
 	int ret = 0;
 
 	ctx = (DVBSubContext *) dec_ctx->private_data;
 
-    display_def = ctx->display_definition;
-    sub->type = CC_BITMAP;
+	display_def = ctx->display_definition;
+	sub->type = CC_BITMAP;
 	sub->lang_index = ctx->lang_index;
 
 	if (display_def)
@@ -1551,9 +1551,9 @@ static int write_dvb_sub(struct lib_cc_decode *dec_ctx, struct cc_subtitle *sub)
 				rect->ocr_text = ocr_str;
 			else
 				rect->ocr_text = NULL;
-            if (ccx_options.dvb_debug_traces_to_stdout) {
-                mprint("\nOCR Result: %s\n", rect->ocr_text ? rect->ocr_text : "NULL");
-            }
+			if (ccx_options.dvb_debug_traces_to_stdout) {
+				mprint("\nOCR Result: %s\n", rect->ocr_text ? rect->ocr_text : "NULL");
+			}
 		}
 		else
 		{
@@ -1567,13 +1567,13 @@ static int write_dvb_sub(struct lib_cc_decode *dec_ctx, struct cc_subtitle *sub)
 	return 0;
 }
 /**
- * @param dvb_ctx    PreInitialized DVB context using DVB
- * @param buf        buffer containing segment data, first sync byte need to 0x0f.
- *                   does not include data_identifier and subtitle_stream_id.
- * @param buf_size   size of buf buffer
- * @param sub        output subtitle data
+ * @param dvb_ctx   PreInitialized DVB context using DVB
+ * @param buf       buffer containing segment data, first sync byte need to 0x0f.
+ *	                does not include data_identifier and subtitle_stream_id.
+ * @param buf_size  size of buf buffer
+ * @param sub		output subtitle data
  *
- * @return           -1 on error
+ * @return		   -1 on error
  */
 int dvbsub_decode(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, const unsigned char *buf, int buf_size, struct cc_subtitle *sub)
 {
@@ -1652,8 +1652,8 @@ int dvbsub_decode(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, co
 				if (enc_ctx->write_previous) //this condition is used for the first subtitle - write_previous will be 0 first so we don't encode a non-existing previous sub
 				{
 					sub->prev->end_time = (dec_ctx->timing->current_pts - dec_ctx->timing->min_pts) / (MPEG_CLOCK_FREQ / 1000); //we set the end time of the previous sub the current pts
-                    
-                    encode_sub(enc_ctx->prev, sub->prev); //we encode it
+					
+					encode_sub(enc_ctx->prev, sub->prev); //we encode it
 					enc_ctx->srt_counter = enc_ctx->prev->srt_counter; //for dvb subs we need to update the current srt counter because we always encode the previous subtitle (and the counter is increased for the previous context)
 					enc_ctx->prev_start = enc_ctx->prev->prev_start;
 					sub->prev->got_output = 0;
@@ -1662,7 +1662,7 @@ int dvbsub_decode(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, co
 					}
 				}
 
-                //write_dvb_sub(dec_ctx, sub);
+				//write_dvb_sub(dec_ctx, sub);
 				/* copy previous encoder context*/
 				free_encoder_context(enc_ctx->prev);
 				enc_ctx->prev = NULL;  
@@ -1682,7 +1682,7 @@ int dvbsub_decode(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, co
 				
 				write_dvb_sub(dec_ctx->prev, sub->prev); //we write the current dvb sub to update decoder context
 				
-                enc_ctx->write_previous = 1; //we update our boolean value so next time the program reaches this block of code, it encodes the previous sub
+				enc_ctx->write_previous = 1; //we update our boolean value so next time the program reaches this block of code, it encodes the previous sub
 				got_segment |= 16;
 				break;
 			default:

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -902,6 +902,7 @@ int general_loop(struct lib_ccx_ctx *ctx)
 		if(!ctx->multiprogram)
 		{
 			struct cap_info* cinfo = NULL;
+			struct encoder_ctx *enc_ctx = NULL;
 			// Find most promising stream: teletext, DVB, ISDB, ATSC, in that order
 			int pid = get_best_stream(ctx->demux_ctx);
 			if(pid < 0)
@@ -948,7 +949,6 @@ int general_loop(struct lib_ccx_ctx *ctx)
 			}
 
 			cinfo = get_cinfo(ctx->demux_ctx, pid);
-			struct encoder_ctx *enc_ctx = NULL;
 			enc_ctx = update_encoder_list_cinfo(ctx, cinfo);
 			dec_ctx = update_decoder_list_cinfo(ctx, cinfo);
 			dec_ctx->dtvcc->encoder = (void *)enc_ctx; //WARN: otherwise cea-708 will not work
@@ -1318,6 +1318,6 @@ int rcwt_loop(struct lib_ccx_ctx *ctx)
 	} // end while(1)
 
 	dbg_print(CCX_DMT_PARSE, "Processed %d bytes\n", bread);
-		free(parsebuf);
+	free(parsebuf);
 	return caps;
 }

--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -583,6 +583,7 @@ char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* i
 	pixDestroy(&cpix);
 	pixDestroy(&color_pix);
 	pixDestroy(&color_pix_out);
+    
 	return text_out;
 }
 

--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -241,6 +241,7 @@ char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* i
 			ppixel++;
 		}
 	}
+	
 	BOX *crop_points = ignore_alpha_at_edge(copy->alpha, copy->data, w, h, color_pix, &color_pix_out);
 #ifdef OCR_DEBUG
 	{
@@ -252,6 +253,7 @@ char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* i
 	i++;
 	}
 #endif
+
 	cpix = pixConvertRGBToGray(cpix, 0.0, 0.0, 0.0); // Abhinav95: Converting image to grayscale for OCR to avoid issues with transparency
 	TessBaseAPISetImage2(ctx->api, cpix);
 	color_pix_out = TessBaseAPIGetThresholdedImage(ctx->api);
@@ -484,19 +486,91 @@ char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* i
 				TessDeleteText(word);
 			} while (TessPageIteratorNext((TessPageIterator *)ri,level));
 
-			//Write closing </font> at the end of the line
+			// Write missing <font> or </font> for each line
 			if(ccx_options.write_format==CCX_OF_SRT ||
 			   ccx_options.write_format==CCX_OF_WEBVTT)
 			{
-				char *substr = "</font>";
-				char *text_out_copy = strdup(text_out);
+				const char *closing_font = "</font>";
+				int length_closing_font = 7; // exclude '\0'
+
+				char *line_start = text_out;
+				int length = strlen(text_out) + length_closing_font * 10;  // usually enough
+				char *new_text_out = malloc(length);
+				char *new_text_out_iter = new_text_out;
+
+				char *last_valid_char = text_out; // last character that is not '\n' or '\0'
+
+				for (char *iter = text_out; *iter; iter++)
+					if (*iter != '\n') last_valid_char = iter;
+
+				char *last_font_tag = text_out; // Last <font> in this line
+				char *last_font_tag_end = NULL;
+
+				while (1) {
+
+					char *line_end = line_start;
+					while (*line_end && *line_end != '\n') line_end++; // find the line end
+
+					if (new_text_out_iter != new_text_out) {
+						memcpy(new_text_out_iter, "\n", 1);
+						new_text_out_iter += 1;
+					}
+
+					// realloc if memory allocated may be not enough
+					int length_needed = (new_text_out_iter - new_text_out) +
+						(line_end - line_start) +
+						length_closing_font + 32;
+
+					if (length_needed > length) {
+
+						length = max(length * 1.5, length_needed);
+						long diff = new_text_out_iter - new_text_out;
+						new_text_out = realloc(new_text_out, length);
+						new_text_out_iter = new_text_out + diff;
+						
+					}
+
+					// Add <font> to the beginning of the line if it is missing
+					// Assume there is always a <font> at the beginning of the first line
+					if (last_font_tag_end && strstr(line_start, "<font color=\"#") != line_start) {
+						if ((new_text_out_iter - new_text_out) +
+							(last_font_tag_end - last_font_tag) > length) {
+							fatal(CCX_COMMON_EXIT_BUG_BUG, "In ocr_bitmap: Running out of memory. It shouldn't happen. Please report.\n", errno);
+						}
+						memcpy(new_text_out_iter, last_font_tag, last_font_tag_end - last_font_tag);
+						new_text_out_iter += last_font_tag_end - last_font_tag;
+					}
+
+					// Find the last <font> tag
+					char *font_tag = line_start;
+					while (1) {
+
+						font_tag = strstr(font_tag + 1, "<font color=\"#");
+						if (font_tag == NULL || font_tag > line_end) break;
+						last_font_tag = font_tag;
+
+					}
+					last_font_tag_end = strstr(last_font_tag, ">") + 1;
+
+					// Copy the content of the subtitle
+					memcpy(new_text_out_iter, line_start, line_end - line_start);
+					new_text_out_iter += line_end - line_start;
+
+					// Add </font> if it is indeed missing
+					if (line_end - line_start < length_closing_font ||
+						strncmp(line_start, closing_font, length_closing_font)) {
+						
+						memcpy(new_text_out_iter, closing_font, length_closing_font);
+						new_text_out_iter += length_closing_font;
+
+					}
+
+					if (line_end - 1 == last_valid_char) break;
+					line_start = line_end + 1;
+				}
+				*new_text_out_iter = '\0';
 				TessDeleteText(text_out);
-				text_out = malloc(strlen(text_out_copy)+strlen(substr)+1);
-				memset(text_out,0,strlen(text_out_copy)+strlen(substr)+1);
-				char *str = strtok(text_out_copy,"\n");
-				strcpy(text_out,str);
-				strcpy(text_out+strlen(str),substr);
-			// printf("%s\n", text_out);
+				text_out = new_text_out;
 			}
 		}
 		TessResultIteratorDelete(ri);
@@ -509,7 +583,6 @@ char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* i
 	pixDestroy(&cpix);
 	pixDestroy(&color_pix);
 	pixDestroy(&color_pix_out);
-
 	return text_out;
 }
 
@@ -738,7 +811,11 @@ void add_ocrtext2str(char *dest, char *src, const char *crlf, unsigned crlf_leng
 {
 	while (*dest != '\0')
 		dest++;
-	while(*src != '\0' && *src != '\n')
+	char *end = src;
+	for (char* c = src; *c; c++) {
+		if (c != '\n') end = c;
+	}
+	while(src != end + 1)
 	{
 		*dest = *src;
 		src++;


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [X] I am an active contributor to CCExtractor.

---
Fix #840 
- Fix the bug that only the first line of text from each caption is shown.
- Fix the bug that the last caption is missing.
- The shifting time isn't really a problem because it is indeed shifting a little bit in the video and the conversion from fps->1000 will also cause some precision problems.
![1](https://user-images.githubusercontent.com/7413706/34340034-7e8e7b9c-e9b7-11e7-911c-7ebd073f7927.png)
