### PR TITLE
[FEATURE] Support mp4 tx3g & multitrack subtitles

### DIFF
--- a/src/gpacmp4/mp4.c
+++ b/src/gpacmp4/mp4.c
@@ -304,20 +304,196 @@ unsigned char * ccdp_find_data(unsigned char * ccdp_atom_content, unsigned int l
 	return data;
 }
 
+// Rrocess clcp type atom
+// Return the length of the atom
+// Return -1 if unrecoverable error happened. In this case, the sample will be skipped.
+static int process_clcp(struct lib_ccx_ctx *ctx, struct encoder_ctx *enc_ctx,
+                        struct lib_cc_decode *dec_ctx, struct cc_subtitle *dec_sub, int *mp4_ret,
+                        u32 sub_type, char *data, size_t data_length)
+{
+    unsigned int atom_length = RB32(data);
+    if (atom_length < 8 || atom_length > data_length) {
+        mprint("Invalid atom length. Atom length: %u,  should be: %u\n", atom_length, data_length);
+        return -1;
+    }
+#ifdef MP4_DEBUG
+    dump(256, (unsigned char *)data, atom_length - 8, 0, 1);
+#endif
+    data += 4;
+    int is_ccdp = !strncmp(data, "ccdp", 4);
+
+    if (!strncmp(data, "cdat", 4) || !strncmp(data, "cdt2", 4) || is_ccdp) {
+        if (sub_type == GF_ISOM_SUBTYPE_C708) {
+            if (!is_ccdp) {
+                mprint("Your video file seems to be an interesting sample for us (%4.4s)\n", data);
+                mprint("We haven't met c708 subtitle not in a \'ccdp\' atom before\n");
+                mprint("Please, report\n");
+                return -1;
+            }
+
+            unsigned int cc_count;
+            data += 4;
+            unsigned char *cc_data = ccdp_find_data((unsigned char *)data, data_length - 8, &cc_count);
+
+            if (!cc_data) {
+                dbg_print(CCX_DMT_PARSE, "mp4-708: no cc data found in ccdp\n");
+                return -1;
+            }
+
+            ctx->dec_global_setting->settings_dtvcc->enabled = 1;
+            unsigned char temp[4];
+            for (int cc_i = 0; cc_i < cc_count; cc_i++, cc_data += 3) {
+                unsigned char cc_info = cc_data[0];
+                unsigned char cc_valid = (unsigned char)((cc_info & 4) >> 2);
+                unsigned char cc_type = (unsigned char)(cc_info & 3);
+
+                if (cc_info == CDP_SECTION_SVC_INFO || cc_info == CDP_SECTION_FOOTER) {
+                    dbg_print(CCX_DMT_PARSE, "MP4-708: premature end of sample (0x73 or 0x74)\n");
+                    break;
+                }
+
+                if ((cc_info == 0xFA || cc_info == 0xFC || cc_info == 0xFD)
+                    && (cc_data[1] & 0x7F) == 0 && (cc_data[2] & 0x7F) == 0) {
+                    dbg_print(CCX_DMT_PARSE, "MP4-708: skipped (zero cc data)\n");
+                    continue;
+                }
+
+                temp[0] = cc_valid;
+                temp[1] = cc_type;
+                temp[2] = cc_data[1];
+                temp[3] = cc_data[2];
+
+                if (cc_type < 2) {
+                    dbg_print(CCX_DMT_PARSE, "MP4-708: atom skipped (cc_type < 2)\n");
+                    continue;
+                }
+                dec_ctx->dtvcc->encoder = (void *)enc_ctx; //WARN: otherwise cea-708 will not work
+                                                           //TODO is it really always 4-bytes long?
+                ccx_dtvcc_process_data(dec_ctx, (unsigned char *)temp, 4);
+                cb_708++;
+            }
+        }
+        else //subtype == GF_ISOM_SUBTYPE_C608
+        {
+            if (is_ccdp) {
+                mprint("Your video file seems to be an interesting sample for us\n");
+                mprint("We haven't met c608 subtitle in a \'ccdp\' atom before\n");
+                mprint("Please, report\n");
+                return -1;
+            }
+
+            int ret = 0;
+            int len = atom_length - 8;
+            data += 4;
+            char *tdata = data;
+            do {
+                // Process each pair independently so we can adjust timing
+                ret = process608((unsigned char *)tdata, len > 2 ? 2 : len, dec_ctx, dec_sub);
+                len -= ret;
+                tdata += ret;
+                cb_field1++;
+                if (dec_sub->got_output) {
+                    *mp4_ret = 1;
+                    encode_sub(enc_ctx, dec_sub);
+                    dec_sub->got_output = 0;
+                }
+            } while (len > 0);
+        }
+    }
+    return atom_length;
+}
+
+// Rrocess tx3g type atom
+// Return the length of the atom
+// Return -1 if unrecoverable error happened or process of the atom is finished.
+// In this case, the sample will be skipped.
+// Argument `encode_last_only` is used to print the last subtitle
+static int process_tx3g(struct lib_ccx_ctx *ctx, struct encoder_ctx *enc_ctx,
+    struct lib_cc_decode *dec_ctx, struct cc_subtitle *dec_sub, int *mp4_ret,
+    char *data, size_t data_length, int encode_last_only) {
+    // tx3g data format:
+    // See https://developer.apple.com/library/content/documentation/QuickTime/QTFF/QTFFChap3/qtff3.html (Section Subtitle Sample Data)
+    // See http://www.etsi.org/deliver/etsi_ts/126200_126299/126245/14.00.00_60/ts_126245v140000p.pdf (Section 5.17)
+    // Basically it's 16-bit length + UTF-8/UTF-16 text + optional extension (ignored)
+    // TODO: support extension & style
+
+    static struct cc_subtitle last_sub;
+    static int has_previous_sub = 0;
+
+    // Always encode the previous subtitle, no matter the current one is valid or not
+    if (has_previous_sub) {
+        dec_sub->end_time = dec_ctx->timing->fts_now;
+        encode_sub(enc_ctx, dec_sub); // encode the previous subtitle
+        has_previous_sub = 0;
+    }
+    if (encode_last_only) return;
+
+    unsigned int atom_length = RB16(data);
+    data += 2;
+    
+    if (atom_length > data_length) {
+        mprint("Invalid atom length. Atom length: %u, should be: %u\n", atom_length, data_length);
+        return -1;
+    }
+    if (atom_length == 0) {
+        return -1;
+    }
+#ifdef MP4_DEBUG
+    dump(256, (unsigned char *)data, atom_length, 0, 1);
+#endif
+
+    // Start encode the current subtitle
+    // But they won't be written to file until we get the next subtitle
+    // So that we can know its end time
+    dec_sub->type = CC_TEXT;
+    dec_sub->start_time = dec_ctx->timing->fts_now;
+    if (dec_sub->data != NULL) free(dec_sub->data);
+    dec_sub->data = malloc(atom_length + 1);
+    memcpy(dec_sub->data, data, atom_length);
+    *((char*)dec_sub->data + atom_length) = '\0';
+
+    *mp4_ret = 1;
+    has_previous_sub = 1;
+
+    return -1;
+}
+
+#define MEDIA_TYPE(type, subtype) (((u64)(type)<<32)+(subtype))
+
+void switch_output_file(struct lib_ccx_ctx *ctx, struct encoder_ctx *enc_ctx, int track_id) {
+    if (enc_ctx->out->filename != NULL) { // Close and release the previous handle
+        free(enc_ctx->out->filename);
+        close(enc_ctx->out->fh);
+    }
+    char *ext = get_file_extension(ctx->write_format);
+    char suffix[32];
+    sprintf(suffix, "_%d", track_id);
+    enc_ctx->out->filename = create_outfilename(get_basename(enc_ctx->first_input_file), suffix, ext);
+    enc_ctx->out->fh = open(enc_ctx->out->filename, O_RDWR | O_CREAT | O_TRUNC | O_BINARY, S_IREAD | S_IWRITE);
+
+    // Reset counters as we switch output file.
+    enc_ctx->cea_708_counter = 0;
+    enc_ctx->srt_counter = 0;
+}
+
 /*
 	Here is application algorithm described in some C-like pseudo code:
 		main(){
 			media = open()
 			for each track in media
-				if track is AVC track
+				swtich track
+                AVC track:
 					for each sample in track
 						for each NALU in sample
 							send to avc.c for processing
+                CC track:
+                    for each sample in track
+                        deliver to corresponding process_xxx functions
 			close(media)
 		}
 
 */
-int processmp4 (struct lib_ccx_ctx *ctx,struct ccx_s_mp4Cfg *cfg, char *file)
+int processmp4 (struct lib_ccx_ctx *ctx, struct ccx_s_mp4Cfg *cfg, char *file)
 {
 	int mp4_ret = 0;
 	GF_ISOFile* f;
@@ -339,7 +515,7 @@ int processmp4 (struct lib_ccx_ctx *ctx,struct ccx_s_mp4Cfg *cfg, char *file)
 
 	if((f = gf_isom_open(file, GF_ISOM_OPEN_READ, NULL)) == NULL)
 	{
-		mprint("failed to open\n");
+		mprint("Failed to open\n");
 		free(dec_ctx->xds_ctx);
 		return -2;
 	}
@@ -359,247 +535,180 @@ int processmp4 (struct lib_ccx_ctx *ctx,struct ccx_s_mp4Cfg *cfg, char *file)
 			(unsigned char) ((type>>16)%0x100),(unsigned char) ((type>>8)%0x100),(unsigned char) (type%0x100),
 			(unsigned char) (subtype>>24%0x100),
 			(unsigned char) ((subtype>>16)%0x100),(unsigned char) ((subtype>>8)%0x100),(unsigned char) (subtype%0x100));
-		if ((type == GF_ISOM_MEDIA_CAPTIONS && subtype == GF_ISOM_SUBTYPE_C608) ||
-			(type == GF_ISOM_MEDIA_CAPTIONS && subtype == GF_ISOM_SUBTYPE_C708))
-			cc_track_count++;
+        if (type == GF_ISOM_MEDIA_CAPTIONS || type == GF_ISOM_MEDIA_SUBT || type == GF_ISOM_MEDIA_TEXT)
+            cc_track_count++;
 		if (type == GF_ISOM_MEDIA_VISUAL && subtype == GF_ISOM_SUBTYPE_AVC_H264)
 			avc_track_count++;
 	}
 
 	mprint("MP4: found %u tracks: %u avc and %u cc\n", track_count, avc_track_count, cc_track_count);
 
-	for(i = 0; i < track_count; i++)
-	{
-		const u32 type = gf_isom_get_media_type(f, i + 1);
-		const u32 subtype = gf_isom_get_media_subtype(f, i + 1, 1);
+    for (i = 0; i < track_count; i++) {
+        const u32 type = gf_isom_get_media_type(f, i + 1);
+        const u32 subtype = gf_isom_get_media_subtype(f, i + 1, 1);
+        mprint("Processing track %d, type=%c%c%c%c subtype=%c%c%c%c\n", i + 1,
+            (unsigned char)(type >> 24 % 0x100), (unsigned char)((type >> 16) % 0x100),
+            (unsigned char)((type >> 8) % 0x100), (unsigned char)(type % 0x100),
+            (unsigned char)(subtype >> 24 % 0x100), (unsigned char)((subtype >> 16) % 0x100),
+            (unsigned char)((subtype >> 8) % 0x100), (unsigned char)(subtype % 0x100));
 
-		if ( type == GF_ISOM_MEDIA_VISUAL && subtype == GF_ISOM_SUBTYPE_XDVB)
-		{
-			if (cc_track_count && !cfg->mp4vidtrack)
-				continue;
-			if(process_xdvb_track(ctx, file, f, i + 1, &dec_sub) != 0)
-			{
-				mprint("error\n");
-				free(dec_ctx->xds_ctx);
-				return -3;
-			}
-			if(dec_sub.got_output)
-			{
-				mp4_ret = 1;
-				encode_sub(enc_ctx, &dec_sub);
-				dec_sub.got_output = 0;
-			}
-		}
+        const u64 track_type = MEDIA_TYPE(type, subtype);
 
-		if( type == GF_ISOM_MEDIA_VISUAL && subtype == GF_ISOM_SUBTYPE_AVC_H264)
-		{
-			if (cc_track_count && !cfg->mp4vidtrack)
-				continue;
-			GF_AVCConfig *cnf = gf_isom_avc_config_get(f,i+1,1);
-			if (cnf!=NULL)
-			{
-				for (j=0; j<gf_list_count(cnf->sequenceParameterSets);j++)
-				{
-					GF_AVCConfigSlot* seqcnf=(GF_AVCConfigSlot* )gf_list_get(cnf->sequenceParameterSets,j);
-					do_NAL (dec_ctx, (unsigned char *) seqcnf->data, seqcnf->size, &dec_sub);
-				}
-			}
+        switch (track_type) {
+        case MEDIA_TYPE(GF_ISOM_MEDIA_VISUAL, GF_ISOM_SUBTYPE_XDVB): //vide:xdvb
+            if (cc_track_count && !cfg->mp4vidtrack)
+                continue;
+            // If there are multiple tracks, change fd for different tracks
+            if (avc_track_count > 1) {
+                switch_output_file(ctx, enc_ctx, i);
+            }
+            if (process_xdvb_track(ctx, file, f, i + 1, &dec_sub) != 0) {
+                mprint("Error\n");
+                free(dec_ctx->xds_ctx);
+                return -3;
+            }
+            if (dec_sub.got_output) {
+                mp4_ret = 1;
+                encode_sub(enc_ctx, &dec_sub);
+                dec_sub.got_output = 0;
+            }
+            break;
 
-			if(process_avc_track(ctx, file, f, i + 1, &dec_sub) != 0)
-			{
-				mprint("error\n");
-				free(dec_ctx->xds_ctx);
-				return -3;
-			}
-			if(dec_sub.got_output)
-			{
-				mp4_ret = 1;
-				encode_sub(enc_ctx, &dec_sub);
-				dec_sub.got_output = 0;
-			}
-		}
-		if (type == GF_ISOM_MEDIA_CAPTIONS &&
-				(subtype == GF_ISOM_SUBTYPE_C608 || subtype == GF_ISOM_SUBTYPE_C708))
-		{
-			if (avc_track_count && cfg->mp4vidtrack)
-				continue;
+        case MEDIA_TYPE(GF_ISOM_MEDIA_VISUAL, GF_ISOM_SUBTYPE_AVC_H264): // vide:avc1
+            if (cc_track_count && !cfg->mp4vidtrack)
+                continue;
+            // If there are multiple tracks, change fd for different tracks
+            if (avc_track_count > 1) {
+                switch_output_file(ctx, enc_ctx, i);
+            }
+            GF_AVCConfig *cnf = gf_isom_avc_config_get(f, i + 1, 1);
+            if (cnf != NULL) {
+                for (j = 0; j < gf_list_count(cnf->sequenceParameterSets); j++) {
+                    GF_AVCConfigSlot* seqcnf = (GF_AVCConfigSlot*)gf_list_get(cnf->sequenceParameterSets, j);
+                    do_NAL(dec_ctx, (unsigned char *)seqcnf->data, seqcnf->size, &dec_sub);
+                }
+            }
+            if (process_avc_track(ctx, file, f, i + 1, &dec_sub) != 0) {
+                mprint("Error\n");
+                free(dec_ctx->xds_ctx);
+                return -3;
+            }
+            if (dec_sub.got_output) {
+                mp4_ret = 1;
+                encode_sub(enc_ctx, &dec_sub);
+                dec_sub.got_output = 0;
+            }
+            break;
 
+        default:
+            if (type != GF_ISOM_MEDIA_CAPTIONS && type != GF_ISOM_MEDIA_SUBT && type != GF_ISOM_MEDIA_TEXT)
+                break; // ignore non cc track
+
+            if (avc_track_count && cfg->mp4vidtrack)
+                continue;
+            // If there are multiple tracks, change fd for different tracks
+            if (cc_track_count > 1) {
+                switch_output_file(ctx, enc_ctx, i);
+            }
+            unsigned num_samples = gf_isom_get_sample_count(f, i + 1);
+
+            u32 ProcessingStreamDescriptionIndex = 0; // Current track we are processing, 0 = we don't know yet
+            u32 timescale = gf_isom_get_media_timescale(f, i + 1);
 #ifdef MP4_DEBUG
-			unsigned num_streams = gf_isom_get_sample_description_count (f,i+1);
+            unsigned num_streams = gf_isom_get_sample_description_count(f, i + 1);
+            u64 duration = gf_isom_get_media_duration(f, i + 1);
+            mprint("%u streams\n", num_streams);
+            mprint("%u sample counts\n", num_samples);
+            mprint("%u timescale\n", (unsigned)timescale);
+            mprint("%u duration\n", (unsigned)duration);
 #endif
-			unsigned num_samples = gf_isom_get_sample_count (f,i+1);
-
-			u32 ProcessingStreamDescriptionIndex = 0; // Current track we are processing, 0 = we don't know yet
-			u32 timescale = gf_isom_get_media_timescale(f,i+1);
+            for (unsigned k = 0; k < num_samples; k++) {
+                u32 StreamDescriptionIndex;
+                GF_ISOSample *sample = gf_isom_get_sample(f, i + 1, k + 1, &StreamDescriptionIndex);
+                if (ProcessingStreamDescriptionIndex && ProcessingStreamDescriptionIndex != StreamDescriptionIndex) {
+                    mprint("This sample seems to have more than one description. This isn't supported yet.\n");
+                    mprint("Submitting this video file will help add support to this case.\n");
+                    break;
+                }
+                if (!ProcessingStreamDescriptionIndex)
+                    ProcessingStreamDescriptionIndex = StreamDescriptionIndex;
+                if (sample == NULL)
+                    continue;
 #ifdef MP4_DEBUG
-			u64 duration = gf_isom_get_media_duration(f,i+1);
-			mprint ("%u streams\n",num_streams);
-			mprint ("%u sample counts\n",num_samples);
-			mprint ("%u timescale\n",(unsigned) timescale);
-			mprint ("%u duration\n",(unsigned) duration);
+                mprint("Data length: %lu\n", sample->dataLength);
+                const LLONG timestamp = (LLONG)((sample->DTS + sample->CTS_Offset) * 1000) / timescale;
 #endif
-			for (unsigned k = 0; k <num_samples; k++)
-			{
-				u32 StreamDescriptionIndex;
-				GF_ISOSample *sample= gf_isom_get_sample(f, i+1, k+1, &StreamDescriptionIndex);
-				if (ProcessingStreamDescriptionIndex && ProcessingStreamDescriptionIndex!=StreamDescriptionIndex)
-				{
-					mprint ("This sample seems to have more than one track. This isn't supported yet.\n");
-					mprint ("Submitting this video file will help add support to this case.\n");
-					break;
-				}
-				if (!ProcessingStreamDescriptionIndex)
-						ProcessingStreamDescriptionIndex=StreamDescriptionIndex;
-				if (sample==NULL)
-					continue;
-#ifdef DEBUG
-				 mprint ("Data length: %lu\n",sample->dataLength);
-				const LLONG timestamp = (LLONG )((sample->DTS + sample->CTS_Offset) * 1000) / timescale;
-#endif
-				set_current_pts(dec_ctx->timing, (sample->DTS + sample->CTS_Offset)*MPEG_CLOCK_FREQ/timescale);
-				set_fts(dec_ctx->timing);
+                set_current_pts(dec_ctx->timing, (sample->DTS + sample->CTS_Offset)*MPEG_CLOCK_FREQ / timescale);
+                set_fts(dec_ctx->timing);
 
-				int atomStart = 0;
-				// process Atom by Atom
-				while (atomStart < sample->dataLength)
-				{
-					char *data = sample->data + atomStart;
-					unsigned int atomLength = RB32(data);
-					if (atomLength < 8 || atomLength > sample->dataLength)
-					{
-						mprint ("Invalid atom length. Atom length: %u,  should be: %u\n", atomLength, sample->dataLength);
-						break;
-					}
-#ifdef MP4_DEBUG
-					dump(256, (unsigned char *)data, atomLength - 8, 0, 1);
-#endif
-					data += 4;
-					int is_ccdp = !strncmp(data, "ccdp", 4);
+                int atomStart = 0;
+                // Process Atom by Atom
+                while (atomStart < sample->dataLength) {
+                    char *data = sample->data + atomStart;
+                    size_t atom_length = -1;
+                    switch (track_type) {
+                    case MEDIA_TYPE(GF_ISOM_MEDIA_TEXT, GF_ISOM_SUBTYPE_TX3G): // text:tx3g
+                    case MEDIA_TYPE(GF_ISOM_MEDIA_SUBT, GF_ISOM_SUBTYPE_TX3G): // sbtl:tx3g (they're the same)
+                        atom_length = process_tx3g(ctx, enc_ctx, dec_ctx,
+                            &dec_sub, &mp4_ret,
+                            data, sample->dataLength, 0);
+                        break;
+                    case MEDIA_TYPE(GF_ISOM_MEDIA_CAPTIONS, GF_ISOM_SUBTYPE_C608): // clcp:c608
+                    case MEDIA_TYPE(GF_ISOM_MEDIA_CAPTIONS, GF_ISOM_SUBTYPE_C708): // clcp:c708
+                        atom_length = process_clcp(ctx, enc_ctx, dec_ctx,
+                            &dec_sub, &mp4_ret, subtype,
+                            data, sample->dataLength);
+                        break;
+                    default:
+                        // See https://gpac.wp.imt.fr/2014/09/04/subtitling-with-gpac/ for more possible types
+                        mprint("\nUnsupported track type %c%c%c%c:%c%c%c%c! Please report.\n",
+                            (unsigned char)(type >> 24 % 0x100), (unsigned char)((type >> 16) % 0x100),
+                            (unsigned char)((type >> 8) % 0x100), (unsigned char)(type % 0x100),
+                            (unsigned char)(subtype >> 24 % 0x100), (unsigned char)((subtype >> 16) % 0x100),
+                            (unsigned char)((subtype >> 8) % 0x100), (unsigned char)(subtype % 0x100));
 
-					if (!strncmp(data, "cdat", 4) || !strncmp(data, "cdt2", 4) || is_ccdp)
-					{
-						if (subtype == GF_ISOM_SUBTYPE_C708)
-						{
-							if (!is_ccdp)
-							{
-								mprint("Your video file seems to be an interesting sample for us\n");
-								mprint("We haven't met c708 subtitle not in a \'ccdp\' atom before\n");
-								mprint("Please, report\n");
-								break;
-							}
+                        mprint("", track_type);
+                    }
+                    if (atom_length == -1) break; // error happened
+                    atomStart += atom_length;
+                }
+                free(sample->data);
+                free(sample);
 
-							unsigned int cc_count;
-							data += 4;
-							unsigned char *cc_data = ccdp_find_data((unsigned char *) data, sample->dataLength - 8, &cc_count);
+                // End of change
+                int progress = (int)((k * 100) / num_samples);
+                if (ctx->last_reported_progress != progress) {
+                    int cur_sec = (int)(get_fts(dec_ctx->timing, dec_ctx->current_field) / 1000);
+                    activity_progress(progress, cur_sec / 60, cur_sec % 60);
+                    ctx->last_reported_progress = progress;
+                }
+            }
+            
+            // Encode the last subtitle
+            if (subtype == GF_ISOM_SUBTYPE_TX3G) {
+                process_tx3g(ctx, enc_ctx, dec_ctx,
+                    &dec_sub, &mp4_ret,
+                    NULL, 0, 1);
+            }
 
-							if (!cc_data)
-							{
-								dbg_print(CCX_DMT_PARSE, "mp4-708: no cc data found in ccdp\n");
-								break;
-							}
+            int cur_sec = (int)(get_fts(dec_ctx->timing, dec_ctx->current_field) / 1000);
+            activity_progress(100, cur_sec / 60, cur_sec % 60);
+        }
 
-							ctx->dec_global_setting->settings_dtvcc->enabled = 1;
-							unsigned char temp[4];
-							for (int cc_i = 0; cc_i < cc_count; cc_i++, cc_data += 3)
-							{
-								unsigned char cc_info = cc_data[0];
-								unsigned char cc_valid = (unsigned char) ((cc_info & 4) >> 2);
-								unsigned char cc_type = (unsigned char) (cc_info & 3);
-
-								if (cc_info == CDP_SECTION_SVC_INFO || cc_info == CDP_SECTION_FOOTER)
-								{
-									dbg_print(CCX_DMT_PARSE, "MP4-708: premature end of sample (0x73 or 0x74)\n");
-									break;
-								}
-
-								if ((cc_info == 0xFA || cc_info == 0xFC || cc_info == 0xFD)
-									&& (cc_data[1] & 0x7F) == 0 && (cc_data[2] & 0x7F) == 0)
-								{
-									dbg_print(CCX_DMT_PARSE, "MP4-708: skipped (zero cc data)\n");
-									continue;
-								}
-
-								temp[0] = cc_valid;
-								temp[1] = cc_type;
-								temp[2] = cc_data[1];
-								temp[3] = cc_data[2];
-
-								if (cc_type < 2)
-								{
-									dbg_print(CCX_DMT_PARSE, "MP4-708: atom skipped (cc_type < 2)\n");
-									continue;
-								}
-								dec_ctx->dtvcc->encoder = (void *)enc_ctx; //WARN: otherwise cea-708 will not work
-								//TODO is it really always 4-bytes long?
-								ccx_dtvcc_process_data(dec_ctx, (unsigned char *) temp, 4);
-								cb_708++;
-							}
-							atomStart = sample->dataLength;
-						}
-						else //subtype == GF_ISOM_SUBTYPE_C608
-						{
-							if (is_ccdp)
-							{
-								mprint("Your video file seems to be an interesting sample for us\n");
-								mprint("We haven't met c608 subtitle in a \'ccdp\' atom before\n");
-								mprint("Please, report\n");
-								break;
-							}
-
-							int ret = 0;
-							int len = atomLength - 8;
-							data += 4;
-							char *tdata = data;							
-							do {
-								// Process each pair independently so we can adjust timing
-								ret = process608((unsigned char *) tdata, len>2?2:len, dec_ctx,
-												 &dec_sub);
-								len -= ret;
-								tdata += ret;
-								cb_field1++;
-								if (dec_sub.got_output) {
-									mp4_ret = 1;
-									encode_sub(enc_ctx, &dec_sub);
-									dec_sub.got_output = 0;
-								}
-							} while (len > 0);
-						}
-					}
-					atomStart += atomLength;
-				}
-				free(sample->data);
-				free(sample);
-
-				// End of change
-				int progress = (int) ((k*100) / num_samples);
-				if (ctx->last_reported_progress != progress)
-				{
-					int cur_sec = (int) (get_fts(dec_ctx->timing, dec_ctx->current_field) / 1000);
-					activity_progress(progress, cur_sec/60, cur_sec%60);
-					ctx->last_reported_progress = progress;
-				}
-			}
-			int cur_sec = (int) (get_fts(dec_ctx->timing, dec_ctx->current_field) / 1000);
-			activity_progress(100, cur_sec/60, cur_sec%60);
-		}
-	}
+    }
 
 	free(dec_ctx->xds_ctx);
 
 	mprint("\nClosing media: ");
-
 	gf_isom_close(f);
 	f = NULL;
 	mprint ("ok\n");
 
-	if(avc_track_count == 0)
-	{
-		mprint("Found no AVC track(s). ", file);
-	}
+	if(avc_track_count)
+        mprint("Found %d AVC track(s). ", avc_track_count);
 	else
-	{
-		mprint("Found %d AVC track(s). ", avc_track_count);
-	}
+        mprint("Found no AVC track(s). ", file);
+
 	if (cc_track_count)
 		mprint ("Found %d CC track(s).\n", cc_track_count);
 	else

--- a/src/gpacmp4/mp4.c
+++ b/src/gpacmp4/mp4.c
@@ -308,99 +308,99 @@ unsigned char * ccdp_find_data(unsigned char * ccdp_atom_content, unsigned int l
 // Return the length of the atom
 // Return -1 if unrecoverable error happened. In this case, the sample will be skipped.
 static int process_clcp(struct lib_ccx_ctx *ctx, struct encoder_ctx *enc_ctx,
-                        struct lib_cc_decode *dec_ctx, struct cc_subtitle *dec_sub, int *mp4_ret,
-                        u32 sub_type, char *data, size_t data_length)
+						struct lib_cc_decode *dec_ctx, struct cc_subtitle *dec_sub, int *mp4_ret,
+						u32 sub_type, char *data, size_t data_length)
 {
-    unsigned int atom_length = RB32(data);
-    if (atom_length < 8 || atom_length > data_length) {
-        mprint("Invalid atom length. Atom length: %u,  should be: %u\n", atom_length, data_length);
-        return -1;
-    }
+	unsigned int atom_length = RB32(data);
+	if (atom_length < 8 || atom_length > data_length) {
+		mprint("Invalid atom length. Atom length: %u,  should be: %u\n", atom_length, data_length);
+		return -1;
+	}
 #ifdef MP4_DEBUG
-    dump(256, (unsigned char *)data, atom_length - 8, 0, 1);
+	dump(256, (unsigned char *)data, atom_length - 8, 0, 1);
 #endif
-    data += 4;
-    int is_ccdp = !strncmp(data, "ccdp", 4);
+	data += 4;
+	int is_ccdp = !strncmp(data, "ccdp", 4);
 
-    if (!strncmp(data, "cdat", 4) || !strncmp(data, "cdt2", 4) || is_ccdp) {
-        if (sub_type == GF_ISOM_SUBTYPE_C708) {
-            if (!is_ccdp) {
-                mprint("Your video file seems to be an interesting sample for us (%4.4s)\n", data);
-                mprint("We haven't met c708 subtitle not in a \'ccdp\' atom before\n");
-                mprint("Please, report\n");
-                return -1;
-            }
+	if (!strncmp(data, "cdat", 4) || !strncmp(data, "cdt2", 4) || is_ccdp) {
+		if (sub_type == GF_ISOM_SUBTYPE_C708) {
+			if (!is_ccdp) {
+				mprint("Your video file seems to be an interesting sample for us (%4.4s)\n", data);
+				mprint("We haven't met c708 subtitle not in a \'ccdp\' atom before\n");
+				mprint("Please, report\n");
+				return -1;
+			}
 
-            unsigned int cc_count;
-            data += 4;
-            unsigned char *cc_data = ccdp_find_data((unsigned char *)data, data_length - 8, &cc_count);
+			unsigned int cc_count;
+			data += 4;
+			unsigned char *cc_data = ccdp_find_data((unsigned char *)data, data_length - 8, &cc_count);
 
-            if (!cc_data) {
-                dbg_print(CCX_DMT_PARSE, "mp4-708: no cc data found in ccdp\n");
-                return -1;
-            }
+			if (!cc_data) {
+				dbg_print(CCX_DMT_PARSE, "mp4-708: no cc data found in ccdp\n");
+				return -1;
+			}
 
-            ctx->dec_global_setting->settings_dtvcc->enabled = 1;
-            unsigned char temp[4];
-            for (int cc_i = 0; cc_i < cc_count; cc_i++, cc_data += 3) {
-                unsigned char cc_info = cc_data[0];
-                unsigned char cc_valid = (unsigned char)((cc_info & 4) >> 2);
-                unsigned char cc_type = (unsigned char)(cc_info & 3);
+			ctx->dec_global_setting->settings_dtvcc->enabled = 1;
+			unsigned char temp[4];
+			for (int cc_i = 0; cc_i < cc_count; cc_i++, cc_data += 3) {
+				unsigned char cc_info = cc_data[0];
+				unsigned char cc_valid = (unsigned char)((cc_info & 4) >> 2);
+				unsigned char cc_type = (unsigned char)(cc_info & 3);
 
-                if (cc_info == CDP_SECTION_SVC_INFO || cc_info == CDP_SECTION_FOOTER) {
-                    dbg_print(CCX_DMT_PARSE, "MP4-708: premature end of sample (0x73 or 0x74)\n");
-                    break;
-                }
+				if (cc_info == CDP_SECTION_SVC_INFO || cc_info == CDP_SECTION_FOOTER) {
+					dbg_print(CCX_DMT_PARSE, "MP4-708: premature end of sample (0x73 or 0x74)\n");
+					break;
+				}
 
-                if ((cc_info == 0xFA || cc_info == 0xFC || cc_info == 0xFD)
-                    && (cc_data[1] & 0x7F) == 0 && (cc_data[2] & 0x7F) == 0) {
-                    dbg_print(CCX_DMT_PARSE, "MP4-708: skipped (zero cc data)\n");
-                    continue;
-                }
+				if ((cc_info == 0xFA || cc_info == 0xFC || cc_info == 0xFD)
+					&& (cc_data[1] & 0x7F) == 0 && (cc_data[2] & 0x7F) == 0) {
+					dbg_print(CCX_DMT_PARSE, "MP4-708: skipped (zero cc data)\n");
+					continue;
+				}
 
-                temp[0] = cc_valid;
-                temp[1] = cc_type;
-                temp[2] = cc_data[1];
-                temp[3] = cc_data[2];
+				temp[0] = cc_valid;
+				temp[1] = cc_type;
+				temp[2] = cc_data[1];
+				temp[3] = cc_data[2];
 
-                if (cc_type < 2) {
-                    dbg_print(CCX_DMT_PARSE, "MP4-708: atom skipped (cc_type < 2)\n");
-                    continue;
-                }
-                dec_ctx->dtvcc->encoder = (void *)enc_ctx; //WARN: otherwise cea-708 will not work
-                                                           //TODO is it really always 4-bytes long?
-                ccx_dtvcc_process_data(dec_ctx, (unsigned char *)temp, 4);
-                cb_708++;
-            }
-        }
-        else //subtype == GF_ISOM_SUBTYPE_C608
-        {
-            if (is_ccdp) {
-                mprint("Your video file seems to be an interesting sample for us\n");
-                mprint("We haven't met c608 subtitle in a \'ccdp\' atom before\n");
-                mprint("Please, report\n");
-                return -1;
-            }
+				if (cc_type < 2) {
+					dbg_print(CCX_DMT_PARSE, "MP4-708: atom skipped (cc_type < 2)\n");
+					continue;
+				}
+				dec_ctx->dtvcc->encoder = (void *)enc_ctx; //WARN: otherwise cea-708 will not work
+														   //TODO is it really always 4-bytes long?
+				ccx_dtvcc_process_data(dec_ctx, (unsigned char *)temp, 4);
+				cb_708++;
+			}
+		}
+		else //subtype == GF_ISOM_SUBTYPE_C608
+		{
+			if (is_ccdp) {
+				mprint("Your video file seems to be an interesting sample for us\n");
+				mprint("We haven't met c608 subtitle in a \'ccdp\' atom before\n");
+				mprint("Please, report\n");
+				return -1;
+			}
 
-            int ret = 0;
-            int len = atom_length - 8;
-            data += 4;
-            char *tdata = data;
-            do {
-                // Process each pair independently so we can adjust timing
-                ret = process608((unsigned char *)tdata, len > 2 ? 2 : len, dec_ctx, dec_sub);
-                len -= ret;
-                tdata += ret;
-                cb_field1++;
-                if (dec_sub->got_output) {
-                    *mp4_ret = 1;
-                    encode_sub(enc_ctx, dec_sub);
-                    dec_sub->got_output = 0;
-                }
-            } while (len > 0);
-        }
-    }
-    return atom_length;
+			int ret = 0;
+			int len = atom_length - 8;
+			data += 4;
+			char *tdata = data;
+			do {
+				// Process each pair independently so we can adjust timing
+				ret = process608((unsigned char *)tdata, len > 2 ? 2 : len, dec_ctx, dec_sub);
+				len -= ret;
+				tdata += ret;
+				cb_field1++;
+				if (dec_sub->got_output) {
+					*mp4_ret = 1;
+					encode_sub(enc_ctx, dec_sub);
+					dec_sub->got_output = 0;
+				}
+			} while (len > 0);
+		}
+	}
+	return atom_length;
 }
 
 // Rrocess tx3g type atom
@@ -409,71 +409,71 @@ static int process_clcp(struct lib_ccx_ctx *ctx, struct encoder_ctx *enc_ctx,
 // In this case, the sample will be skipped.
 // Argument `encode_last_only` is used to print the last subtitle
 static int process_tx3g(struct lib_ccx_ctx *ctx, struct encoder_ctx *enc_ctx,
-    struct lib_cc_decode *dec_ctx, struct cc_subtitle *dec_sub, int *mp4_ret,
-    char *data, size_t data_length, int encode_last_only) {
-    // tx3g data format:
-    // See https://developer.apple.com/library/content/documentation/QuickTime/QTFF/QTFFChap3/qtff3.html (Section Subtitle Sample Data)
-    // See http://www.etsi.org/deliver/etsi_ts/126200_126299/126245/14.00.00_60/ts_126245v140000p.pdf (Section 5.17)
-    // Basically it's 16-bit length + UTF-8/UTF-16 text + optional extension (ignored)
-    // TODO: support extension & style
+	struct lib_cc_decode *dec_ctx, struct cc_subtitle *dec_sub, int *mp4_ret,
+	char *data, size_t data_length, int encode_last_only) {
+	// tx3g data format:
+	// See https://developer.apple.com/library/content/documentation/QuickTime/QTFF/QTFFChap3/qtff3.html (Section Subtitle Sample Data)
+	// See http://www.etsi.org/deliver/etsi_ts/126200_126299/126245/14.00.00_60/ts_126245v140000p.pdf (Section 5.17)
+	// Basically it's 16-bit length + UTF-8/UTF-16 text + optional extension (ignored)
+	// TODO: support extension & style
 
-    static struct cc_subtitle last_sub;
-    static int has_previous_sub = 0;
+	static struct cc_subtitle last_sub;
+	static int has_previous_sub = 0;
 
-    // Always encode the previous subtitle, no matter the current one is valid or not
-    if (has_previous_sub) {
-        dec_sub->end_time = dec_ctx->timing->fts_now;
-        encode_sub(enc_ctx, dec_sub); // encode the previous subtitle
-        has_previous_sub = 0;
-    }
-    if (encode_last_only) return;
+	// Always encode the previous subtitle, no matter the current one is valid or not
+	if (has_previous_sub) {
+		dec_sub->end_time = dec_ctx->timing->fts_now;
+		encode_sub(enc_ctx, dec_sub); // encode the previous subtitle
+		has_previous_sub = 0;
+	}
+	if (encode_last_only) return;
 
-    unsigned int atom_length = RB16(data);
-    data += 2;
-    
-    if (atom_length > data_length) {
-        mprint("Invalid atom length. Atom length: %u, should be: %u\n", atom_length, data_length);
-        return -1;
-    }
-    if (atom_length == 0) {
-        return -1;
-    }
+	unsigned int atom_length = RB16(data);
+	data += 2;
+	
+	if (atom_length > data_length) {
+		mprint("Invalid atom length. Atom length: %u, should be: %u\n", atom_length, data_length);
+		return -1;
+	}
+	if (atom_length == 0) {
+		return -1;
+	}
 #ifdef MP4_DEBUG
-    dump(256, (unsigned char *)data, atom_length, 0, 1);
+	dump(256, (unsigned char *)data, atom_length, 0, 1);
 #endif
 
-    // Start encode the current subtitle
-    // But they won't be written to file until we get the next subtitle
-    // So that we can know its end time
-    dec_sub->type = CC_TEXT;
-    dec_sub->start_time = dec_ctx->timing->fts_now;
-    if (dec_sub->data != NULL) free(dec_sub->data);
-    dec_sub->data = malloc(atom_length + 1);
-    memcpy(dec_sub->data, data, atom_length);
-    *((char*)dec_sub->data + atom_length) = '\0';
+	// Start encode the current subtitle
+	// But they won't be written to file until we get the next subtitle
+	// So that we can know its end time
+	dec_sub->type = CC_TEXT;
+	dec_sub->start_time = dec_ctx->timing->fts_now;
+	if (dec_sub->data != NULL) free(dec_sub->data);
+	dec_sub->data = malloc(atom_length + 1);
+	memcpy(dec_sub->data, data, atom_length);
+	*((char*)dec_sub->data + atom_length) = '\0';
 
-    *mp4_ret = 1;
-    has_previous_sub = 1;
+	*mp4_ret = 1;
+	has_previous_sub = 1;
 
-    return -1;
+	return -1;
 }
 
 #define MEDIA_TYPE(type, subtype) (((u64)(type)<<32)+(subtype))
 
 void switch_output_file(struct lib_ccx_ctx *ctx, struct encoder_ctx *enc_ctx, int track_id) {
-    if (enc_ctx->out->filename != NULL) { // Close and release the previous handle
-        free(enc_ctx->out->filename);
-        close(enc_ctx->out->fh);
-    }
-    char *ext = get_file_extension(ctx->write_format);
-    char suffix[32];
-    sprintf(suffix, "_%d", track_id);
-    enc_ctx->out->filename = create_outfilename(get_basename(enc_ctx->first_input_file), suffix, ext);
-    enc_ctx->out->fh = open(enc_ctx->out->filename, O_RDWR | O_CREAT | O_TRUNC | O_BINARY, S_IREAD | S_IWRITE);
+	if (enc_ctx->out->filename != NULL) { // Close and release the previous handle
+		free(enc_ctx->out->filename);
+		close(enc_ctx->out->fh);
+	}
+	char *ext = get_file_extension(ctx->write_format);
+	char suffix[32];
+	sprintf(suffix, "_%d", track_id);
+	enc_ctx->out->filename = create_outfilename(get_basename(enc_ctx->first_input_file), suffix, ext);
+	enc_ctx->out->fh = open(enc_ctx->out->filename, O_RDWR | O_CREAT | O_TRUNC | O_BINARY, S_IREAD | S_IWRITE);
 
-    // Reset counters as we switch output file.
-    enc_ctx->cea_708_counter = 0;
-    enc_ctx->srt_counter = 0;
+	// Reset counters as we switch output file.
+	enc_ctx->cea_708_counter = 0;
+	enc_ctx->srt_counter = 0;
 }
 
 /*
@@ -482,13 +482,13 @@ void switch_output_file(struct lib_ccx_ctx *ctx, struct encoder_ctx *enc_ctx, in
 			media = open()
 			for each track in media
 				swtich track
-                AVC track:
+				AVC track:
 					for each sample in track
 						for each NALU in sample
 							send to avc.c for processing
-                CC track:
-                    for each sample in track
-                        deliver to corresponding process_xxx functions
+				CC track:
+					for each sample in track
+						deliver to corresponding process_xxx functions
 			close(media)
 		}
 
@@ -535,167 +535,167 @@ int processmp4 (struct lib_ccx_ctx *ctx, struct ccx_s_mp4Cfg *cfg, char *file)
 			(unsigned char) ((type>>16)%0x100),(unsigned char) ((type>>8)%0x100),(unsigned char) (type%0x100),
 			(unsigned char) (subtype>>24%0x100),
 			(unsigned char) ((subtype>>16)%0x100),(unsigned char) ((subtype>>8)%0x100),(unsigned char) (subtype%0x100));
-        if (type == GF_ISOM_MEDIA_CAPTIONS || type == GF_ISOM_MEDIA_SUBT || type == GF_ISOM_MEDIA_TEXT)
-            cc_track_count++;
+		if (type == GF_ISOM_MEDIA_CAPTIONS || type == GF_ISOM_MEDIA_SUBT || type == GF_ISOM_MEDIA_TEXT)
+			cc_track_count++;
 		if (type == GF_ISOM_MEDIA_VISUAL && subtype == GF_ISOM_SUBTYPE_AVC_H264)
 			avc_track_count++;
 	}
 
 	mprint("MP4: found %u tracks: %u avc and %u cc\n", track_count, avc_track_count, cc_track_count);
 
-    for (i = 0; i < track_count; i++) {
-        const u32 type = gf_isom_get_media_type(f, i + 1);
-        const u32 subtype = gf_isom_get_media_subtype(f, i + 1, 1);
-        mprint("Processing track %d, type=%c%c%c%c subtype=%c%c%c%c\n", i + 1,
-            (unsigned char)(type >> 24 % 0x100), (unsigned char)((type >> 16) % 0x100),
-            (unsigned char)((type >> 8) % 0x100), (unsigned char)(type % 0x100),
-            (unsigned char)(subtype >> 24 % 0x100), (unsigned char)((subtype >> 16) % 0x100),
-            (unsigned char)((subtype >> 8) % 0x100), (unsigned char)(subtype % 0x100));
+	for (i = 0; i < track_count; i++) {
+		const u32 type = gf_isom_get_media_type(f, i + 1);
+		const u32 subtype = gf_isom_get_media_subtype(f, i + 1, 1);
+		mprint("Processing track %d, type=%c%c%c%c subtype=%c%c%c%c\n", i + 1,
+			(unsigned char)(type >> 24 % 0x100), (unsigned char)((type >> 16) % 0x100),
+			(unsigned char)((type >> 8) % 0x100), (unsigned char)(type % 0x100),
+			(unsigned char)(subtype >> 24 % 0x100), (unsigned char)((subtype >> 16) % 0x100),
+			(unsigned char)((subtype >> 8) % 0x100), (unsigned char)(subtype % 0x100));
 
-        const u64 track_type = MEDIA_TYPE(type, subtype);
+		const u64 track_type = MEDIA_TYPE(type, subtype);
 
-        switch (track_type) {
-        case MEDIA_TYPE(GF_ISOM_MEDIA_VISUAL, GF_ISOM_SUBTYPE_XDVB): //vide:xdvb
-            if (cc_track_count && !cfg->mp4vidtrack)
-                continue;
-            // If there are multiple tracks, change fd for different tracks
-            if (avc_track_count > 1) {
-                switch_output_file(ctx, enc_ctx, i);
-            }
-            if (process_xdvb_track(ctx, file, f, i + 1, &dec_sub) != 0) {
-                mprint("Error\n");
-                free(dec_ctx->xds_ctx);
-                return -3;
-            }
-            if (dec_sub.got_output) {
-                mp4_ret = 1;
-                encode_sub(enc_ctx, &dec_sub);
-                dec_sub.got_output = 0;
-            }
-            break;
+		switch (track_type) {
+		case MEDIA_TYPE(GF_ISOM_MEDIA_VISUAL, GF_ISOM_SUBTYPE_XDVB): //vide:xdvb
+			if (cc_track_count && !cfg->mp4vidtrack)
+				continue;
+			// If there are multiple tracks, change fd for different tracks
+			if (avc_track_count > 1) {
+				switch_output_file(ctx, enc_ctx, i);
+			}
+			if (process_xdvb_track(ctx, file, f, i + 1, &dec_sub) != 0) {
+				mprint("Error\n");
+				free(dec_ctx->xds_ctx);
+				return -3;
+			}
+			if (dec_sub.got_output) {
+				mp4_ret = 1;
+				encode_sub(enc_ctx, &dec_sub);
+				dec_sub.got_output = 0;
+			}
+			break;
 
-        case MEDIA_TYPE(GF_ISOM_MEDIA_VISUAL, GF_ISOM_SUBTYPE_AVC_H264): // vide:avc1
-            if (cc_track_count && !cfg->mp4vidtrack)
-                continue;
-            // If there are multiple tracks, change fd for different tracks
-            if (avc_track_count > 1) {
-                switch_output_file(ctx, enc_ctx, i);
-            }
-            GF_AVCConfig *cnf = gf_isom_avc_config_get(f, i + 1, 1);
-            if (cnf != NULL) {
-                for (j = 0; j < gf_list_count(cnf->sequenceParameterSets); j++) {
-                    GF_AVCConfigSlot* seqcnf = (GF_AVCConfigSlot*)gf_list_get(cnf->sequenceParameterSets, j);
-                    do_NAL(dec_ctx, (unsigned char *)seqcnf->data, seqcnf->size, &dec_sub);
-                }
-            }
-            if (process_avc_track(ctx, file, f, i + 1, &dec_sub) != 0) {
-                mprint("Error\n");
-                free(dec_ctx->xds_ctx);
-                return -3;
-            }
-            if (dec_sub.got_output) {
-                mp4_ret = 1;
-                encode_sub(enc_ctx, &dec_sub);
-                dec_sub.got_output = 0;
-            }
-            break;
+		case MEDIA_TYPE(GF_ISOM_MEDIA_VISUAL, GF_ISOM_SUBTYPE_AVC_H264): // vide:avc1
+			if (cc_track_count && !cfg->mp4vidtrack)
+				continue;
+			// If there are multiple tracks, change fd for different tracks
+			if (avc_track_count > 1) {
+				switch_output_file(ctx, enc_ctx, i);
+			}
+			GF_AVCConfig *cnf = gf_isom_avc_config_get(f, i + 1, 1);
+			if (cnf != NULL) {
+				for (j = 0; j < gf_list_count(cnf->sequenceParameterSets); j++) {
+					GF_AVCConfigSlot* seqcnf = (GF_AVCConfigSlot*)gf_list_get(cnf->sequenceParameterSets, j);
+					do_NAL(dec_ctx, (unsigned char *)seqcnf->data, seqcnf->size, &dec_sub);
+				}
+			}
+			if (process_avc_track(ctx, file, f, i + 1, &dec_sub) != 0) {
+				mprint("Error\n");
+				free(dec_ctx->xds_ctx);
+				return -3;
+			}
+			if (dec_sub.got_output) {
+				mp4_ret = 1;
+				encode_sub(enc_ctx, &dec_sub);
+				dec_sub.got_output = 0;
+			}
+			break;
 
-        default:
-            if (type != GF_ISOM_MEDIA_CAPTIONS && type != GF_ISOM_MEDIA_SUBT && type != GF_ISOM_MEDIA_TEXT)
-                break; // ignore non cc track
+		default:
+			if (type != GF_ISOM_MEDIA_CAPTIONS && type != GF_ISOM_MEDIA_SUBT && type != GF_ISOM_MEDIA_TEXT)
+				break; // ignore non cc track
 
-            if (avc_track_count && cfg->mp4vidtrack)
-                continue;
-            // If there are multiple tracks, change fd for different tracks
-            if (cc_track_count > 1) {
-                switch_output_file(ctx, enc_ctx, i);
-            }
-            unsigned num_samples = gf_isom_get_sample_count(f, i + 1);
+			if (avc_track_count && cfg->mp4vidtrack)
+				continue;
+			// If there are multiple tracks, change fd for different tracks
+			if (cc_track_count > 1) {
+				switch_output_file(ctx, enc_ctx, i);
+			}
+			unsigned num_samples = gf_isom_get_sample_count(f, i + 1);
 
-            u32 ProcessingStreamDescriptionIndex = 0; // Current track we are processing, 0 = we don't know yet
-            u32 timescale = gf_isom_get_media_timescale(f, i + 1);
+			u32 ProcessingStreamDescriptionIndex = 0; // Current track we are processing, 0 = we don't know yet
+			u32 timescale = gf_isom_get_media_timescale(f, i + 1);
 #ifdef MP4_DEBUG
-            unsigned num_streams = gf_isom_get_sample_description_count(f, i + 1);
-            u64 duration = gf_isom_get_media_duration(f, i + 1);
-            mprint("%u streams\n", num_streams);
-            mprint("%u sample counts\n", num_samples);
-            mprint("%u timescale\n", (unsigned)timescale);
-            mprint("%u duration\n", (unsigned)duration);
+			unsigned num_streams = gf_isom_get_sample_description_count(f, i + 1);
+			u64 duration = gf_isom_get_media_duration(f, i + 1);
+			mprint("%u streams\n", num_streams);
+			mprint("%u sample counts\n", num_samples);
+			mprint("%u timescale\n", (unsigned)timescale);
+			mprint("%u duration\n", (unsigned)duration);
 #endif
-            for (unsigned k = 0; k < num_samples; k++) {
-                u32 StreamDescriptionIndex;
-                GF_ISOSample *sample = gf_isom_get_sample(f, i + 1, k + 1, &StreamDescriptionIndex);
-                if (ProcessingStreamDescriptionIndex && ProcessingStreamDescriptionIndex != StreamDescriptionIndex) {
-                    mprint("This sample seems to have more than one description. This isn't supported yet.\n");
-                    mprint("Submitting this video file will help add support to this case.\n");
-                    break;
-                }
-                if (!ProcessingStreamDescriptionIndex)
-                    ProcessingStreamDescriptionIndex = StreamDescriptionIndex;
-                if (sample == NULL)
-                    continue;
+			for (unsigned k = 0; k < num_samples; k++) {
+				u32 StreamDescriptionIndex;
+				GF_ISOSample *sample = gf_isom_get_sample(f, i + 1, k + 1, &StreamDescriptionIndex);
+				if (ProcessingStreamDescriptionIndex && ProcessingStreamDescriptionIndex != StreamDescriptionIndex) {
+					mprint("This sample seems to have more than one description. This isn't supported yet.\n");
+					mprint("Submitting this video file will help add support to this case.\n");
+					break;
+				}
+				if (!ProcessingStreamDescriptionIndex)
+					ProcessingStreamDescriptionIndex = StreamDescriptionIndex;
+				if (sample == NULL)
+					continue;
 #ifdef MP4_DEBUG
-                mprint("Data length: %lu\n", sample->dataLength);
-                const LLONG timestamp = (LLONG)((sample->DTS + sample->CTS_Offset) * 1000) / timescale;
+				mprint("Data length: %lu\n", sample->dataLength);
+				const LLONG timestamp = (LLONG)((sample->DTS + sample->CTS_Offset) * 1000) / timescale;
 #endif
-                set_current_pts(dec_ctx->timing, (sample->DTS + sample->CTS_Offset)*MPEG_CLOCK_FREQ / timescale);
-                set_fts(dec_ctx->timing);
+				set_current_pts(dec_ctx->timing, (sample->DTS + sample->CTS_Offset)*MPEG_CLOCK_FREQ / timescale);
+				set_fts(dec_ctx->timing);
 
-                int atomStart = 0;
-                // Process Atom by Atom
-                while (atomStart < sample->dataLength) {
-                    char *data = sample->data + atomStart;
-                    size_t atom_length = -1;
-                    switch (track_type) {
-                    case MEDIA_TYPE(GF_ISOM_MEDIA_TEXT, GF_ISOM_SUBTYPE_TX3G): // text:tx3g
-                    case MEDIA_TYPE(GF_ISOM_MEDIA_SUBT, GF_ISOM_SUBTYPE_TX3G): // sbtl:tx3g (they're the same)
-                        atom_length = process_tx3g(ctx, enc_ctx, dec_ctx,
-                            &dec_sub, &mp4_ret,
-                            data, sample->dataLength, 0);
-                        break;
-                    case MEDIA_TYPE(GF_ISOM_MEDIA_CAPTIONS, GF_ISOM_SUBTYPE_C608): // clcp:c608
-                    case MEDIA_TYPE(GF_ISOM_MEDIA_CAPTIONS, GF_ISOM_SUBTYPE_C708): // clcp:c708
-                        atom_length = process_clcp(ctx, enc_ctx, dec_ctx,
-                            &dec_sub, &mp4_ret, subtype,
-                            data, sample->dataLength);
-                        break;
-                    default:
-                        // See https://gpac.wp.imt.fr/2014/09/04/subtitling-with-gpac/ for more possible types
-                        mprint("\nUnsupported track type %c%c%c%c:%c%c%c%c! Please report.\n",
-                            (unsigned char)(type >> 24 % 0x100), (unsigned char)((type >> 16) % 0x100),
-                            (unsigned char)((type >> 8) % 0x100), (unsigned char)(type % 0x100),
-                            (unsigned char)(subtype >> 24 % 0x100), (unsigned char)((subtype >> 16) % 0x100),
-                            (unsigned char)((subtype >> 8) % 0x100), (unsigned char)(subtype % 0x100));
+				int atomStart = 0;
+				// Process Atom by Atom
+				while (atomStart < sample->dataLength) {
+					char *data = sample->data + atomStart;
+					size_t atom_length = -1;
+					switch (track_type) {
+					case MEDIA_TYPE(GF_ISOM_MEDIA_TEXT, GF_ISOM_SUBTYPE_TX3G): // text:tx3g
+					case MEDIA_TYPE(GF_ISOM_MEDIA_SUBT, GF_ISOM_SUBTYPE_TX3G): // sbtl:tx3g (they're the same)
+						atom_length = process_tx3g(ctx, enc_ctx, dec_ctx,
+							&dec_sub, &mp4_ret,
+							data, sample->dataLength, 0);
+						break;
+					case MEDIA_TYPE(GF_ISOM_MEDIA_CAPTIONS, GF_ISOM_SUBTYPE_C608): // clcp:c608
+					case MEDIA_TYPE(GF_ISOM_MEDIA_CAPTIONS, GF_ISOM_SUBTYPE_C708): // clcp:c708
+						atom_length = process_clcp(ctx, enc_ctx, dec_ctx,
+							&dec_sub, &mp4_ret, subtype,
+							data, sample->dataLength);
+						break;
+					default:
+						// See https://gpac.wp.imt.fr/2014/09/04/subtitling-with-gpac/ for more possible types
+						mprint("\nUnsupported track type %c%c%c%c:%c%c%c%c! Please report.\n",
+							(unsigned char)(type >> 24 % 0x100), (unsigned char)((type >> 16) % 0x100),
+							(unsigned char)((type >> 8) % 0x100), (unsigned char)(type % 0x100),
+							(unsigned char)(subtype >> 24 % 0x100), (unsigned char)((subtype >> 16) % 0x100),
+							(unsigned char)((subtype >> 8) % 0x100), (unsigned char)(subtype % 0x100));
 
-                        mprint("", track_type);
-                    }
-                    if (atom_length == -1) break; // error happened
-                    atomStart += atom_length;
-                }
-                free(sample->data);
-                free(sample);
+						mprint("", track_type);
+					}
+					if (atom_length == -1) break; // error happened
+					atomStart += atom_length;
+				}
+				free(sample->data);
+				free(sample);
 
-                // End of change
-                int progress = (int)((k * 100) / num_samples);
-                if (ctx->last_reported_progress != progress) {
-                    int cur_sec = (int)(get_fts(dec_ctx->timing, dec_ctx->current_field) / 1000);
-                    activity_progress(progress, cur_sec / 60, cur_sec % 60);
-                    ctx->last_reported_progress = progress;
-                }
-            }
-            
-            // Encode the last subtitle
-            if (subtype == GF_ISOM_SUBTYPE_TX3G) {
-                process_tx3g(ctx, enc_ctx, dec_ctx,
-                    &dec_sub, &mp4_ret,
-                    NULL, 0, 1);
-            }
+				// End of change
+				int progress = (int)((k * 100) / num_samples);
+				if (ctx->last_reported_progress != progress) {
+					int cur_sec = (int)(get_fts(dec_ctx->timing, dec_ctx->current_field) / 1000);
+					activity_progress(progress, cur_sec / 60, cur_sec % 60);
+					ctx->last_reported_progress = progress;
+				}
+			}
+			
+			// Encode the last subtitle
+			if (subtype == GF_ISOM_SUBTYPE_TX3G) {
+				process_tx3g(ctx, enc_ctx, dec_ctx,
+					&dec_sub, &mp4_ret,
+					NULL, 0, 1);
+			}
 
-            int cur_sec = (int)(get_fts(dec_ctx->timing, dec_ctx->current_field) / 1000);
-            activity_progress(100, cur_sec / 60, cur_sec % 60);
-        }
+			int cur_sec = (int)(get_fts(dec_ctx->timing, dec_ctx->current_field) / 1000);
+			activity_progress(100, cur_sec / 60, cur_sec % 60);
+		}
 
-    }
+	}
 
 	free(dec_ctx->xds_ctx);
 
@@ -705,9 +705,9 @@ int processmp4 (struct lib_ccx_ctx *ctx, struct ccx_s_mp4Cfg *cfg, char *file)
 	mprint ("ok\n");
 
 	if(avc_track_count)
-        mprint("Found %d AVC track(s). ", avc_track_count);
+		mprint("Found %d AVC track(s). ", avc_track_count);
 	else
-        mprint("Found no AVC track(s). ", file);
+		mprint("Found no AVC track(s). ", file);
 
 	if (cc_track_count)
 		mprint ("Found %d CC track(s).\n", cc_track_count);

--- a/src/gpacmp4/mp4.c
+++ b/src/gpacmp4/mp4.c
@@ -457,7 +457,7 @@ static int process_tx3g(struct lib_ccx_ctx *ctx, struct encoder_ctx *enc_ctx,
 	*mp4_ret = 1;
 	has_previous_sub = 1;
 
-	return -1;
+	return -1; // Assume there's only one subtitle in one atom.
 }
 
 /*

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -1416,3 +1416,19 @@ unsigned int get_font_encoded(struct encoder_ctx *ctx, unsigned char *buffer, in
 	}
 	return (unsigned)(buffer - orig); // Return length
 }
+
+void switch_output_file(struct lib_ccx_ctx *ctx, struct encoder_ctx *enc_ctx, int track_id) {
+	if (enc_ctx->out->filename != NULL) { // Close and release the previous handle
+		free(enc_ctx->out->filename);
+		close(enc_ctx->out->fh);
+	}
+	char *ext = get_file_extension(ctx->write_format);
+	char suffix[32];
+	sprintf(suffix, "_%d", track_id);
+	enc_ctx->out->filename = create_outfilename(get_basename(enc_ctx->first_input_file), suffix, ext);
+	enc_ctx->out->fh = open(enc_ctx->out->filename, O_RDWR | O_CREAT | O_TRUNC | O_BINARY, S_IREAD | S_IWRITE);
+
+	// Reset counters as we switch output file.
+	enc_ctx->cea_708_counter = 0;
+	enc_ctx->srt_counter = 0;
+}

--- a/src/lib_ccx/ccx_encoders_common.h
+++ b/src/lib_ccx/ccx_encoders_common.h
@@ -228,4 +228,6 @@ unsigned int get_line_encoded(struct encoder_ctx *ctx, unsigned char *buffer, in
 unsigned int get_color_encoded(struct encoder_ctx *ctx, unsigned char *buffer, int line_num, struct eia608_screen *data);
 unsigned int get_font_encoded(struct encoder_ctx *ctx, unsigned char *buffer, int line_num, struct eia608_screen *data);
 int pass_cc_buffer_to_python(struct eia608_screen *data, struct encoder_ctx *context);
+
+void switch_output_file(struct lib_ccx_ctx *ctx, struct encoder_ctx *enc_ctx, int track_id);
 #endif


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [X] I am an active contributor to CCExtractor.

---

This will fix #807 .
**FEATURE:**
- sbtl:tx3g and text:tx3g handler.
- Support multitrack subtitles.

**KNOWN ISSUES:**
- Styles & extensions of tx3g subtitles are ignored.
- The empty default file will be created, even though sometimes(when there're multiple tracks) we don't use it.
- `-o outputfilename` option is not honered. I don't think I caused it though. It seems to be broken long time ago.

**NOTE:**
- I didn't test the situation when a sample has multiple atoms in it (Is it possible? I don't have a video sample to verify).
- Although I think the timing is handled correctly, I don't have enough samples to verify.
- All my local mp4 samples are extracted correctly, but I'd give the sample platform a go anyway.