### PR TITLE
[FEATURE] Added support for EIA-608 inside MKV

### DIFF
--- a/src/lib_ccx/matroska.h
+++ b/src/lib_ccx/matroska.h
@@ -177,6 +177,8 @@ char* matroska_track_text_subtitle_id_extensions[] = {
         NULL, NULL  // Unknown
 };
 
+char* avc_codec_id = "V_MPEG4/ISO/AVC";
+
 /* Messages */
 #define MATROSKA_INFO "\nMatroska parser info: "
 #define MATROSKA_WARNING "\nMatroska parser warning: "
@@ -205,9 +207,9 @@ struct matroska_sub_sentence {
 };
 
 struct matroska_avc_frame {
-    char *data;
+    UBYTE *data;
     ULLONG len;
-    LLONG FTS;
+    ULLONG FTS;
 };
 
 struct matroska_sub_track {
@@ -225,6 +227,7 @@ struct matroska_ctx {
     struct matroska_sub_track** sub_tracks;
     struct lib_ccx_ctx* ctx;
     struct cc_subtitle dec_sub;
+    int avc_track_number; // ID of AVC track. -1 if there is none
     int sub_tracks_count;
 	int block_index;
     int sentence_count;
@@ -253,9 +256,10 @@ void parse_segment_info(FILE* file);
 struct matroska_sub_sentence* parse_segment_cluster_block_group_block(struct matroska_ctx* mkv_ctx, ULLONG cluster_timecode);
 void parse_segment_cluster_block_group(struct matroska_ctx* mkv_ctx, ULLONG cluster_timecode);
 void parse_segment_cluster(struct matroska_ctx* mkv_ctx);
-void parse_simple_block(struct matroska_ctx* mkv_ctx, ULLONG timecode);
+void parse_simple_block(struct matroska_ctx* mkv_ctx, ULLONG frame_timestamp);
 int process_avc_frame_mkv(struct matroska_ctx* mkv_ctx, struct matroska_avc_frame frame);
 void parse_segment_track_entry(struct matroska_ctx* mkv_ctx);
+void parse_private_codec_data(struct matroska_ctx* mkv_ctx);
 void parse_segment_tracks(struct matroska_ctx* mkv_ctx);
 void parse_segment(struct matroska_ctx* mkv_ctx);
 

--- a/src/lib_ccx/matroska.h
+++ b/src/lib_ccx/matroska.h
@@ -204,6 +204,11 @@ struct matroska_sub_sentence {
 	struct block_addition* blockaddition;
 };
 
+struct matroska_avc_frame {
+    char *data;
+    ULLONG len;
+    LLONG FTS;
+};
 
 struct matroska_sub_track {
     char* header;   // Style header for ASS/SSA (and other) subtitles
@@ -219,6 +224,7 @@ struct matroska_sub_track {
 struct matroska_ctx {
     struct matroska_sub_track** sub_tracks;
     struct lib_ccx_ctx* ctx;
+    struct cc_subtitle dec_sub;
     int sub_tracks_count;
 	int block_index;
     int sentence_count;
@@ -247,6 +253,8 @@ void parse_segment_info(FILE* file);
 struct matroska_sub_sentence* parse_segment_cluster_block_group_block(struct matroska_ctx* mkv_ctx, ULLONG cluster_timecode);
 void parse_segment_cluster_block_group(struct matroska_ctx* mkv_ctx, ULLONG cluster_timecode);
 void parse_segment_cluster(struct matroska_ctx* mkv_ctx);
+void parse_simple_block(struct matroska_ctx* mkv_ctx, ULLONG timecode);
+int process_avc_frame_mkv(struct matroska_ctx* mkv_ctx, struct matroska_avc_frame frame);
 void parse_segment_track_entry(struct matroska_ctx* mkv_ctx);
 void parse_segment_tracks(struct matroska_ctx* mkv_ctx);
 void parse_segment(struct matroska_ctx* mkv_ctx);


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [x] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Added support for extracting EIA-608 subtitles from MKV files. For now it works with MP4/h264. Solves #1068, #1070 