### PR TITLE
Fixes #1086 by adding -latrusmap option that maps Latin symbols to Cy…

### DIFF
--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -66,6 +66,7 @@ struct ccx_s_teletext_config
 	int nofontcolor;
 	int nohtmlescape;
 	char millis_separator;
+    int latrusmap;
 };
 
 struct ccx_s_mp4Cfg

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -614,7 +614,9 @@ void print_usage (void)
 	mprint ("                       free to play with it but be aware that this format\n");
 	mprint ("                       is really live - don't rely on its output format\n");
 	mprint ("                       not changing between versions.\n");
-	mprint ("                 -xds: In timed transcripts, all XDS information will be saved\n");
+    mprint ("            -latrusmap Map Latin symbols to Cyrillic ones in special cases\n");
+    mprint ("                       of Russian Teletext files (issue #1086)\n");
+    mprint ("                 -xds: In timed transcripts, all XDS information will be saved\n");
 	mprint ("                       to the output file.\n");
 	mprint ("                  -lf: Use LF (UNIX) instead of CRLF (DOS, Windows) as line\n");
 	mprint ("                       terminator.\n");
@@ -1968,7 +1970,7 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		}
 		if (strcmp (argv[i],"-xds")==0)
 		{
-			// XDS can be set regardless of -UCLA (isFinal) usage.
+            // XDS can be set regardless of -UCLA (isFinal) usage.
 			opt->transcript_settings.xds = 1;
 			continue;
 		}
@@ -2143,6 +2145,11 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 			}
 			continue;
 		}
+        if (strcmp (argv[i],"-latrusmap")==0 )
+        {
+            tlt_config.latrusmap = 1;
+            continue;
+        }
 		if (strcmp (argv[i],"-tickertext")==0 || strcmp (argv[i],"-tickertape")==0)
 		{
 			opt->tickertext = 1;


### PR DESCRIPTION
…rillic ones in some of the Russian Teletext files

Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [X] I am an active contributor to CCExtractor.

---

Fix for #1086 . Pass -latrusmap option to ccextractor and Latin symbols will be converted to Cyrillic ones. HTML font tags should not be converted (didn't have test examples for that, but I used font_tag_opened option to check whether we are handling font tag or not)