### PR TITLE
Make the build reproducible

### DIFF
--- a/linux/pre-build.sh
+++ b/linux/pre-build.sh
@@ -21,7 +21,7 @@ fi
 if [ -z "$commit" ]; then
 	commit="Unknown"
 fi
-builddate=`date +%Y-%m-%d`
+builddate=`date --utc --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%Y-%m-%d`
 echo "Storing variables in file"
 echo "Commit: $commit"
 echo "Date: $builddate"

--- a/mac/pre-build.sh
+++ b/mac/pre-build.sh
@@ -21,7 +21,7 @@ fi
 if [ -z "$commit" ]; then
 	commit="Unknown"
 fi
-builddate=`date +%Y-%m-%d`
+builddate=`date --utc --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%Y-%m-%d`
 echo "Storing variables in file"
 echo "Commit: $commit"
 echo "Date: $builddate"


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that ccextractor could not be built reproducibly.

This is due to it including the current date.

This was originally filed in Debian as #896867 [1] and uses the
SOURCE_DATE_EPOCH environment variable [2].

 [0] https://reproducible-builds.org/
 [1] https://bugs.debian.org/896867
 [2] https://reproducible-builds.org/specs/source-date-epoch/