### PR TITLE
[FIX] Fix Travis CI not executing `linux/build`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ compiler:
 - gcc
 - clang
 
-install:
+before_install:
 - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then brew install pkg-config autoconf automake libtool tesseract leptonica; fi
 - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then sudo apt-get install -y libcurl4-gnutls-dev tesseract-ocr tesseract-ocr-dev libleptonica-dev autoconf-archive; fi
 - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then sudo apt-get install python-distutils-extra tesseract-ocr tesseract-ocr-eng libopencv-dev libtesseract-dev libleptonica-dev python-all-dev swig libcv-dev python-opencv python-numpy python-setuptools build-essential subversion; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ compiler:
 - gcc
 - clang
 
-
 install:
 - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then brew install pkg-config autoconf automake libtool tesseract leptonica; fi
 - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then sudo apt-get install -y libcurl4-gnutls-dev tesseract-ocr tesseract-ocr-dev libleptonica-dev autoconf-archive; fi
@@ -19,8 +18,8 @@ install:
 - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then git clone https://github.com/tesseract-ocr/tesseract.git; cd tesseract; ./autogen.sh; ./configure --enable-debug; LDFLAGS="-L/usr/local/lib" CFLAGS="-I/usr/local/include" make; sudo make install; sudo ldconfig; cd ..; fi
 
 script:
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd mac; ./build.command; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd mac; ./autogen.sh; ./configure; make; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd mac; ./build.command; cd ..; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd mac; ./autogen.sh; ./configure; make; cd ..; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd linux; ./build; cd ..; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then mkdir build; cd build; cmake ../src/; make; cd ..; fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd linux; ./autogen.sh; ./configure; make; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd linux; ./autogen.sh; ./configure; make; cd ..; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,20 @@ install:
 - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then git clone https://github.com/tesseract-ocr/tesseract.git; cd tesseract; ./autogen.sh; ./configure --enable-debug; LDFLAGS="-L/usr/local/lib" CFLAGS="-I/usr/local/include" make; sudo make install; sudo ldconfig; cd ..; fi
 
 script:
+- pwd
+- ls
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd mac; ./build.command; fi
+
+- pwd
+- ls
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd mac; ./autogen.sh; ./configure; make; fi
+- pwd
+- ls
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd linux; ./build; cd ..; fi
+- pwd
+- ls
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then mkdir build; cd build; cmake ../src/; make; cd ..; fi
+
+- pwd
+- ls
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd linux; ./autogen.sh; ./configure; make; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,24 +15,12 @@ install:
 - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then brew install pkg-config autoconf automake libtool tesseract leptonica; fi
 - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then sudo apt-get install -y libcurl4-gnutls-dev tesseract-ocr tesseract-ocr-dev libleptonica-dev autoconf-archive; fi
 - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then sudo apt-get install python-distutils-extra tesseract-ocr tesseract-ocr-eng libopencv-dev libtesseract-dev libleptonica-dev python-all-dev swig libcv-dev python-opencv python-numpy python-setuptools build-essential subversion; fi
-- if [[ $TRAVIS_OS_NAME == 'linux' ]]; then wget https://github.com/DanBloomberg/leptonica/releases/download/1.74.4/leptonica-1.74.4.tar.gz && tar xvf leptonica-1.74.4.tar.gz; cd leptonica-1.74.4; ./configure && make && sudo make install; fi
+- if [[ $TRAVIS_OS_NAME == 'linux' ]]; then wget https://github.com/DanBloomberg/leptonica/releases/download/1.74.4/leptonica-1.74.4.tar.gz && tar xvf leptonica-1.74.4.tar.gz; cd leptonica-1.74.4; ./configure && make && sudo make install; cd ..; fi
 - if [[ $TRAVIS_OS_NAME == 'linux' ]]; then git clone https://github.com/tesseract-ocr/tesseract.git; cd tesseract; ./autogen.sh; ./configure --enable-debug; LDFLAGS="-L/usr/local/lib" CFLAGS="-I/usr/local/include" make; sudo make install; sudo ldconfig; cd ..; fi
 
 script:
-- pwd
-- ls
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd mac; ./build.command; fi
-
-- pwd
-- ls
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cd mac; ./autogen.sh; ./configure; make; fi
-- pwd
-- ls
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd linux; ./build; cd ..; fi
-- pwd
-- ls
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then mkdir build; cd build; cmake ../src/; make; cd ..; fi
-
-- pwd
-- ls
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd linux; ./autogen.sh; ./configure; make; fi


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [X] I am an active contributor to CCExtractor.

---

During installing the dependencies, one of the command forgets to exit the directory:
```
if [[ $TRAVIS_OS_NAME == 'linux' ]]; then wget https://github.com/DanBloomberg/leptonica/releases/download/1.74.4/leptonica-1.74.4.tar.gz && tar xvf leptonica-1.74.4.tar.gz; cd leptonica-1.74.4; ./configure && make && sudo make install; fi
```
It makes `cd linux; ./build; cd ..; fi` fail to execute.

I also changed `install` to `before_install`, as suggested by travis:
> In a before_install step, you can install additional dependencies required by your project such as Ubuntu packages or custom services.

It can make the verbose dependencies installation collapsed.