### PR TITLE
[FIX] Fix possible segfaults in hardsubx_classifier.c due to strdup

### DIFF
--- a/src/lib_ccx/hardsubx_classifier.c
+++ b/src/lib_ccx/hardsubx_classifier.c
@@ -48,9 +48,12 @@ char *get_ocr_text_wordwise(struct lib_hardsubx_ctx *ctx, PIX *image)
 	{
 		do
 		{
-			char* word = strdup(TessResultIteratorGetUTF8Text(it, level));
-			if(word==NULL || strlen(word)==0)
+			char* word;
+			char* ts_word = TessResultIteratorGetUTF8Text(it, level);
+			if(ts_word==NULL || strlen(ts_word)==0)
 				continue;
+			word = strdup(ts_word);
+			TessDeleteText(ts_word);
 			if(text_out == NULL)
 			{
 				if(ctx->detect_italics)
@@ -136,9 +139,12 @@ char *get_ocr_text_letterwise(struct lib_hardsubx_ctx *ctx, PIX *image)
 	{
 		do
 		{
-			char* letter = strdup(TessResultIteratorGetUTF8Text(it, level));
-			if(letter==NULL || strlen(letter)==0)
+			char* letter;
+			char* ts_letter = TessResultIteratorGetUTF8Text(it, level);
+			if(ts_letter==NULL || strlen(ts_letter)==0)
 				continue;
+			letter = strdup(ts_letter);
+			TessDeleteText(ts_letter);
 			if(text_out==NULL)
 			{
 				text_out = strdup(letter);
@@ -203,9 +209,12 @@ char *get_ocr_text_wordwise_threshold(struct lib_hardsubx_ctx *ctx, PIX *image, 
 	{
 		do
 		{
-			char* word = strdup(TessResultIteratorGetUTF8Text(it, level));
-			if(word==NULL || strlen(word)==0)
+			char* word;
+			char* ts_word = TessResultIteratorGetUTF8Text(it, level);
+			if(ts_word ==NULL || strlen(ts_word)==0)
 				continue;
+			word = strdup(ts_word);
+			TessDeleteText(ts_word);
 			float conf = TessResultIteratorConfidence(it,level);
 			if(conf < threshold)
 				continue;
@@ -303,9 +312,12 @@ char *get_ocr_text_letterwise_threshold(struct lib_hardsubx_ctx *ctx, PIX *image
 	{
 		do
 		{
-			char* letter = strdup(TessResultIteratorGetUTF8Text(it, level));
-			if(letter==NULL || strlen(letter)==0)
+			char* letter;
+			char* ts_letter = TessResultIteratorGetUTF8Text(it, level);
+			if(ts_letter==NULL || strlen(ts_letter)==0)
 				continue;
+			letter = strdup(ts_letter);
+			TessDeleteText(ts_letter);
 			float conf = TessResultIteratorConfidence(it,level);
 			if(conf < threshold)
 				continue;


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

`strdup` will give a segmentation fault if the argument passed to it is
`NULL`. `TessResultIteratorGetUTF8Text` returns a `char*` which can be `NULL`
and we should not call `strdup` directly over it. Once we check if the
value returned is not `NULL`, then we can call `strdup`.

This also fixes #928.