### PR TITLE
Implemented --noempty parameter for not generating output file instead of empty one

### DIFF
--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -33,6 +33,25 @@ void sigint_handler(int sig)
 
 void print_end_msg(void)
 {
+    //When all work is done we can check whether file with subtitles is empty.
+    int mode;
+    char path[256];
+    FILE *f = fopen("noempty.txt", "r");
+    fscanf(f, "%d", &mode);
+    fscanf(f, "%s", path);
+    fclose(f);
+    // if noempty mode is active
+    if (mode == 1){
+      FILE *f = fopen(path, "r");
+      fseek(f, 0, SEEK_END);
+      unsigned int size = ftell(f);
+      // size of an empty file is 3 but we put 8 to omit possible spaces and endlines
+      if (size < 8)
+          remove(path);  // if file is empty remove it
+      remove("noempty.txt");
+      fclose(f);
+    }
+	
     mprint("Issues? Open a ticket here\n");
     mprint("https://github.com/CCExtractor/ccextractor/issues\n");
 }

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -34,6 +34,8 @@
 
 static int inputfile_capacity=0;
 
+int noempty = 0;
+
 int process_cap_file (char *filename)
 {
 	int ret = 0;
@@ -1153,6 +1155,11 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 	// Parse parameters
 	for (int i=1; i<argc; i++)
 	{
+		if (!strcmp (argv[i],"--noempty")){
+		        // changing mode to --noempty
+			noempty = 1;
+			i++;
+		}
 		if (!strcmp (argv[i],"--help") || !strcmp(argv[i], "-h"))
 		{
 			print_usage();
@@ -2066,6 +2073,11 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		if (strcmp (argv[i],"-o")==0 && i<argc-1)
 		{
 			opt->output_filename = argv[i+1];
+			// creating temporary file for storing data
+			FILE *f = fopen("noempty.txt", "w");
+			fprintf(f, "%d\n", noempty);
+			fprintf(f, "%s", argv[i+1]);
+			fclose(f);
 			i++;
 			continue;
 		}


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

{pull request content here}
