### PR TITLE
[FEATURE] displaying possible teletext pages without actual extraction

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -9,6 +9,7 @@
 - Fix: Many typos in comments and output messages
 - Fix: Ignore Visual Studio temporary project files
 - New: Add support for non-Latin characters in stdout
+- New: Display possible teletext pages without actual extracting(-out=report)
 
 0.87 (2018-10-23)
 -----------------

--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -9,7 +9,7 @@
 - Fix: Many typos in comments and output messages
 - Fix: Ignore Visual Studio temporary project files
 - New: Add support for non-Latin characters in stdout
-- New: Display possible teletext pages without actual extracting(-out=report)
+- New: Display possible teletext pages without actual extraction(-out=report)
 
 0.87 (2018-10-23)
 -----------------

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -672,12 +672,14 @@ int process_data(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, str
 	else if (data_node->bufferdatatype == CCX_TELETEXT)
 	{
 		//telxcc_update_gt(dec_ctx->private_data, ctx->demux_ctx->global_timestamp);
-		if (enc_ctx) {
+		if (enc_ctx) 
+		{
 			ret = tlt_process_pes_packet(dec_ctx, data_node->buffer, data_node->len, dec_sub, enc_ctx->sentence_cap);
 			if (ret == CCX_EINVAL)
 				return ret;
 		}
-		else {
+		else 
+		{
 			tlt_process_pes_packet(dec_ctx, data_node->buffer, data_node->len, dec_sub, 0);
 		}
 		

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -677,6 +677,10 @@ int process_data(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, str
 			if (ret == CCX_EINVAL)
 				return ret;
 		}
+		else {
+			tlt_process_pes_packet(dec_ctx, data_node->buffer, data_node->len, dec_sub, 0);
+		}
+		
 		got = data_node->len;
 	}
 	else if (data_node->bufferdatatype == CCX_PRIVATE_MPEG2_CC)

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -907,13 +907,13 @@ void process_telx_packet(struct TeletextCtx *ctx, data_unit_t data_unit_id, tele
 			if (!ctx->seen_sub_page[thisp])
 			{
 				ctx->seen_sub_page[thisp]=1;
-				mprint ("\rNotice: Teletext page with possible subtitles detected: %03d\n",thisp);
+				printf ("\rNotice: Teletext page with possible subtitles detected: %03d\n",thisp);
 			}
 		}
 		if ((tlt_config.page == 0) && (flag_subtitle == YES) && (i < 0xff))
 		{
 			tlt_config.page = (m << 8) | (unham_8_4(packet->data[1]) << 4) | unham_8_4(packet->data[0]);
-			mprint ("- No teletext page specified, first received suitable page is %03x, not guaranteed\n", tlt_config.page);
+			printf ("- No teletext page specified, first received suitable page is %03x, not guaranteed\n", tlt_config.page);
         }
 
 		// Page number and control bits


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [X] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [X] I am an active contributor to CCExtractor.

---
According to #1034 added ability to print possible teletext pages in -out=report mode.
