### PR TITLE
[FIX] Remove webvtt styling when not using webvtt-full

### DIFF
--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -93,7 +93,7 @@ static const char *smptett_header = "<?xml version=\"1.0\" encoding=\"UTF-8\" st
 			"  <body>\n"
 			"    <div>\n";
 
-static const char *webvtt_header[] = {"WEBVTT","\r\n","\r\n","STYLE","\r\n","\r\n",NULL};
+static const char *webvtt_header[] = {"WEBVTT","\r\n","\r\n",NULL};
 
 static const char *simple_xml_header = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<captions>\r\n";
 

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -93,7 +93,7 @@ static const char *smptett_header = "<?xml version=\"1.0\" encoding=\"UTF-8\" st
 			"  <body>\n"
 			"    <div>\n";
 
-static const char *webvtt_header[] = {"WEBVTT","\r\n","\r\n",NULL};
+static const char *webvtt_header[] = {"WEBVTT","\r\n",NULL};
 
 static const char *simple_xml_header = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<captions>\r\n";
 

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -225,7 +225,7 @@ int write_webvtt_header(struct encoder_ctx *context)
 		char* outline_css_file = (char*)malloc((strlen(css_file_name) + strlen(webvtt_outline_css)) * sizeof(char));
 		sprintf(outline_css_file, webvtt_outline_css, css_file_name);
 		write (context->out->fh, outline_css_file, strlen(outline_css_file));
-	} else {
+	} else if (ccx_options.use_webvtt_styling) {
 		write(context->out->fh, webvtt_inline_css, strlen(webvtt_inline_css));
 		if(ccx_options.enc_cfg.line_terminator_lf == 1) // If -lf parameter is set.
 		{

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -252,8 +252,6 @@ int write_webvtt_header(struct encoder_ctx *context)
 		}
 		write(context->out->fh, "##\n", 3);
 	}
-	
-	write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 
 	context->wrote_webvtt_header = 1; // Do it even if couldn't write the header, because it won't be possible anyway
 }
@@ -295,7 +293,7 @@ int write_cc_bitmap_as_webvtt(struct cc_subtitle *sub, struct encoder_ctx *conte
 			sprintf(timeline, "%02u:%02u:%02u.%03u --> %02u:%02u:%02u.%03u%s",
 				h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
 			used = encode_line(context, context->buffer, (unsigned char *)timeline);
-            write(context->out->fh, context->buffer, used);
+			write(context->out->fh, context->buffer, used);
 			len = strlen(str);
 			write(context->out->fh, str, len);
 			write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -251,6 +251,7 @@ int write_webvtt_header(struct encoder_ctx *context)
 			write(context->out->fh,"\r\n",2);
 		}
 		write(context->out->fh, "##\n", 3);
+		written = write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 	}
 
 	context->wrote_webvtt_header = 1; // Do it even if couldn't write the header, because it won't be possible anyway

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -8,7 +8,8 @@
 
 static const char *webvtt_outline_css = "@import(%s)\n";
 
-static const char *webvtt_inline_css = "/* default values */\n"
+static const char *webvtt_inline_css = "STYLE\n\n"
+		"/* default values */\n"
 		"::cue {\n"
 		"  line-height: 5.33vh;\n"
 		"  font-size: 4.1vh;\n"

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -491,7 +491,8 @@ int write_cc_buffer_as_webvtt(struct eia608_screen *data, struct encoder_ctx *co
 				}
 
 				// write current text symbol
-				write(context->out->fh, &(context->subline[j]), 1);
+				if (context->subline[j] != '\0')
+					write(context->out->fh, &(context->subline[j]), 1);
 
 				if (ccx_options.use_webvtt_styling)
 				{

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -251,7 +251,7 @@ int write_webvtt_header(struct encoder_ctx *context)
 			write(context->out->fh,"\r\n",2);
 		}
 		write(context->out->fh, "##\n", 3);
-		written = write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
+		write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 	}
 
 	context->wrote_webvtt_header = 1; // Do it even if couldn't write the header, because it won't be possible anyway


### PR DESCRIPTION

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [x] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

addresses #1076 

leaves behind the null terminator bug, but it hasn't been an issue with anything except gedit as of yet.