### PR TITLE
[FIX] Fix several memory leaks using Leptonica API for hardcoded subtitle extraction

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,6 +1,7 @@
 0.89 (TBD)
 -----------------
 - Fix: ccx_demuxer_mxf.c: Parse framerate from MXF captions to fix caption timings.
+- Fix: hardsubx_decoder.c: Fix memory leaks using Leptonica API.
 
 0.88 (2019-05-21)
 -----------------

--- a/src/lib_ccx/hardsubx.c
+++ b/src/lib_ccx/hardsubx.c
@@ -1,7 +1,7 @@
 #ifdef ENABLE_HARDSUBX
+#include <tesseract/capi.h>
+#include <leptonica/allheaders.h>
 #include "hardsubx.h"
-#include "tesseract/capi.h"
-#include "allheaders.h"
 #include "ocr.h"
 #include "utility.h"
 

--- a/src/lib_ccx/hardsubx.h
+++ b/src/lib_ccx/hardsubx.h
@@ -9,8 +9,8 @@
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libswscale/swscale.h>
-#include "allheaders.h"
-#include "tesseract/capi.h"
+#include <leptonica/allheaders.h>
+#include <tesseract/capi.h>
 
 enum hardsubx_color_type
 {

--- a/src/lib_ccx/hardsubx.h
+++ b/src/lib_ccx/hardsubx.h
@@ -86,9 +86,9 @@ void _dinit_hardsubx(struct lib_hardsubx_ctx **ctx);
 int hardsubx_process_data(struct lib_hardsubx_ctx *ctx);
 
 //hardsubx_decoder.c
-int hardsubx_process_frames_linear(struct lib_hardsubx_ctx *ctx, struct encoder_ctx *enc_ctx);
+void hardsubx_process_frames_linear(struct lib_hardsubx_ctx *ctx, struct encoder_ctx *enc_ctx);
 int hardsubx_process_frames_tickertext(struct lib_hardsubx_ctx *ctx, struct encoder_ctx *enc_ctx);
-int hardsubx_process_frames_binary(struct lib_hardsubx_ctx *ctx);
+void hardsubx_process_frames_binary(struct lib_hardsubx_ctx *ctx);
 char* _process_frame_white_basic(struct lib_hardsubx_ctx *ctx, AVFrame *frame, int width, int height, int index);
 char *_process_frame_color_basic(struct lib_hardsubx_ctx *ctx, AVFrame *frame, int width, int height, int index);
 void _display_frame(struct lib_hardsubx_ctx *ctx, AVFrame *frame, int width, int height, int timestamp);

--- a/src/lib_ccx/hardsubx_classifier.c
+++ b/src/lib_ccx/hardsubx_classifier.c
@@ -7,7 +7,7 @@
 #include <libavformat/avformat.h>
 #include <libavutil/imgutils.h>
 #include <libswscale/swscale.h>
-#include "allheaders.h"
+#include <leptonica/allheaders.h>
 #include "hardsubx.h"
 
 char *get_ocr_text_simple(struct lib_hardsubx_ctx *ctx, PIX *image)

--- a/src/lib_ccx/hardsubx_decoder.c
+++ b/src/lib_ccx/hardsubx_decoder.c
@@ -152,7 +152,6 @@ char *_process_frame_color_basic(struct lib_hardsubx_ctx *ctx, AVFrame *frame, i
     gray_im_2 = pixConvertRGBToGray(hue_im,0.0,0.0,0.0);
     edge_im_2 = pixDilateGray(gray_im_2, 5, 5);
 
-	pixd = pixCreate(width,height,1);
 	pixSauvolaBinarize(gray_im_2, 15, 0.3, 1, NULL, NULL, NULL, &pixd);
 
 	feat_im = pixCreate(width,height,32);
@@ -260,7 +259,6 @@ void _display_frame(struct lib_hardsubx_ctx *ctx, AVFrame *frame, int width, int
 	gray_im_2 = pixConvertRGBToGray(hue_im,0.0,0.0,0.0);
 	edge_im_2 = pixDilateGray(gray_im_2, 5, 5);
 
-    pixd = pixCreate(width,height,1);
     pixSauvolaBinarize(gray_im_2, 15, 0.3, 1, NULL, NULL, NULL, &pixd);
 
 	feat_im = pixCreate(width,height,32);

--- a/src/lib_ccx/hardsubx_decoder.c
+++ b/src/lib_ccx/hardsubx_decoder.c
@@ -7,9 +7,9 @@
 #include <libavformat/avformat.h>
 #include <libavutil/imgutils.h>
 #include <libswscale/swscale.h>
-#include "allheaders.h"
+#include <leptonica/allheaders.h>
+#include <tesseract/capi.h>
 #include "hardsubx.h"
-#include "capi.h"
 
 char* _process_frame_white_basic(struct lib_hardsubx_ctx *ctx, AVFrame *frame, int width, int height, int index)
 {

--- a/src/lib_ccx/hardsubx_imgops.c
+++ b/src/lib_ccx/hardsubx_imgops.c
@@ -7,7 +7,7 @@
 #include <libavformat/avformat.h>
 #include <libavutil/imgutils.h>
 #include <libswscale/swscale.h>
-#include "allheaders.h"
+#include <leptonica/allheaders.h>
 #include "hardsubx.h"
 
 #define BLACK 20.0

--- a/src/lib_ccx/hardsubx_utility.c
+++ b/src/lib_ccx/hardsubx_utility.c
@@ -7,7 +7,7 @@
 #include <libavformat/avformat.h>
 #include <libavutil/imgutils.h>
 #include <libswscale/swscale.h>
-#include "allheaders.h"
+#include <leptonica/allheaders.h>
 #include "hardsubx.h"
 
 int64_t convert_pts_to_ms(int64_t pts, AVRational time_base)

--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -1,9 +1,9 @@
 #include "png.h"
 #include "lib_ccx.h"
 #ifdef ENABLE_OCR
-#include "tesseract/capi.h"
+#include <tesseract/capi.h>
 #include "ccx_common_constants.h"
-#include "allheaders.h"
+#include <leptonica/allheaders.h>
 #include <dirent.h>
 #include "ccx_encoders_helpers.h"
 #include "ocr.h"

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -16,8 +16,8 @@
 #include "utf8proc/utf8proc.h"
 
 #ifdef ENABLE_OCR
-#include "tesseract/capi.h"
-#include "allheaders.h"
+#include <tesseract/capi.h>
+#include <leptonica/allheaders.h>
 #endif
 
 #ifdef ENABLE_HARDSUBX

--- a/src/lib_ccx/utility.h
+++ b/src/lib_ccx/utility.h
@@ -14,6 +14,9 @@
 
 #define CCX_NOPTS	((int64_t)UINT64_C(0x8000000000000000))
 
+#define MIN(a,b) (((a)<(b))?(a):(b))
+#define MAX(a,b) (((a)>(b))?(a):(b))
+
 struct ccx_rational
 {
 	int num;


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [X] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [X] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Leptonica functions in [`hardsubx_decoder.c`](https://github.com/CCExtractor/ccextractor/blob/2bcd993c0f9ba97fe33f5bdb43d4596b9b927fa3/src/lib_ccx/hardsubx.c) such as `pixConvertRGBToGray`, `pixSobelEdgeFilter`, `pixDilateGray` or `pixThresholdToBinary` allocate a new Pix struct everytime they are called, rather than modifying the one passed as an argument.

This leads to a memory leak everytime the functions `_process_frame_white_basic`, `_process_frame_color_basic`, `_display_frame` or `_process_frame_tickertext` are called, which happens at every frame of the input video and results in a huge memory consumption, even for a video the size of a few hundred MBs.

The proposed fix keeps track of all the created Pix structs and destroys them properly after each call to the mentioned functions. Library inclusions for Leptonica and Tesseract libraries have also been modified to look up the standard include directories.
