### PR TITLE
**[FIX]** Solve #1077. Add check for empty streams.

### DIFF
--- a/src/lib_ccx/ts_info.c
+++ b/src/lib_ccx/ts_info.c
@@ -131,7 +131,8 @@ int get_best_stream(struct ccx_demuxer *ctx)
 
 	list_for_each_entry(iter, &ctx->cinfo_tree.all_stream, all_stream, struct cap_info)
 	{
-		if(iter->codec == CCX_CODEC_ATSC_CC)
+		// If saw_pesstart is 0 then stream doesn't have payload. Helps against empty streams
+        if(iter->codec == CCX_CODEC_ATSC_CC && iter->saw_pesstart)
 			return iter->pid;
 	}
 


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [x] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Fixes #1077. This one-line change ensures that we select only **CCX_CODEC_ATSC_CC** streams with payload.