### PR TITLE
libtesseract-dev instead of tesseract-ocr-dev

### DIFF
--- a/linux/build
+++ b/linux/build
@@ -77,7 +77,7 @@ then
 fi
 if [[ $out == *"capi.h: No such file or directory"* ]]
 then
-    echo "Error: please install tesseract development library (tesseract-ocr-dev for Debian/Ubuntu)";
+    echo "Error: please install tesseract development library (libtesseract-dev for Debian/Ubuntu)";
     exit 3
 fi
 if [[ $out == *"allheaders.h: No such file or directory"* ]]


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [x] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [x] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

The tesseract development library is libtesseract-dev. The tesseract-ocr-dev library is not found.
(in case of 18.04).
I apologise. This point is already mentioned in the docs. I did not go through it properly. My bad.