### PR TITLE
[FIX]-nocf not working with OCR'ing

### DIFF
--- a/src/lib_ccx/ccx_common_option.c
+++ b/src/lib_ccx/ccx_common_option.c
@@ -64,7 +64,6 @@ void init_options (struct ccx_s_options *options)
 	options->ucla = 0; // By default, -UCLA not used
 	options->tickertext = 0; // By default, do not assume ticker style text
 	options->hardsubx = 0; // By default, don't try to extract hard subtitles
-	options->dvbcolor = 1; // By default, attempt to detect both text and color
 	options->dvblang = NULL; // By default, autodetect DVB language
 	options->ocrlang = NULL; // By default, autodetect .traineddata file
 	options->ocr_oem = 0; // By default, set Tesseract OEM mode OEM_TESSERACT_ONLY (0)

--- a/src/lib_ccx/ccx_common_option.h
+++ b/src/lib_ccx/ccx_common_option.h
@@ -134,7 +134,6 @@ struct ccx_s_options // Options from user parameters
 	int ucla;                         // 1 if UCLA used, 0 if not
 	int tickertext;                   // 1 if ticker text style burned in subs, 0 if not
 	int hardsubx;                     // 1 if burned-in subtitles to be extracted
-	int dvbcolor;                     // 1 if Color to be detected for DVB
 	char *dvblang;                    // The name of the language stream for DVB
 	char *ocrlang;                    // The name of the .traineddata file to be loaded with tesseract
 	int ocr_oem;                      // The Tesseract OEM mode, could be 0 (default), 1 or 2

--- a/src/lib_ccx/ccx_encoders_splitbysentence.c
+++ b/src/lib_ccx/ccx_encoders_splitbysentence.c
@@ -9,7 +9,7 @@
  * Only SBS-related bugs!
  *
  * IMPORTANT: SBS is color-blind, and color tags mislead SBS.
- * Please, use `-sbs` option with `-nodvbcolor` (actual for CCE 0.8.5)
+ * Please, use `-sbs` option with `-nofc` (actual for CCE 0.8.5)
  */
 
 #include "ccx_common_platform.h"

--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -287,7 +287,8 @@ char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* i
 	TessDeleteText(text_out_from_tes);
 
 	// Begin color detection
-	if(ccx_options.dvbcolor && strlen(text_out)>0)
+	// Using tlt_config.nofontcolor (true when "--nofontcolor" parameter used) to skip color detection if not required
+	if(ccx_options.dvbcolor && strlen(text_out)>0 && !tlt_config.nofontcolor)
 	{
 		float h0 = -100;
 		int written_tag = 0;

--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -288,7 +288,7 @@ char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* i
 
 	// Begin color detection
 	// Using tlt_config.nofontcolor (true when "--nofontcolor" parameter used) to skip color detection if not required
-	if(ccx_options.dvbcolor && strlen(text_out)>0 && !tlt_config.nofontcolor)
+	if(strlen(text_out)>0 && !tlt_config.nofontcolor)
 	{
 		float h0 = -100;
 		int written_tag = 0;

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -614,9 +614,6 @@ void print_usage (void)
 	mprint ("                       2 = live output. 3 = both\n");
 	mprint ("                 -sem: Create a .sem file for each output file that is open\n");
 	mprint ("                       and delete it on file close.\n");
-	mprint ("            -dvbcolor: For DVB subtitles, also output the color of the\n");
-	mprint ("                       subtitles, if the output format is SRT or WebVTT.\n");
-	mprint ("          -nodvbcolor: In DVB subtitles, disable color in output.\n");
 	mprint ("             -dvblang: For DVB subtitles, select which language's caption\n");
 	mprint ("                       stream will be processed. e.g. 'eng' for English.\n");
 	mprint ("                       If there are multiple languages, only this specified\n");
@@ -1486,18 +1483,6 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 			{
 				mprint("Invalid option for codec %s\n",argv[i]);
 			}
-			continue;
-		}
-
-		if(strcmp(argv[i],"-dvbcolor")==0)
-		{
-			opt->dvbcolor = 1;
-			continue;
-		}
-		// -dvbcolor counterpart
-		if (strcmp(argv[i], "-nodvbcolor") == 0)
-		{
-			opt->dvbcolor = 0;
 			continue;
 		}
 


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [X] I am an active contributor to CCExtractor.

---

Fix #955 

The addition of check for "tlt_config.nofontcolor" allows CCExtractor to skip detecting colors in the Optical Character Reading mode.

![screenshot from 2018-03-07 01-05-55](https://user-images.githubusercontent.com/32812320/37055462-cdb18318-21a7-11e8-8ebf-057469feb0a4.png)

arguments used for nofc:  
`-nofc -in=ts -nobom -trim -noteletext -codec dvbsub -dvblang bul -ocrlang bul animalplanet.ts`

arguments used without nofc:
`-in=ts -nobom -trim -noteletext -codec dvbsub -dvblang bul -ocrlang bul animalplanet.ts`

