### PR TITLE
[FEATURE] Display quantisation mode

### DIFF
--- a/src/lib_ccx/params_dump.c
+++ b/src/lib_ccx/params_dump.c
@@ -188,6 +188,23 @@ void params_dump(struct lib_ccx_ctx *ctx)
 				(long) (ccx_options.enc_cfg.endcreditsforatmost.time_in_ms/1000)
 		       );
 	}
+	// print quantisation mode used
+	mprint("[Quantisation-mode: ");
+	switch(ccx_options.ocr_quantmode)
+	{
+		case 0:
+			// when no quantisation
+			mprint("None]\n");
+			break;
+		case 1:
+			// default mode, CCExtractor's internal function
+			mprint("CCExtractor's internal function]\n");
+			break;
+		case 2:
+			// reduced color palette quantisation
+			mprint("Reduced color palette]\n");
+			break;
+	}
 }
 
 #define Y_N(cond) ((cond) ? "Yes" : "No")


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [X] I am an active contributor to CCExtractor.

---

Solves #953 
Concerns #929 

Displays the quantization mode used as shown in the below screen-shot. 

![screenshot from 2018-03-06 11-30-12](https://user-images.githubusercontent.com/32812320/37016927-7e7da0c4-2134-11e8-8fe4-971270b659de.png)
Argument set in above subtitle extraction is "-quant 2"

