### PR TITLE
[FIX] Fix segfault in add_cc_sub_text and initialize to NULL in init_encoder 

### DIFF
--- a/src/lib_ccx/ccx_common_common.c
+++ b/src/lib_ccx/ccx_common_common.c
@@ -70,6 +70,8 @@ void freep(void *arg)
 int add_cc_sub_text(struct cc_subtitle *sub, char *str, LLONG start_time,
 		LLONG end_time, char *info, char *mode, enum ccx_encoding_type e_type)
 {
+	if (str == NULL || strlen(str) == 0)
+		return 0;
 	if (sub->nb_data)
 	{
 		for(;sub->next;sub = sub->next);

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -1038,6 +1038,7 @@ struct encoder_ctx *init_encoder(struct encoder_cfg *opt)
 	ctx->segment_last_key_frame = 0;
 	ctx->nospupngocr = opt->nospupngocr;
 
+	ctx->prev = NULL;
 	return ctx;
 }
 


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

This commit adds some checks to avoid segmentation faults.

* In `add_cc_sub_text()`, strdup will cause a segfault if we duplicate an
  empty string.

* In `init_encoder()`, initialize pointer fields to NULL to avoid random
  addressing so we can avoid illegal memory accessing and segfaults in
  other places.