### PR TITLE
[Fix] Compilation using cmake on linux

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -137,7 +137,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
 
-set (EXTRA_LIBS ${EXTRA_LIBS} -lz -lm)
+set (EXTRA_LIBS ${EXTRA_LIBS} -lz -lm -lpthread)
 
 find_package (PkgConfig)
 


### PR DESCRIPTION

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

Linux Distribution Details:
Distributor ID: Ubuntu
Description:    Ubuntu 14.04.5 LTS
Release:        14.04
Codename:       trusty

Failing cmake command:
cmake -DWITH_FFMPEG=ON ../src/

Passing cmake command:
cmake ../src/

Error Seen while compilation:
Linking C executable ccextractor
/usr/bin/ld: /usr/local/lib/libavformat.a(allformats.o): undefined reference to symbol 'pthread_once@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [ccextractor] Error 1
make[1]: *** [CMakeFiles/ccextractor.dir/all] Error 2
make: *** [all] Error 2
