### PR TITLE
[IMPROVEMENT] Don't add files with empty filename & show better msg for multiple input files.

### DIFF
--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -122,7 +122,7 @@ int api_start(struct ccx_s_options api_options)
             switch (ctx->total_inputsize)
             {
                 case -1*ENOENT:
-                    fatal(EXIT_NO_INPUT_FILES, "Failed to open input file: File does not exist.");
+                    fatal(EXIT_NO_INPUT_FILES, "Failed to open one of the input file(s): File does not exist.");
                 case -1*EACCES:
                     fatal(EXIT_READ_ERROR, "Failed to open input file: Unable to access");
                 case -1*EINVAL:

--- a/src/lib_ccx/file_functions.c
+++ b/src/lib_ccx/file_functions.c
@@ -24,7 +24,7 @@ LLONG get_file_size (int in)
 	return length;
 }
 
-LLONG get_total_file_size (struct lib_ccx_ctx *ctx) // -1 if one or more files failed to open
+LLONG get_total_file_size (struct lib_ccx_ctx *ctx) // -1 if one of the file(s) failed to open
 {
 	LLONG ts=0;
 	int h;

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -114,6 +114,8 @@ int parsedelay (struct ccx_s_options *opt, char *par)
 
 int append_file_to_queue (struct ccx_s_options *opt,char *filename)
 {
+	if(filename[0] == '\0') //skip files with empty file name (ex : ./ccextractor "")
+		return 0;
 	char *c=(char *) malloc (strlen (filename)+1);
 	if (c==NULL)
 		return -1;

--- a/src/lib_ccx/params_dump.c
+++ b/src/lib_ccx/params_dump.c
@@ -11,8 +11,9 @@ void params_dump(struct lib_ccx_ctx *ctx)
 	switch (ccx_options.input_source)
 	{
 		case CCX_DS_FILE:
+			dbg_print(CCX_DMT_VERBOSE, "Files (%d): ", ctx->num_input_files);
 			for (int i=0;i<ctx->num_input_files;i++)
-				mprint ("%s%s",ctx->inputfile[i],i==(ctx->num_input_files-1)?"":",");
+				mprint ("%s%s",ctx->inputfile[i],i==(ctx->num_input_files-1)?"":", ");
 			break;
 		case CCX_DS_STDIN:
 			mprint ("stdin");


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

If CCExtractor is passed an empty argument, it tries to open it as a file. E.g.
`ccextractor ""` OR
`ccextractor {file1} "" {file2}`

In case of multiple input files, if one or more failed to open, CCExtractor exists with the message `Failed to open input file: File does not exist.` Since my second parameter was an empty filename `""` (came from an empty key in a script), I kept on thinking somehow "," is being appended to filename. 
It showed : `Input: filename,`.

With this PR:

- If filename is empty, that file is skipped.
- If one or more file fails to open, it tells that.
- Shows number of files while dumping parameters.