### PR TITLE
[FIX]Fix failing cmake due to liblept/tesseract header files

### DIFF
--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -3,8 +3,6 @@
 #include "utf8proc.h"
 #include "zlib.h"
 #include "gpac/version.h"
-#include "capi.h"
-#include "allheaders.h"
 #include "lib_ccx.h"
 #include "ccx_common_option.h"
 #include "utility.h"
@@ -16,6 +14,12 @@
 #include "../lib_hash/sha2.h"
 #include <string.h>
 #include <stdio.h>
+
+#ifdef ENABLE_OCR
+#include "capi.h"
+#include "allheaders.h"
+#endif
+
 #ifdef ENABLE_HARDSUBX
 #include "hardsubx.h"
 #endif
@@ -968,7 +972,7 @@ void version(char *location) {
 #endif
 	mprint("	libGPAC Version: %s\n", GPAC_VERSION);
 	mprint("	zlib: %s\n", ZLIB_VERSION);
-	mprint("	utf8proc Version: %s\n", (const char*) utf8proc_version());
+//	mprint("	utf8proc Version: %s\n", (const char*) utf8proc_version());
 	mprint("	protobuf-c Version: %s\n", (const char*) protobuf_c_version());
 	mprint("	libpng Version: %s\n", PNG_LIBPNG_VER_STRING);
 	mprint("	FreeType \n");


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [X] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---
Bug introduced in #939 
Removed utf8proc which make couldn't identify.
