### PR TITLE
[FIX] Minor issue with spaces in teletext

### DIFF
--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -739,7 +739,8 @@ void process_page(struct TeletextCtx *ctx, teletext_page_t *page, struct cc_subt
 							page_buffer_add_string (ctx, "</font>");
 							font_tag_opened = NO;
 						}
-
+                                                
+						page_buffer_add_string(ctx, " ");
 						// black is considered as white for telxcc purpose
 						// telxcc writes <font/> tags only when needed
 						if ((v > 0x0) && (v < 0x7))


### PR DESCRIPTION
- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [X] I absolutely love CCExtractor, but have not contributed previously.

---

Currently setting a colour doesn't necessarily add a space even though the specifications mandate it. This commit is designed to change that.

This is designed to fix a different problem than #922. There is currently no space when the colour changes in teletext (except with --nofontcolor). See for example [this sample](https://github.com/CCExtractor/ccextractor/files/1721771/Sample.zip) which contains multiple instances of what I am talking about. The default output (with colours) contains the following (only lines that show this have been kept):
```
2
00:00:03,240 --> 00:00:06,039
<font color="#ffff00">Dann räumen wir</font>
<font color="#ffff00">mal aus, oder?</font><font color="#00ffff">Ja.</font>

4
00:00:18,200 --> 00:00:20,919
<font color="#00ff00">Toby, sag mal</font>
<font color="#00ff00">"Infrastruktur"!</font><font color="#ff00ff">"Infaschuktur".</font>


12
00:00:43,480 --> 00:00:46,319
<font color="#00ff00">Schön!</font>Und wie ist das so?
```
Whereas with --nofontcolor the output is:
```
2
00:00:03,240 --> 00:00:06,039
Dann räumen wir
mal aus, oder? Ja.

4
00:00:18,200 --> 00:00:20,919
Toby, sag mal
"Infrastruktur"! "Infaschuktur".

12
00:00:43,480 --> 00:00:46,319
Schön! Und wie ist das so?
```
As one sees without --nofontcolor there is no space between '?' and 'Ja' in the second line, between '!' and '"' in the fourth and between '!' and 'U' in the 12th line. This little patch adresses this.