### PR TITLE
[FIX] Fix a heap corruption in add_ocrtext2str

### DIFF
--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -836,6 +836,7 @@ void add_ocrtext2str(char *dest, char *src, const char *crlf, unsigned crlf_leng
 			if (!char_found) {
 				src = line_scan;
 			}
+			if (*src == '\0') break;
 		}
 		*dest = *src;
 		src++;


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [X] I am an active contributor to CCExtractor.

---

Fix a heap corruption in add_ocrtext2str