### PR TITLE
[IMPROVEMENT] [FIX] Improve the start and end timestamps of extracted burned in captions

### DIFF
--- a/src/lib_ccx/hardsubx_decoder.c
+++ b/src/lib_ccx/hardsubx_decoder.c
@@ -374,13 +374,16 @@ int hardsubx_process_frames_tickertext(struct lib_hardsubx_ctx *ctx, struct enco
 int hardsubx_process_frames_linear(struct lib_hardsubx_ctx *ctx, struct encoder_ctx *enc_ctx)
 {
 	// Do an exhaustive linear search over the video
+
+	int prev_sub_encoded = 1; // Previous seen subtitle encoded or not
 	int got_frame;
-	int dist;
+	int dist = 0;
 	int cur_sec,total_sec,progress;
 	int frame_number = 0;
-	int64_t begin_time = 0,end_time = 0,prev_packet_pts = 0;
-	char *subtitle_text=NULL;
-	char *prev_subtitle_text=NULL;
+	int64_t prev_begin_time = 0, prev_end_time = 0; // Begin and end time of previous seen subtitle
+	int64_t prev_packet_pts = 0;
+	char *subtitle_text=NULL; // Subtitle text of current frame
+	char *prev_subtitle_text=NULL; // Previously seen subtitle text
 
 	while(av_read_frame(ctx->format_ctx, &ctx->packet)>=0)
 	{
@@ -425,27 +428,42 @@ int hardsubx_process_frames_linear(struct lib_hardsubx_ctx *ctx, struct encoder_
 				progress = (cur_sec*100)/total_sec;
 				activity_progress(progress,cur_sec/60,cur_sec%60);
 
-				if(subtitle_text==NULL)
-					continue;
-				if(!strlen(subtitle_text))
-					continue;
-				char *double_enter = strstr(subtitle_text,"\n\n");
-				if(double_enter!=NULL)
-					*(double_enter)='\0';
-				//subtitle_text = prune_string(subtitle_text);
+				if((!subtitle_text && !prev_subtitle_text) || (subtitle_text && !strlen(subtitle_text) && !prev_subtitle_text)) {
+					prev_end_time = convert_pts_to_ms(ctx->packet.pts, ctx->format_ctx->streams[ctx->video_stream_id]->time_base);
+				}
 
-				end_time = convert_pts_to_ms(ctx->packet.pts, ctx->format_ctx->streams[ctx->video_stream_id]->time_base);
-				if(prev_subtitle_text)
+				if(subtitle_text) {
+					char *double_enter = strstr(subtitle_text,"\n\n");
+					if(double_enter!=NULL)
+						*(double_enter)='\0';
+				}
+
+				if(!prev_sub_encoded && prev_subtitle_text)
 				{
-					//TODO: Encode text with highest confidence
-					dist = edit_distance(subtitle_text, prev_subtitle_text, strlen(subtitle_text), strlen(prev_subtitle_text));
-
-					if(dist > (0.2 * fmin(strlen(subtitle_text), strlen(prev_subtitle_text))))
+					if(subtitle_text)
 					{
-						add_cc_sub_text(ctx->dec_sub, prev_subtitle_text, begin_time, end_time, "", "BURN", CCX_ENC_UTF_8);
-						encode_sub(enc_ctx, ctx->dec_sub);
-						begin_time = end_time + 1;
+						dist = edit_distance(subtitle_text, prev_subtitle_text, strlen(subtitle_text), strlen(prev_subtitle_text));
+						if(dist < (0.2 * fmin(strlen(subtitle_text), strlen(prev_subtitle_text))))
+						{
+							dist = -1;
+							subtitle_text = NULL;
+							prev_end_time = convert_pts_to_ms(ctx->packet.pts, ctx->format_ctx->streams[ctx->video_stream_id]->time_base);
+						}
 					}
+					if(dist != -1)
+					{
+						add_cc_sub_text(ctx->dec_sub, prev_subtitle_text, prev_begin_time, prev_end_time, "", "BURN", CCX_ENC_UTF_8);
+						encode_sub(enc_ctx, ctx->dec_sub);
+						prev_begin_time = prev_end_time + 1;
+						prev_subtitle_text = NULL;
+						prev_sub_encoded = 1;
+						prev_end_time = convert_pts_to_ms(ctx->packet.pts, ctx->format_ctx->streams[ctx->video_stream_id]->time_base);
+						if(subtitle_text) {
+							prev_subtitle_text = strdup(subtitle_text);
+							prev_sub_encoded = 0;
+						}
+					}
+					dist = 0;
 				}
 
 				// if(ctx->conf_thresh > 0)
@@ -460,15 +478,24 @@ int hardsubx_process_frames_linear(struct lib_hardsubx_ctx *ctx, struct encoder_
 				// {
 				// 	prev_subtitle_text = strdup(subtitle_text);
 				// }
-				prev_subtitle_text = strdup(subtitle_text);
+
+				if(!prev_subtitle_text && subtitle_text) {
+					prev_begin_time = prev_end_time + 1;
+					prev_end_time = convert_pts_to_ms(ctx->packet.pts, ctx->format_ctx->streams[ctx->video_stream_id]->time_base);
+					prev_subtitle_text = strdup(subtitle_text);
+					prev_sub_encoded = 0;
+				}
 				prev_packet_pts = ctx->packet.pts;
 			}
 		}
 		av_packet_unref(&ctx->packet);
 	}
 
-	add_cc_sub_text(ctx->dec_sub, prev_subtitle_text, begin_time, end_time, "", "BURN", CCX_ENC_UTF_8);
-	encode_sub(enc_ctx, ctx->dec_sub);
+	if(!prev_sub_encoded) {
+		add_cc_sub_text(ctx->dec_sub, prev_subtitle_text, prev_begin_time, prev_end_time, "", "BURN", CCX_ENC_UTF_8);
+		encode_sub(enc_ctx, ctx->dec_sub);
+		prev_sub_encoded = 1;
+	}
 	activity_progress(100,cur_sec/60,cur_sec%60);
 
 }


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

The start and end timestamps of extracted burned in captions are flawed
and off by a large difference. Also, the start time of the first burned
in caption extracted is always zero, which is not always the case. And
the extracted captions always appear in continuous timestamps.

To see that, you can download this file from the UK TV Samples in the samples repository:
https://drive.google.com/open?id=0B_61ywKPmI0TdlRWcVdnajVJUWs

Since the duration of that file is 15 minutes, we can trim it down to 30 seconds for our purposes:
`ffmpeg -i BBC1.mp4 -acodec copy -vcodec copy -scodec copy -ss 00:00:00 -t 00:00:30 bbc.mp4`

This will generate the first 30 seconds of the `BBC1.mp4` in `bbc.mp4`.
Now, before this commit, if I compile ccextractor with hard subs enabled and run the following command:
`./ccextractor bbc.mp4 -hardsubx -sub_color yellow -conf_thresh 60`,
the generated `bbc.srt`(ignore the weird looking characters, that is just OCR not giving a good output I guess) is:
```
1
00:00:00,000 --> 00:00:08,500
Oh, no. No, lim tired.

2
00:00:08,502 --> 00:00:09,380
.‘7 -
Oh, no. No, I'm tired.

3
00:00:09,382 --> 00:00:14,380
Baby shower was rubbish.
I'm just going to go to bed.

4
00:00:14,382 --> 00:00:15,340
Are you OK? '_‘ -' _: 1:. . .. '... .

5
00:00:15,342 --> 00:00:16,500
Are you OK?

6
00:00:16,502 --> 00:00:18,340
Are you OK? ‘

7
00:00:18,342 --> 00:00:23,460
All right. Well, don't stay up
'too late. You've got a lot to do.

8
00:00:23,462 --> 00:00:28,380
I ..' Night-night.

9
00:00:28,382 --> 00:00:28,380
“Sir-ht :l 1 .

```
One can see that the timings are clearly flawed, and are off by a large margin.
Also, the way that the code is written, the first extracted caption will always have
a starting timestamp of 00:00:00. Also, the extracted subtitles always come one after
the other in terms of time(i.e., there is only a 2 ms gap between two consecutive captions
making it look like the whole video had hard subs in it throughout).

This commit improves the start and end timestamps of the extracted
burned in captions and reduces the error significantly, bringing the
timestamps fairly close to the actual timings as they appear in the
media file.

With these changes included, and running the command:
`./ccextractor bbc.mp4 -hardsubx -sub_color yellow -conf_thresh 60`,
the generated `bbc.srt` is:
```
1
00:00:07,342 --> 00:00:08,500
.‘7 -
Oh, no. No, I'm tired.

2
00:00:09,382 --> 00:00:10,300
Baby shower was rubbish.
I'm just going to go to bed.

3
00:00:14,382 --> 00:00:15,340
Are you OK?

4
00:00:15,342 --> 00:00:16,500
Are you OK? ‘

5
00:00:17,382 --> 00:00:22,380
All right. Well, don't stay up*
too late. You've got a lot to do.

6
00:00:22,382 --> 00:00:23,460
I ..' Night-night.

```
One can see that while the OCR output is the same, the timings have improved and
are closer to the actual timings in the media file.