### PR TITLE
**[IMPROVEMENT]** Update COMPILATION.MD for Ubuntu 18.04 (and possibly others)

### DIFF
--- a/docs/COMPILATION.MD
+++ b/docs/COMPILATION.MD
@@ -24,6 +24,7 @@ sudo apt-get install -y tesseract-ocr
 sudo apt-get install -y tesseract-ocr-dev
 sudo apt-get install -y libleptonica-dev
 ```
+**Note:** On Ubuntu Version 18.04 (Bionic) and (probably) later, install `libtesseract-dev` rather than `tesseract-ocr-dev`, which does not exist anymore.
 
 **Note:** On Ubuntu Version 14.04 (Trusty) and earlier, you should build leptonica and tesseract from source
 


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).** -- I haven't: Does the Changelog cover documentation?

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

This is an improvement to the documentation / compile guide: At least in Ubuntu 18.04 (possibly the related Debian version and newer Ubuntus) the package `tesseract-ocr-dev` does not exist anymore. It was replaced by `libtesseract-dev`.

