### PR TITLE
[FIX] Correct -HARDSUBX Bug In CMake

### DIFF
--- a/src/lib_ccx/CMakeLists.txt
+++ b/src/lib_ccx/CMakeLists.txt
@@ -16,16 +16,19 @@ if (WITH_FFMPEG)
     pkg_check_modules (AVFORMAT REQUIRED libavformat)
     pkg_check_modules (AVUTIL REQUIRED libavutil)
     pkg_check_modules (AVCODEC REQUIRED libavcodec)
+    pkg_check_modules (AVFILTER REQUIRED libavfilter)
     pkg_check_modules (SWSCALE REQUIRED libswscale)
 
     set (EXTRA_LIBS ${EXTRA_LIBS} ${AVFORMAT_LIBRARIES})
     set (EXTRA_LIBS ${EXTRA_LIBS} ${AVUTIL_LIBRARIES})
     set (EXTRA_LIBS ${EXTRA_LIBS} ${AVCODEC_LIBRARIES})
+    set (EXTRA_LIBS ${EXTRA_LIBS} ${AVFILTER_LIBRARIES})
     set (EXTRA_LIBS ${EXTRA_LIBS} ${SWSCALE_LIBRARIES})
 
     set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${AVFORMAT_INCLUDE_DIRS})
     set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${AVUTIL_INCLUDE_DIRS})
     set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${AVCODEC_INCLUDE_DIRS})
+    set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${AVFILTER_INCLUDE_DIRS})
     set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${SWSCALE_INCLUDE_DIRS})
 
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DENABLE_FFMPEG")
@@ -57,6 +60,27 @@ aux_source_directory ("${PROJECT_SOURCE_DIR}/gpacmp4/" SOURCEFILE)
 add_library (ccx ${SOURCEFILE} ccx_dtvcc.h ccx_dtvcc.c)
 target_link_libraries (ccx ${EXTRA_LIBS})
 target_include_directories (ccx PUBLIC ${EXTRA_INCLUDES})
+
+if (WITH_HARDSUBX)
+    find_package(PkgConfig)
+
+    pkg_check_modules (AVFORMAT REQUIRED libavformat)
+    pkg_check_modules (AVUTIL REQUIRED libavutil)
+    pkg_check_modules (AVCODEC REQUIRED libavcodec)
+    pkg_check_modules (SWSCALE REQUIRED libswscale)
+
+    set (EXTRA_LIBS ${EXTRA_LIBS} ${AVFORMAT_LIBRARIES})
+    set (EXTRA_LIBS ${EXTRA_LIBS} ${AVUTIL_LIBRARIES})
+    set (EXTRA_LIBS ${EXTRA_LIBS} ${AVCODEC_LIBRARIES})
+    set (EXTRA_LIBS ${EXTRA_LIBS} ${SWSCALE_LIBRARIES})
+
+    set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${AVFORMAT_INCLUDE_DIRS})
+    set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${AVUTIL_INCLUDE_DIRS})
+    set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${AVCODEC_INCLUDE_DIRS})
+    set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${SWSCALE_INCLUDE_DIRS})
+
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DENABLE_HARDSUBX")
+endif (WITH_HARDSUBX)
 
 if (MINGW OR CYGWIN)
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DGPAC_CONFIG_WIN32")


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [X] I am an active contributor to CCExtractor.

---
Currently, during the building process with the "-HARDSUBX" parameter (implemented in #966 ) and cmake, the below error pops up.

![screenshot from 2018-04-02 02-01-44](https://user-images.githubusercontent.com/32812320/38177242-c9a7760a-361b-11e8-912c-ffd595d01754.png)

This error is caused since there is no setting for HARDSUBX in the CMAKELISTS.txt present inside the src/lib_ccx directory and hence the "-ENABLE_HARDSUBX" remains off.

This pull request fixes the error by adding the parameter and it's settings to the Cmake file.

[Tested independently on Digital Ocean server]
