### PR TITLE
[FIX] Implicit declaration of these functions throws warning during build

### DIFF
--- a/src/gpacmp4/isom_write.c
+++ b/src/gpacmp4/isom_write.c
@@ -40,6 +40,8 @@ GF_Err CanAccessMovie(GF_ISOFile *movie, u32 Mode)
 }
 
 s32 gf_lang_find(const char *);
+const char *gf_lang_get_3cc(u32);
+
 
 static GF_Err unpack_track(GF_TrackBox *trak)
 {

--- a/src/gpacmp4/isom_write.c
+++ b/src/gpacmp4/isom_write.c
@@ -39,6 +39,8 @@ GF_Err CanAccessMovie(GF_ISOFile *movie, u32 Mode)
 	return GF_OK;
 }
 
+s32 gf_lang_find(const char *);
+
 static GF_Err unpack_track(GF_TrackBox *trak)
 {
 	GF_Err e = GF_OK;


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ x] I have checked that another pull request for this purpose does not exist.
- [x ] I have considered, and confirmed that this submission will be valuable to others.
- [x ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x ] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ x] I have used CCExtractor just a couple of times.
- [ x] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Should I declare these functions in a header file and include the header file rather than doing it this way?

P.S.: I used the build script on my linux machine which throws warning
