### PR TITLE
[IMPROVEMENT]Remove multiple RGB to grey conversion while OCR

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 0.88(2018-10-24) (unreleased)
 -----------------
+- Optimize: Remove multiple RGB to grey conversion in OCR.
 - Fix: Update UTF8Proc to 2.2.0
 - Fix: Warn instead of fatal when a 0xFF marker is missing
 

--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -192,7 +192,7 @@ BOX* ignore_alpha_at_edge(png_byte *alpha, unsigned char* indata, int w, int h, 
 char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* indata,int w, int h, struct image_copy *copy)
 {
 	// uncomment the below lines to output raw image as debug.png iteratively
-	//save_spupng("debug.png", indata, w, h, palette, alpha, 16);
+	// save_spupng("debug.png", indata, w, h, palette, alpha, 16);
 
 	PIX	*pix = NULL;
 	PIX	*cpix = NULL;
@@ -246,7 +246,7 @@ char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* i
 	}
 
 	BOX *crop_points = ignore_alpha_at_edge(copy->alpha, copy->data, w, h, color_pix, &color_pix_out);
-	//Converting image to grayscale for OCR to avoid issues with transparency
+	// Converting image to grayscale for OCR to avoid issues with transparency
 	cpix_gs = pixConvertRGBToGray(cpix, 0.0, 0.0, 0.0);
 #ifdef OCR_DEBUG
 	{

--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -244,20 +244,21 @@ char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* i
 			ppixel++;
 		}
 	}
-	
+
 	BOX *crop_points = ignore_alpha_at_edge(copy->alpha, copy->data, w, h, color_pix, &color_pix_out);
+	//Converting image to grayscale for OCR to avoid issues with transparency
+	cpix_gs = pixConvertRGBToGray(cpix, 0.0, 0.0, 0.0);
 #ifdef OCR_DEBUG
 	{
 	char str[128] = "";
 	static int i = 0;
 	sprintf(str,"temp/file_c_%d.jpg",i);
 	printf("Writing file_c_%d.jpg\n", i);
-	pixWrite(str, pixConvertRGBToGray(cpix, 0.0, 0.0, 0.0), IFF_JFIF_JPEG);
+	pixWrite(str, cpix_gs, IFF_JFIF_JPEG);
 	i++;
 	}
 #endif
 
-	cpix_gs = pixConvertRGBToGray(cpix, 0.0, 0.0, 0.0); // Abhinav95: Converting image to grayscale for OCR to avoid issues with transparency
 	if (cpix_gs==NULL)
 		tess_ret=-1;
 	else
@@ -273,7 +274,7 @@ char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* i
 			pixDestroy(&cpix_gs);
 			pixDestroy(&color_pix);
 			pixDestroy(&color_pix_out);
-		
+
 			return NULL;
 		}
 	}


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [X] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [X] I am an active contributor to CCExtractor.

---

Remove multiple RGB to grey conversion while OCR
