### PR TITLE
[IMPROVEMENT] Modify -quant 0 option

### DIFF
--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -191,6 +191,9 @@ BOX* ignore_alpha_at_edge(png_byte *alpha, unsigned char* indata, int w, int h, 
 
 char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* indata,int w, int h, struct image_copy *copy)
 {
+	// uncomment the below lines to output raw image as debug.png iteratively
+	//save_spupng("debug.png", indata, w, h, palette, alpha, 16);
+
 	PIX	*pix = NULL;
 	PIX	*cpix = NULL;
 	PIX *color_pix = NULL;
@@ -660,7 +663,7 @@ static int quantize_map(png_byte *alpha, png_color *palette,
 #endif
 	/**
 	 * using selection  sort since need to find only max_color
-	 * Hostogram becomes invalid in this loop
+	 * Histogram becomes invalid in this loop
 	 */
 	for (int i = 0; i < max_color; i++)
 	{
@@ -774,7 +777,24 @@ int ocr_rect(void* arg, struct cc_bitmap *rect, char **str, int bgcolor, int ocr
 			case 1:
 				quantize_map(alpha, palette, rect->data[0], size, 3, rect->nb_colors);
 				break;
-		}		
+
+			// Case 2 reduces the color set of the image
+			case 2:
+				for(int i=0; i<(rect->nb_colors); i++)
+				{
+					// Taking the quotient of the palette color with 8 shades in each RGB 
+					palette[i].red=(int)((palette[i].red+1)/32);
+					palette[i].blue=(int)((palette[i].blue+1)/32);
+					palette[i].green=(int)((palette[i].green+1)/32);
+
+					// Making the palette color value closest to original, from among the 8 set colors
+					palette[i].red*=32;
+					palette[i].blue*=32;
+					palette[i].green*=32;
+				}
+				break;
+		}
+
 		*str = ocr_bitmap(arg, palette, alpha, rect->data[0], rect->w, rect->h, copy);
 
 end:

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -619,9 +619,10 @@ void print_usage (void)
 	mprint ("                       This option is also helpful when the traineddata file\n");
 	mprint ("                       has non standard names that don't follow ISO specs\n");
 	mprint ("          -quant mode: How to quantize the bitmap before passing it to tesseract");
-	mprint ("                       for OCR'ing.");
-	mprint ("                              0 = Don't quantize at all.");
-	mprint ("                              1 = Use CCExtractor's internal function (default).");
+	mprint ("                       for OCR'ing.\n");
+	mprint ("                       0: Don't quantize at all.\n");
+	mprint ("                       1: Use CCExtractor's internal function (default).\n");
+	mprint ("                       2: Reduce distinct color count in image for faster results.\n");
 	mprint ("                 -oem: Select the OEM mode for Tesseract, could be 0, 1 or 2.\n");
 	mprint ("                       0: OEM_TESSERACT_ONLY - default value, the fastest mode.\n");
 	mprint ("                       1: OEM_LSTM_ONLY - use LSTM algorithm for recognition.\n");


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
 - [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [X] I am an active contributor to CCExtractor.

---
This pull request aims at simplifying and making the -quant 0 parameter faster. It does so by reducing the number of distinct color shades available in the palette of the PNG image under processing. 

An example would be, say a palette color is (248, 187, 027). The new algorithm reduces this image to (224, 160, 0). This is one quantised value amongst the (8*8*8) which can be formed under this algorithm. Since the color palette is reduced and our rect bitmap structures point to palette for their pixel color value; in a way this algorithm decreases the color value to the nearest multiple of 32 for R,G,B; effectively quantising it without much reduction in the actual image visibility. 

As can be seen in the below screenshot, this method improves the time taken (92 seconds vs 100 seconds) and also gives a better result than no quantisation. 

![With 8-bit color reduction](https://user-images.githubusercontent.com/32812320/36497081-47a274d6-1760-11e8-8a6e-f1ff883af9d6.png)

As is marked in the below screenshot (with no quant algorithm at all), a dialogue is read as "Are you off the deck". This is a mistake which does not happen and is read as "Are you off the clock" with the improved algorithm. The video is provided along with the timestamp to check for authenticity.

![without color reduction](https://user-images.githubusercontent.com/32812320/36497173-835fbc2c-1760-11e8-9044-f0a1d4527320.png)

![video screenshot](https://user-images.githubusercontent.com/32812320/36497188-8ecdec28-1760-11e8-9955-e68e72ed51c0.png)

At last below is a diff between the two files to see the other error corrections that the method provides, (for example it correctly reads "I" (capital "i") which were read as "|")

![difference between the two extracted subtitles](https://user-images.githubusercontent.com/32812320/36497260-cd5e6eae-1760-11e8-8c30-f26ffd1f6222.png)

For video file, refer issue #929 

Minor Addition: Added below line which can be uncommented to output debug.png from ocr_bitmap() function
`save_spupng("debug.png", indata, w, h, palette, alpha, 16);`
