### PR TITLE
[FIX] DVB Teletext subtitle incomplete #922

### DIFF
--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -634,43 +634,25 @@ void process_page(struct TeletextCtx *ctx, teletext_page_t *page, struct cc_subt
 	// process data
 	for (uint8_t row = 1; row < 25; row++)
 	{
-		// anchors for string trimming purpose
-		uint8_t col_start = 40;
-		uint8_t col_stop = 40;
+        // anchors for string trimming purpose
+        uint8_t col_start = 40;
+        uint8_t col_stop = 40;
 
-		for (int8_t col = 39; col >= 0; col--)
-		{
-			if (page->text[row][col] == 0xb)
-			{   
-                // check for double 0/B
-                if (col > 1 && page->text[row][col-1] == 0xb) //
-                {
-                    // check for 0/A, to cancel the action of the Start Box code 0/B
-                    int a_detected = 0; // is 0/A detected in front of 0/B?
-                    for (int8_t temp = col-1; temp >= 0; temp--)
-                    {
-                        // replace 0/A with space
-                        if (page->text[row][temp] == 0xa)
-                        {
-                            page->text[row][temp] = 0x20;
-                            a_detected = 1;
-                        }
-                    }
-
-                    if (a_detected)
-                    {
-                        page->text[row][col] = 0x20;
-                        page->text[row][col-1] = 0x20;
-                    }
-                }//
-                else
-                {
-                    col_start = col;
-                    line_count++;
-                    break;
-                }
-			}
-		}
+        for (int8_t col = 0; col < 40; col++)
+        {
+            if (col_start == 40 && page->text[row][col] == 0xb)
+            {
+                col_start = col;
+                line_count++;
+            }
+            else if (page->text[row][col] == 0xb || page->text[row][col] == 0xa)
+            {
+                // replace all 0/B and 0/A characters with 0/20, as specified in ETS 300 706:
+                // 'Unless operating in "Hold Mosaics" mode, each character space occupied by a
+                // spacing attribute is displayed as a SPACE
+                page->text[row][col] = 0x20;
+            }
+        }
 		// line is empty
 		if (col_start > 39)
 			continue;

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -646,18 +646,22 @@ void process_page(struct TeletextCtx *ctx, teletext_page_t *page, struct cc_subt
                 if (col > 1 && page->text[row][col-1] == 0xb) //
                 {
                     // check for 0/A, to cancel the action of the Start Box code 0/B
+                    int a_detected = 0; // is 0/A detected in front of 0/B?
                     for (int8_t temp = col-1; temp >= 0; temp--)
                     {
-                        // replace 0/A and 0/B with space
+                        // replace 0/A with space
                         if (page->text[row][temp] == 0xa)
                         {
                             page->text[row][temp] = 0x20;
-                            page->text[row][col] = 0x20;
-                            page->text[row][col-1] = 0x20;
-                            break;
+                            a_detected = 1;
                         }
                     }
-                    continue;
+
+                    if (a_detected)
+                    {
+                        page->text[row][col] = 0x20;
+                        page->text[row][col-1] = 0x20;
+                    }
                 }//
                 else
                 {
@@ -913,7 +917,7 @@ void process_telx_packet(struct TeletextCtx *ctx, data_unit_t data_unit_id, tele
 		{
 			tlt_config.page = (m << 8) | (unham_8_4(packet->data[1]) << 4) | unham_8_4(packet->data[0]);
 			mprint ("- No teletext page specified, first received suitable page is %03x, not guaranteed\n", tlt_config.page);
-			}
+        }
 
 		// Page number and control bits
 		page_number = (m << 8) | (unham_8_4(packet->data[1]) << 4) | unham_8_4(packet->data[0]);

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -638,8 +638,7 @@ void process_page(struct TeletextCtx *ctx, teletext_page_t *page, struct cc_subt
         uint8_t col_start = 40;
         uint8_t col_stop = 40;
 
-        uint8_t last_replacement_index = 0;
-        int box_open = 0;
+        uint8_t box_open = NO;
         for (int8_t col = 0; col < 40; col++)
         {
             // replace all 0/B and 0/A characters with 0/20, as specified in ETS 300 706:
@@ -656,13 +655,12 @@ void process_page(struct TeletextCtx *ctx, teletext_page_t *page, struct cc_subt
                 {
                     page->text[row][col] = 0x20;
                 }
-                box_open = 1;
+                box_open = YES;
             }
             else if (page->text[row][col] == 0xa) // close the box
             {
                 page->text[row][col] = 0x20;
-                last_replacement_index = col; // remember the last index of replacement
-                box_open = 0;
+                box_open = NO;
             }
             // characters between 0xA and 0xB shouldn't be displayed
             // page->text[row][col] > 0x20 added to preserve color information
@@ -670,11 +668,6 @@ void process_page(struct TeletextCtx *ctx, teletext_page_t *page, struct cc_subt
             {
                 page->text[row][col] = 0x20;
             }
-        }
-        // put 0xa back to last_replacement_index
-        if (last_replacement_index)
-        {
-            page->text[row][last_replacement_index] = 0xa;
         }
 		// line is empty
 		if (col_start > 39)
@@ -688,8 +681,6 @@ void process_page(struct TeletextCtx *ctx, teletext_page_t *page, struct cc_subt
 					col_start = col;
 				col_stop = col;
 			}
-			if (page->text[row][col] == 0xa)
-				break;
 		}
 		// line is empty
 		if (col_stop > 39)

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -637,6 +637,7 @@ void process_page(struct TeletextCtx *ctx, teletext_page_t *page, struct cc_subt
         // anchors for string trimming purpose
         uint8_t col_start = 40;
         uint8_t col_stop = 40;
+        uint8_t last_replacement_index = 0;
 
         for (int8_t col = 0; col < 40; col++)
         {
@@ -651,7 +652,13 @@ void process_page(struct TeletextCtx *ctx, teletext_page_t *page, struct cc_subt
                 // 'Unless operating in "Hold Mosaics" mode, each character space occupied by a
                 // spacing attribute is displayed as a SPACE
                 page->text[row][col] = 0x20;
+                last_replacement_index = col; // remember the last index of replacement
             }
+        }
+        // change the value of last position to 0xa to indicate end of subtitle
+        if (last_replacement_index)
+        {
+            page->text[row][last_replacement_index] = 0xa;
         }
 		// line is empty
 		if (col_start > 39)

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -658,13 +658,15 @@ void process_page(struct TeletextCtx *ctx, teletext_page_t *page, struct cc_subt
                 }
                 box_open = 1;
             }
+            else if (page->text[row][col] == 0xa) // close the box
             {
                 page->text[row][col] = 0x20;
                 last_replacement_index = col; // remember the last index of replacement
                 box_open = 0;
             }
             // characters between 0xA and 0xB shouldn't be displayed
-            else if (!box_open && col_start < 40)
+            // page->text[row][col] > 0x20 added to preserve color information
+            else if (!box_open && col_start < 40 && page->text[row][col] > 0x20)
             {
                 page->text[row][col] = 0x20;
             }

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -634,41 +634,41 @@ void process_page(struct TeletextCtx *ctx, teletext_page_t *page, struct cc_subt
 	// process data
 	for (uint8_t row = 1; row < 25; row++)
 	{
-        // anchors for string trimming purpose
-        uint8_t col_start = 40;
-        uint8_t col_stop = 40;
+        	// anchors for string trimming purpose
+        	uint8_t col_start = 40;
+        	uint8_t col_stop = 40;
 
-        uint8_t box_open = NO;
-        for (int8_t col = 0; col < 40; col++)
-        {
-            // replace all 0/B and 0/A characters with 0/20, as specified in ETS 300 706:
-            // Unless operating in "Hold Mosaics" mode, each character space occupied by a
-            // spacing attribute is displayed as a SPACE
-            if (page->text[row][col] == 0xb) // open the box
-            {
-                if (col_start == 40)
-                {
-                    col_start = col;
-                    line_count++;
-                }
-                else
-                {
-                    page->text[row][col] = 0x20;
-                }
-                box_open = YES;
-            }
-            else if (page->text[row][col] == 0xa) // close the box
-            {
-                page->text[row][col] = 0x20;
-                box_open = NO;
-            }
-            // characters between 0xA and 0xB shouldn't be displayed
-            // page->text[row][col] > 0x20 added to preserve color information
-            else if (!box_open && col_start < 40 && page->text[row][col] > 0x20)
-            {
-                page->text[row][col] = 0x20;
-            }
-        }
+        	uint8_t box_open = NO;
+        	for (int8_t col = 0; col < 40; col++)
+        	{
+            		// replace all 0/B and 0/A characters with 0/20, as specified in ETS 300 706:
+            		// Unless operating in "Hold Mosaics" mode, each character space occupied by a
+            		// spacing attribute is displayed as a SPACE
+            		if (page->text[row][col] == 0xb) // open the box
+            		{
+                		if (col_start == 40)
+                		{
+                    			col_start = col;
+                    			line_count++;
+                		}
+                		else
+                		{
+                    			page->text[row][col] = 0x20;
+                		}
+                		box_open = YES;
+            		}
+            		else if (page->text[row][col] == 0xa) // close the box
+            		{
+                		page->text[row][col] = 0x20;
+                		box_open = NO;
+            		}
+            		// characters between 0xA and 0xB shouldn't be displayed
+            		// page->text[row][col] > 0x20 added to preserve color information
+            		else if (!box_open && col_start < 40 && page->text[row][col] > 0x20)
+            		{
+                		page->text[row][col] = 0x20;
+            		}
+        	}
 		// line is empty
 		if (col_start > 39)
 			continue;


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---
Attempt to solve issue #922 by replacing 0xB and 0xA in the middle of row with space character

Generated srt:
![fixed](https://user-images.githubusercontent.com/32807097/35971299-868bc1c8-0d08-11e8-8c11-0ff6d0f2c7a6.PNG)


Playing the generated srt on windows 10 Movies & TV app:
![geeignet](https://user-images.githubusercontent.com/32807097/35971281-68460bc4-0d08-11e8-996e-9c6078a391fd.PNG)



