### PR TITLE
[IMPROVEMENT] [encode_line] Fix typo and reformat

### DIFF
--- a/src/lib_ccx/ccx_encoders_helpers.c
+++ b/src/lib_ccx/ccx_encoders_helpers.c
@@ -159,7 +159,7 @@ int clever_capitalize(struct encoder_ctx *context, int line_num, struct eia608_s
 
 // Encodes a generic string. Note that since we use the encoders for closed caption
 // data, text would have to be encoded as CCs... so using special characters here
-// it's a bad idea.
+// is a bad idea.
 unsigned encode_line(struct encoder_ctx *ctx, unsigned char *buffer, unsigned char *text)
 {
 	unsigned bytes = 0;
@@ -169,18 +169,15 @@ unsigned encode_line(struct encoder_ctx *ctx, unsigned char *buffer, unsigned ch
 		{
 		case CCX_ENC_UTF_8:
 		case CCX_ENC_LATIN_1:
-			*buffer = *text;
+			*buffer++ = *text++;
 			bytes++;
-			buffer++;
 			break;
 		case CCX_ENC_UNICODE:
-			*buffer = *text;
-			*(buffer + 1) = 0;
+			*buffer++ = *text++;
+			*buffer++ = 0;
 			bytes += 2;
-			buffer += 2;
 			break;
 		}
-		text++;
 	}
 	*buffer = 0;
 	return bytes;


### PR DESCRIPTION
- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**
- [X] I have used CCExtractor just a couple of times.
---

Fix typo and use the opportunity to change encode_line