### PR TITLE
[IMPROVEMENT] Checks for text before newlines on DVB subtitles

### DIFF
--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -810,20 +810,39 @@ int compare_rect_by_ypos(const void*p1, const void *p2, void*arg)
 
 void add_ocrtext2str(char *dest, char *src, const char *crlf, unsigned crlf_length)
 {
+	char *line_scan;
+	int char_found;
 	while (*dest != '\0')
-		dest++;
-	char *end = src;
-	for (char* c = src; *c; c++) {
-		if (c != '\n') end = c;
-	}
-	while(src != end + 1)
+			dest++;
+	while (*src != '\0')
 	{
+		//checks if a line has actual content in it before adding it
+		if (*src == '\n') {
+			char_found = 0;
+			line_scan = src + 1;
+			//multiple blocks of newlines
+			while (*(line_scan) == '\n') {
+				line_scan++;
+				src++;
+			}
+			//empty lines
+			while (*line_scan != '\n' && *line_scan != '\0') {
+				if (*line_scan > 32) {
+					char_found = 1;
+					break;
+				}
+				line_scan++;
+			}
+			if (!char_found) {
+				src = line_scan;
+			}
+		}
 		*dest = *src;
 		src++;
 		dest++;
 	}
 	memcpy(dest, crlf, crlf_length);
-	dest[crlf_length] = 0;	
+	dest[crlf_length] = 0;
 	/*
 	*dest++ = '\n';
 	*dest = '\0'; */


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [X] I have used CCExtractor just a couple of times.

---

Tesseract caused some previous problems with lots of newlines, which would cause issues with output being full of empty and useless whitespace. PR checks each line of text for any content, and moves up to the next line if there is no content.