### PR TITLE
[FIX] Add the `X-TIMESTAMP-MAP` header at all time to webvtt files. WIP

### DIFF
--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -425,7 +425,7 @@ static int write_bom(struct encoder_ctx *ctx, struct ccx_s_write *out)
 }
 
 // Returns -1 on error and 0 on success
-static int write_subtitle_file_header(struct encoder_ctx *ctx, struct ccx_s_write *out)
+static int write_subtitle_file_header(struct encoder_ctx *ctx, struct ccx_s_write *out, struct ccx_common_timing_ctx *timing)
 {
 	int used;
 	int header_size = 0;
@@ -485,6 +485,7 @@ static int write_subtitle_file_header(struct encoder_ctx *ctx, struct ccx_s_writ
 					return -1;
 				}
 			}
+			write_webvtt_header(ctx, timing);
 			break;
 		case CCX_OF_SAMI: // This header brought to you by McPoodle's CCASDI
 			//fprintf_encoded (wb->fh, sami_header);
@@ -944,7 +945,7 @@ int reset_output_ctx(struct encoder_ctx *ctx, struct encoder_cfg *cfg)
 	return init_output_ctx(ctx, cfg);
 }
 
-struct encoder_ctx *init_encoder(struct encoder_cfg *opt)
+struct encoder_ctx *init_encoder(struct encoder_cfg *opt, struct ccx_common_timing_ctx *timing)
 {
 	int ret;
 	int i;
@@ -1042,7 +1043,7 @@ struct encoder_ctx *init_encoder(struct encoder_cfg *opt)
 	ctx->encoded_br_length = encode_line(ctx, ctx->encoded_br, (unsigned char *)"<br>");
 
 	for (i = 0; i < ctx->nb_out; i++)
-		write_subtitle_file_header(ctx, ctx->out + i);
+		write_subtitle_file_header(ctx, ctx->out + i, timing);
 
 	ctx->dtvcc_extract = opt->dtvcc_extract;
 
@@ -1204,7 +1205,7 @@ int encode_sub(struct encoder_ctx *context, struct cc_subtitle *sub)
 						if (ccx_options.keep_output_closed && context->out->temporarily_closed)
 						{
 							temporarily_open_output(context->out);
-							write_subtitle_file_header(context, context->out);
+							write_subtitle_file_header(context, context->out, context->timing);
 						}
 						wrote_something = write_cc_buffer_as_simplexml(data, context);
 						if (ccx_options.keep_output_closed)

--- a/src/lib_ccx/ccx_encoders_common.h
+++ b/src/lib_ccx/ccx_encoders_common.h
@@ -170,7 +170,8 @@ struct encoder_ctx
  *
  * @return Allocated and properly initilaized Encoder Context, NULL on failure
  */
-struct encoder_ctx *init_encoder(struct encoder_cfg *opt);
+struct encoder_ctx *init_encoder(struct encoder_cfg *opt,
+								 struct ccx_common_timing_ctx *timing);
 
 /**
  * try to add end credits in subtitle file and then write subtitle

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -215,13 +215,16 @@ void write_webvtt_header(struct encoder_ctx *context, struct ccx_common_timing_c
 		unsigned h1, m1, s1, ms1;
 		millis_to_time(timing->sync_pts2fts_fts, &h1, &m1, &s1, &ms1);
 
+		unsigned int newline_location = 0;
 		// If the user has not disabled X-TIMESTAMP-MAP
 		if (!context->no_timestamp_map)
 		{
-			sprintf(header_string, "X-TIMESTAMP-MAP=MPEGTS:%ld,LOCAL:%02u:%02u:%02u.%03u%s",
-				timing->sync_pts2fts_pts, h1, m1, s1, ms1,
-				ccx_options.enc_cfg.line_terminator_lf ? "\n\n" : "\r\n\r\n");
+			newline_location = sprintf(header_string, "X-TIMESTAMP-MAP=MPEGTS:%ld,LOCAL:%02u:%02u:%02u.%03u",
+					timing->sync_pts2fts_pts, h1, m1, s1, ms1);
 		}
+		memcpy(header_string + newline_location, context->encoded_crlf, context->encoded_crlf_length);
+		memcpy(header_string + newline_location, context->encoded_crlf, context->encoded_crlf_length);
+
 		used = encode_line(context, context->buffer, (unsigned char *)header_string);
 		write(context->out->fh, context->buffer, used);
 	}

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -920,7 +920,7 @@ int general_loop(struct lib_ccx_ctx *ctx)
 				{
 					struct cap_info *cinfo_video = get_cinfo(ctx->demux_ctx, pid); // Must be pid, not video_pid or DVB crashes (possibly buffer consumption?) - TODO
 					struct lib_cc_decode *dec_ctx_video = update_decoder_list_cinfo(ctx, cinfo_video);
-					enc_ctx = update_encoder_list_cinfo(ctx, cinfo_video);
+					enc_ctx = update_encoder_list_cinfo(ctx, cinfo_video, NULL);
 					struct cc_subtitle *dec_sub_video = &dec_ctx_video->dec_sub;
 					struct demuxer_data *data_node_video = get_data_stream(datalist, video_pid);
 					if (data_node_video)
@@ -949,9 +949,7 @@ int general_loop(struct lib_ccx_ctx *ctx)
 			}
 
 			cinfo = get_cinfo(ctx->demux_ctx, pid);
-			enc_ctx = update_encoder_list_cinfo(ctx, cinfo);
 			dec_ctx = update_decoder_list_cinfo(ctx, cinfo);
-			dec_ctx->dtvcc->encoder = (void *)enc_ctx; //WARN: otherwise cea-708 will not work
 
 			if (dec_ctx->timing->min_pts == 0x01FFFFFFFFLL) //if we didn't set the min_pts of the program
 			{
@@ -1022,6 +1020,10 @@ int general_loop(struct lib_ccx_ctx *ctx)
 			}
 			if (data_node->bufferdatatype == CCX_TELETEXT && dec_ctx->private_data) //if we have teletext subs, we set the min_pts here
 				set_tlt_delta(dec_ctx, min_pts);
+
+			enc_ctx = update_encoder_list_cinfo(ctx, cinfo, dec_ctx->timing);
+			dec_ctx->dtvcc->encoder = (void *)enc_ctx; //WARN: otherwise cea-708 will not work
+
 			ret = process_data(enc_ctx, dec_ctx, data_node);
 			if (enc_ctx != NULL) {
 				if (enc_ctx->srt_counter || enc_ctx->cea_708_counter || dec_ctx->saw_caption_block || ret == 1)
@@ -1059,7 +1061,7 @@ int general_loop(struct lib_ccx_ctx *ctx)
 					data_node = get_data_stream(datalist, cinfo->pid);
 				}
 
-				enc_ctx = update_encoder_list_cinfo(ctx, cinfo);
+				enc_ctx = update_encoder_list_cinfo(ctx, cinfo, NULL);
 				dec_ctx = update_decoder_list_cinfo(ctx, cinfo);
 				dec_ctx->dtvcc->encoder = (void *)enc_ctx; //WARN: otherwise cea-708 will not work
 

--- a/src/lib_ccx/hardsubx.c
+++ b/src/lib_ccx/hardsubx.c
@@ -97,7 +97,7 @@ int hardsubx_process_data(struct lib_hardsubx_ctx *ctx)
 
 	// Pass on the processing context to the appropriate functions
 	struct encoder_ctx *enc_ctx;
-	enc_ctx = init_encoder(&ccx_options.enc_cfg);
+	enc_ctx = init_encoder(&ccx_options.enc_cfg, NULL);
 
 	mprint("Beginning burned-in subtitle detection...\n");
 

--- a/src/lib_ccx/lib_ccx.c
+++ b/src/lib_ccx/lib_ccx.c
@@ -341,7 +341,7 @@ struct lib_cc_decode *update_decoder_list_cinfo(struct lib_ccx_ctx *ctx, struct 
 	return dec_ctx;
 }
 
-struct encoder_ctx *update_encoder_list_cinfo(struct lib_ccx_ctx *ctx, struct cap_info *cinfo)
+struct encoder_ctx *update_encoder_list_cinfo(struct lib_ccx_ctx *ctx, struct cap_info *cinfo, struct ccx_common_timing_ctx *timing)
 {
 	struct encoder_ctx *enc_ctx;
 	unsigned int pn = 0;
@@ -390,7 +390,7 @@ struct encoder_ctx *update_encoder_list_cinfo(struct lib_ccx_ctx *ctx, struct ca
 		{
 			ccx_options.enc_cfg.program_number = pn;
 			ccx_options.enc_cfg.in_format = in_format;
-			enc_ctx = init_encoder(&ccx_options.enc_cfg);
+			enc_ctx = init_encoder(&ccx_options.enc_cfg, timing);
 			if (!enc_ctx)
 				return NULL;
 			list_add_tail(&(enc_ctx->list), &(ctx->enc_ctx_head));
@@ -410,7 +410,7 @@ struct encoder_ctx *update_encoder_list_cinfo(struct lib_ccx_ctx *ctx, struct ca
 		}
 
 		sprintf(ccx_options.enc_cfg.output_filename, "%s_%d%s", ctx->basefilename, pn, extension);
-		enc_ctx = init_encoder(&ccx_options.enc_cfg);
+		enc_ctx = init_encoder(&ccx_options.enc_cfg, timing);
 		if (!enc_ctx)
 		{
 			freep(&ccx_options.enc_cfg.output_filename);
@@ -430,5 +430,5 @@ struct encoder_ctx *update_encoder_list_cinfo(struct lib_ccx_ctx *ctx, struct ca
 
 struct encoder_ctx *update_encoder_list(struct lib_ccx_ctx *ctx)
 {
-	return update_encoder_list_cinfo(ctx, NULL);
+	return update_encoder_list_cinfo(ctx, NULL, NULL);
 }

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -310,7 +310,7 @@ int is_decoder_processed_enough(struct lib_ccx_ctx *ctx);
 struct lib_cc_decode *update_decoder_list_cinfo(struct lib_ccx_ctx *ctx, struct cap_info* cinfo);
 struct lib_cc_decode *update_decoder_list(struct lib_ccx_ctx *ctx);
 
-struct encoder_ctx *update_encoder_list_cinfo(struct lib_ccx_ctx *ctx, struct cap_info* cinfo);
+struct encoder_ctx *update_encoder_list_cinfo(struct lib_ccx_ctx *ctx, struct cap_info* cinfo, struct ccx_common_timing_ctx *timing);
 struct encoder_ctx * update_encoder_list(struct lib_ccx_ctx *ctx);
 struct encoder_ctx *get_encoder_by_pn(struct lib_ccx_ctx *ctx, int pn);
 #endif


### PR DESCRIPTION
Fix #1127

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [X] I have used CCExtractor just a couple of times.

Add the `X-TIMESTAMP-MAP` header at all time to webvtt files.