### PR TITLE
[IMPROVEMENT] MXF caption frame rates

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,3 +1,7 @@
+0.89 (TBD)
+-----------------
+- Fix: ccx_demuxer_mxf.c: Parse framerate from MXF captions to fix caption timings.
+
 0.88 (2019-05-21)
 -----------------
 - New: More tapping points for debug image in ccextractor.


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [x] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Update the MXF demuxer so that it parses frame rates out of the CDP data.  Without this, ccextractor assumed 29.97 fps in all content, so for example, on a 59.94 fps file the caption timings were double what they should be.
