### PR TITLE
[IMPROVEMENT] Change initialization of Tesseract and fix segfault in hardsubx.

### DIFF
--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -129,6 +129,25 @@ char* probe_tessdata_location(int lang_index)
 	return NULL;
 }
 
+/**
+ * probe_tessdata_location_string
+ *
+ * This function returns tesseract data location given language string
+ */
+char* probe_tessdata_location_string(char* lang)
+{
+    int lang_index = -1;
+    for(int i = 0; i < NB_LANGUAGE; i++) {
+        if(language[i]) {
+            if(strcmp(lang, language[i]) == 0) lang_index = i;
+        }
+    }
+
+    if(lang_index == -1) return NULL; // No such language found
+
+    return probe_tessdata_location(lang_index);
+}
+
 void* init_ocr(int lang_index)
 {
 	int ret = -1;

--- a/src/lib_ccx/ocr.h
+++ b/src/lib_ccx/ocr.h
@@ -12,6 +12,7 @@ struct image_copy //A copy of the original OCR image, used for color detection
 };
 
 void delete_ocr (void** arg);
+char* probe_tessdata_location_string(char* lang);
 void* init_ocr(int lang_index);
 char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* indata,int w, int h, struct image_copy *copy);
 int ocr_rect(void* arg, struct cc_bitmap *rect, char **str, int bgcolor, int ocr_quantmode);


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

Changed the way Tesseract is initialized in hardsubx to be the same as in ocr.c. Fixed the problem with incorrect pass of pointer to av_frame_free function, which caused segfault.
