### PR TITLE
[FEATURE] Allow build with hardsubx using cmake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ project (CCExtractor)
 option (WITH_FFMPEG "Build using FFmpeg demuxer and decoder" OFF)
 option (WITH_OCR "Build with OCR (Optical Character Recognition) feature" OFF)
 option (WITH_SHARING "Build with sharing and translation support" OFF)
+option (WITH_HARDSUBX "Build with support for burned-in subtitles" OFF)
 
 # Version number
 set (CCEXTRACTOR_VERSION_MAJOR 0)
@@ -149,16 +150,19 @@ if (PKG_CONFIG_FOUND AND WITH_FFMPEG)
   pkg_check_modules (AVFORMAT REQUIRED libavformat)
   pkg_check_modules (AVUTIL REQUIRED libavutil)
   pkg_check_modules (AVCODEC REQUIRED libavcodec)
+  pkg_check_modules (AVFILTER REQUIRED libavfilter)
   pkg_check_modules (SWSCALE REQUIRED libswscale)
 
   set (EXTRA_LIBS ${EXTRA_LIBS} ${AVFORMAT_LIBRARIES})
   set (EXTRA_LIBS ${EXTRA_LIBS} ${AVUTIL_LIBRARIES})
   set (EXTRA_LIBS ${EXTRA_LIBS} ${AVCODEC_LIBRARIES})
+  set (EXTRA_LIBS ${EXTRA_LIBS} ${AVFILTER_LIBRARIES})
   set (EXTRA_LIBS ${EXTRA_LIBS} ${SWSCALE_LIBRARIES})
 
   set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${AVFORMAT_INCLUDE_DIRS})
   set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${AVUTIL_INCLUDE_DIRS})
   set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${AVCODEC_INCLUDE_DIRS})
+  set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${AVFILTER_INCLUDE_DIRS})
   set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${SWSCALE_INCLUDE_DIRS})
 
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DENABLE_FFMPEG")
@@ -194,6 +198,31 @@ if (PKG_CONFIG_FOUND AND WITH_SHARING)
 
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DENABLE_SHARING")
 endif (PKG_CONFIG_FOUND AND WITH_SHARING)
+
+########################################################
+# Build for hardsubx using avformat, avutil, avcodec and
+# swscale
+########################################################
+
+if (PKG_CONFIG_FOUND AND WITH_HARDSUBX)
+
+  pkg_check_modules (AVFORMAT REQUIRED libavformat)
+  pkg_check_modules (AVUTIL REQUIRED libavutil)
+  pkg_check_modules (AVCODEC REQUIRED libavcodec)
+  pkg_check_modules (SWSCALE REQUIRED libswscale)
+
+  set (EXTRA_LIBS ${EXTRA_LIBS} ${AVFORMAT_LIBRARIES})
+  set (EXTRA_LIBS ${EXTRA_LIBS} ${AVUTIL_LIBRARIES})
+  set (EXTRA_LIBS ${EXTRA_LIBS} ${AVCODEC_LIBRARIES})
+  set (EXTRA_LIBS ${EXTRA_LIBS} ${SWSCALE_LIBRARIES})
+
+  set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${AVFORMAT_INCLUDE_DIRS})
+  set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${AVUTIL_INCLUDE_DIRS})
+  set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${AVCODEC_INCLUDE_DIRS})
+  set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${SWSCALE_INCLUDE_DIRS})
+
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DENABLE_HARDSUBX")
+endif (PKG_CONFIG_FOUND AND WITH_HARDSUBX)
 
 add_executable (ccextractor ${SOURCEFILE} ${FREETYPE_SOURCE} ${UTF8PROC_SOURCE})
 target_link_libraries (ccextractor ${EXTRA_LIBS})


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [X] I am an active contributor to CCExtractor.

---
Fixes #964 

To allow building with hardsubx, option has been added along with checking for the libraries it requires which have been cross-checked with Makefile.am

https://github.com/CCExtractor/ccextractor/blob/3d6a9f4d57e5fb63b004f5b341a310e8d931f7cf/linux/Makefile.am#L330

Below is the build result after implementing the changes and using cmake.

![screenshot from 2018-03-14 00-16-08](https://user-images.githubusercontent.com/32812320/37363780-cebe1e8e-271e-11e8-8068-00efdf33cc66.png)

`make -j8` was successful in compiling the source code. Below is the command used on a file to test.

![screenshot from 2018-03-14 00-16-33](https://user-images.githubusercontent.com/32812320/37363861-038c59e6-271f-11e8-8023-6f6aea432fe2.png)

The required library for building with FFMPEG, "avfilter", was not listed in the required libraries and hence has been added to it. This was done in response to an error caused at the time of testing (due to absence of libavfilter-dev in my system), below is the error. Parameters used:
`cd ./build`
`cmake -DWITH_FFMPEG=ON ../src/`
`make -j8`

![screenshot from 2018-03-14 00-13-29](https://user-images.githubusercontent.com/32812320/37363971-3c6b2788-271f-11e8-9eec-6ac512783fa2.png)

The tests were also done on a remote Digital Ocean droplet by forking the branch and hence are system independent and are working.



