### PR TITLE
[FIX] Fix a bug that caused -out=spupng sometimes crashes

### DIFF
--- a/src/lib_ccx/ccx_encoders_spupng.c
+++ b/src/lib_ccx/ccx_encoders_spupng.c
@@ -11,7 +11,7 @@ void draw_str(char *str, uint8_t * canvas, int rowstride)
 	int i = 0;
 	pen[0] = COL_BLACK;
 	pen[1] = COL_WHITE;
-	for(ptr = str; ptr != '\0';ptr++)
+	for (ptr = str; *ptr != '\0'; ptr++)
 	{
 		cell = canvas + ((i+1) * CCW);
 		draw_char_indexed(cell, rowstride, pen, 0, 0, 0);


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [X] I am an active contributor to CCExtractor.

---

Fix a bug that caused -out=spupng sometimes crashes
