### PR TITLE
Fix caption loss due to CW command

### DIFF
--- a/src/lib_ccx/ccx_decoders_708.c
+++ b/src/lib_ccx/ccx_decoders_708.c
@@ -748,9 +748,11 @@ void dtvcc_handle_CWx_SetCurrentWindow(ccx_dtvcc_service_decoder *decoder, int w
 										   "window [%d] is not defined\n", window_id);
 }
 
-void dtvcc_handle_CLW_ClearWindows(ccx_dtvcc_service_decoder *decoder, int windows_bitmap)
+void dtvcc_handle_CLW_ClearWindows(ccx_dtvcc_ctx *dtvcc,ccx_dtvcc_service_decoder *decoder, int windows_bitmap)
 {
 	ccx_common_logging.debug_ftn(CCX_DMT_708, "[CEA-708] dtvcc_handle_CLW_ClearWindows: windows: ");
+	int screen_content_changed = 0,
+		window_had_content;
 	if (windows_bitmap == 0)
 		ccx_common_logging.debug_ftn(CCX_DMT_708, "none\n");
 	else
@@ -760,12 +762,22 @@ void dtvcc_handle_CLW_ClearWindows(ccx_dtvcc_service_decoder *decoder, int windo
 			if (windows_bitmap & 1)
 			{
 				ccx_common_logging.debug_ftn(CCX_DMT_708, "[W%d] ", i);
+				window_had_content = window->is_defined && window->visible && !window->is_empty;
+				if (window_had_content)
+				{
+					screen_content_changed = 1;
+					_dtvcc_window_update_time_hide(window, dtvcc->timing);
+					_dtvcc_window_copy_to_screen(decoder, &decoder->windows[i]);
+				}
 				_dtvcc_window_clear(decoder, i);
 			}
 			windows_bitmap >>= 1;
 		}
 	}
 	ccx_common_logging.debug_ftn(CCX_DMT_708, "\n");
+	if (screen_content_changed && !_dtvcc_decoder_has_visible_windows(decoder))
+		_dtvcc_screen_print(dtvcc, decoder);
+	
 }
 
 void dtvcc_handle_DSW_DisplayWindows(ccx_dtvcc_service_decoder *decoder, int windows_bitmap, struct ccx_common_timing_ctx *timing)
@@ -1402,7 +1414,7 @@ int _dtvcc_handle_C1(ccx_dtvcc_ctx *dtvcc,
 			dtvcc_handle_CWx_SetCurrentWindow(decoder, com.code - CCX_DTVCC_C1_CW0); /* Window 0 to 7 */
 			break;
 		case CCX_DTVCC_C1_CLW:
-			dtvcc_handle_CLW_ClearWindows(decoder, data[1]);
+			dtvcc_handle_CLW_ClearWindows(dtvcc,decoder, data[1]);
 			break;
 		case CCX_DTVCC_C1_DSW:
 			dtvcc_handle_DSW_DisplayWindows(decoder, data[1], dtvcc->timing);

--- a/src/lib_ccx/ccx_decoders_708.c
+++ b/src/lib_ccx/ccx_decoders_708.c
@@ -761,12 +761,13 @@ void dtvcc_handle_CLW_ClearWindows(ccx_dtvcc_ctx *dtvcc,ccx_dtvcc_service_decode
 		{
 			if (windows_bitmap & 1)
 			{
+				
 				ccx_common_logging.debug_ftn(CCX_DMT_708, "[W%d] ", i);
-				window_had_content = window->is_defined && window->visible && !window->is_empty;
+				window_had_content = &decoder->windows[i]->is_defined && &decoder->windows[i]->visible && !&decoder->windows[i]->is_empty;
 				if (window_had_content)
 				{
 					screen_content_changed = 1;
-					_dtvcc_window_update_time_hide(window, dtvcc->timing);
+					_dtvcc_window_update_time_hide(&decoder->windows[i], dtvcc->timing);
 					_dtvcc_window_copy_to_screen(decoder, &decoder->windows[i]);
 				}
 				_dtvcc_window_clear(decoder, i);

--- a/src/lib_ccx/ccx_decoders_708.c
+++ b/src/lib_ccx/ccx_decoders_708.c
@@ -761,9 +761,9 @@ void dtvcc_handle_CLW_ClearWindows(ccx_dtvcc_ctx *dtvcc,ccx_dtvcc_service_decode
 		{
 			if (windows_bitmap & 1)
 			{
-				
+				ccx_dtvcc_window *window = &decoder->windows[i];
 				ccx_common_logging.debug_ftn(CCX_DMT_708, "[W%d] ", i);
-				window_had_content = &decoder->windows[i]->is_defined && &decoder->windows[i]->visible && !&decoder->windows[i]->is_empty;
+				window_had_content = window->is_defined && window->visible && !window->is_empty;
 				if (window_had_content)
 				{
 					screen_content_changed = 1;
@@ -776,7 +776,7 @@ void dtvcc_handle_CLW_ClearWindows(ccx_dtvcc_ctx *dtvcc,ccx_dtvcc_service_decode
 		}
 	}
 	ccx_common_logging.debug_ftn(CCX_DMT_708, "\n");
-	if (screen_content_changed && !_dtvcc_decoder_has_visible_windows(decoder))
+	if (screen_content_changed )
 		_dtvcc_screen_print(dtvcc, decoder);
 	
 }


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [ x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**


- [ x] I am an active contributor to CCExtractor.

---

Whenever ClearWindow command is issued to currently visible window , the captions stored in window are not copied to screen , since only toggle, hide window and delete window command do that right now , therefore data was out, with this PR , the caption are copied to screen and printed if there is some data and window was visible when Clearwindow was issued.