### PR TITLE
[Fix] Put OCR specific code inside ifdef

### DIFF
--- a/src/lib_ccx/dvb_subtitle_decoder.c
+++ b/src/lib_ccx/dvb_subtitle_decoder.c
@@ -1680,21 +1680,6 @@ int dvbsub_decode(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, co
 				enc_ctx->write_previous = 1; //we update our boolean value so next time the program reaches this block of code, it encodes the previous sub
 				got_segment |= 16;
 
-				if (ccx_options.dvb_debug_traces_to_stdout) {
-					if (sub->prev) {
-						struct cc_bitmap* content_prev = sub->prev->data;
-						mprint("\nPrevious subtitle %x (%s)\nStart time: %lld; End time: %lld",
-							sub->prev, content_prev ?
-							(content_prev->ocr_text ? content_prev->ocr_text : "NULL OCR") : "NULL DATA",
-							sub->prev->start_time, sub->prev->end_time);
-					}
-					struct cc_bitmap* content = sub->data;
-					mprint("\nCurrent subtitle %x (%s)\nStart time: %lld; End time: %lld\n",
-						sub, content ?
-						(content->ocr_text ? content->ocr_text : "NULL OCR") : "NULL DATA",
-						sub->start_time, sub->end_time);
-				}
-
 				break;
 			default:
 				mprint("Subtitling segment type 0x%x, page id %d, length %d\n",

--- a/src/lib_ccx/dvb_subtitle_decoder.c
+++ b/src/lib_ccx/dvb_subtitle_decoder.c
@@ -1679,7 +1679,22 @@ int dvbsub_decode(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, co
 				write_dvb_sub(dec_ctx->prev, sub->prev); //we write the current dvb sub to update decoder context
 				enc_ctx->write_previous = 1; //we update our boolean value so next time the program reaches this block of code, it encodes the previous sub
 				got_segment |= 16;
-
+#ifdef ENABLE_OCR
+				if (ccx_options.dvb_debug_traces_to_stdout) {
+					if (sub->prev) {
+						struct cc_bitmap* content_prev = sub->prev->data;
+						mprint("\nPrevious subtitle %x (%s)\nStart time: %lld; End time: %lld",
+							sub->prev, content_prev ?
+							(content_prev->ocr_text ? content_prev->ocr_text : "NULL OCR") : "NULL DATA",
+							sub->prev->start_time, sub->prev->end_time);
+					}
+					struct cc_bitmap* content = sub->data;
+					mprint("\nCurrent subtitle %x (%s)\nStart time: %lld; End time: %lld\n",
+						sub, content ?
+						(content->ocr_text ? content->ocr_text : "NULL OCR") : "NULL DATA",
+						sub->start_time, sub->end_time);
+				}
+#endif
 				break;
 			default:
 				mprint("Subtitling segment type 0x%x, page id %d, length %d\n",


### PR DESCRIPTION
Removed debug code. No idea why it causes travis fails to build

Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [X] I am an active contributor to CCExtractor.

---

Put debug code into ifdef to avoid failing compilation when OCR is disabled.