### PR TITLE
[IMPROVEMENT] Add RHEL based distros instructions.

### DIFF
--- a/docs/COMPILATION.MD
+++ b/docs/COMPILATION.MD
@@ -14,6 +14,7 @@ git clone https://github.com/CCExtractor/ccextractor.git
 
 1. Make sure all the dependencies are met.
 
+Debian:
 ```
 sudo apt-get install -y libglew-dev
 sudo apt-get install -y libglfw3-dev
@@ -24,6 +25,18 @@ sudo apt-get install -y tesseract-ocr
 sudo apt-get install -y tesseract-ocr-dev
 sudo apt-get install -y libleptonica-dev
 ```
+
+RHEL:
+```
+yum install -y glew-devel
+yum install -y glfw-devel
+yum install -y cmake
+yum install -y gcc
+yum install -y libcurl-devel
+yum install -y tesseract-devel
+yum install -y leptonica-devel
+```
+
 **Note:** On Ubuntu Version 18.04 (Bionic) and (probably) later, install `libtesseract-dev` rather than `tesseract-ocr-dev`, which does not exist anymore.
 
 **Note:** On Ubuntu Version 14.04 (Trusty) and earlier, you should build leptonica and tesseract from source


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [x] I am an active contributor to CCExtractor.

---

These are CentOS 7 based, but should work across the board, specifically including 8. I've tested in CENTOS 7 and Fedora 30

