### PR TITLE
[IMPROVEMENT] Add instruction required to build ccextractor with hardsubx support

### DIFF
--- a/docs/HARDSUBX.txt
+++ b/docs/HARDSUBX.txt
@@ -37,6 +37,7 @@ pkg-config --libs libswscale
 On success, you should see the correct include directory path and the linker flags.
 
 To build the program with hardsubx support, from the Linux directory run:-
+./configure --enable-hardsubx
 make ENABLE_HARDSUBX=yes
 
 NOTE: The build has been tested with FFMpeg version 3.1.0, and Tesseract 3.04.


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [x] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

To build ccextractor with hardsubx support on linux, we need to configure
ccextractor with the `-enable-hardsubx` switch along with the
`ENABLE_HARDSUBX` flag passed during compilation with make. This commit
adds the missing configure instruction.
