### PR TITLE
[FEATURE] Added support for non-Latin characters in stdout

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -8,6 +8,7 @@
 - Fix: Enable printing hdtv stats to console.
 - Fix: Many typos in comments and output messages
 - Fix: Ignore Visual Studio temporary project files
+- New: Add support for non-Latin characters in stdout
 
 0.87 (2018-10-23)
 -----------------

--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -5,6 +5,7 @@ License: GPL 2.0
 */
 #include "ccextractor.h"
 #include <stdio.h>
+#include <locale.h>
 
 volatile int terminate_asap = 0;
 
@@ -502,6 +503,7 @@ int api_param_count(struct ccx_s_options* api_options)
 
 int main(int argc, char* argv[])
 {
+    setlocale(LC_ALL, "");
     struct ccx_s_options* api_options = api_init_options();
     check_configuration_file(*api_options);
 #ifdef PYTHON_API


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [X] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [X] I am an active contributor to CCExtractor.

---
I found out that ccextractor didn't display non-Latin characters in stdout. There were problems displaying input files with russian letters, subtitles which contain non-Latin symbols (with -stdout parameter) and so on. Fixed this problem.
* Strange symbols in Input filename before changes
![beforechanges](https://user-images.githubusercontent.com/44312997/50024009-b1305e00-ffe9-11e8-9109-e7e514598c65.png)

* Fixed non-Latin letters
![afterchanges](https://user-images.githubusercontent.com/44312997/50024014-b8f00280-ffe9-11e8-8f5a-2b9a434faced.png)


