### PR TITLE
[FIX] for issue #668 (Windows and Multicast)

### DIFF
--- a/src/lib_ccx/networking.h
+++ b/src/lib_ccx/networking.h
@@ -20,6 +20,7 @@ void net_send_epg(
 		);
 
 int net_tcp_read(int socket, void *buffer, size_t length);
+int net_udp_read(int socket, void *buffer, size_t length, const char *src_str, const char *addr_str);
 
 int start_tcp_srv(const char *port, const char *pwd);
 


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).** 

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [X] I have used CCExtractor just a couple of times.
- [X] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

So I read that in windows we need to bind to INADDR_ANY only while joining the multicast group, so I left it at that only. Now while receiving the stream from udp multicast, I peak at the header file and match the source ip with the provided ip and only continue if the IPs match. I have tested it on windows using ffmpeg stream system. Let me know if any more changes need to be done.
