### PR TITLE
[FIX] Segmentation fault on VOB #1128

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -9,6 +9,7 @@
 - Fix: Correct if-clauses (missing or misplaced brackets).
 - Fix: Comment out some unused code.
 - Fix: Resolve bunch of compilation's warnings.
+- Fix: Segmentation fault on VOB #1128
 
 0.88 (2019-05-21)
 -----------------

--- a/src/lib_ccx/ccx_decoders_common.c
+++ b/src/lib_ccx/ccx_decoders_common.c
@@ -307,6 +307,7 @@ struct lib_cc_decode* init_cc_decode (struct ccx_decoders_common_settings_t *set
 	ctx->stat_hdtv              = 0;
 	ctx->stat_divicom           = 0;
 	ctx->false_pict_header = 0;
+	ctx->is_alloc=0;
 
 	memcpy(&ctx->extraction_start, &setting->extraction_start,sizeof(struct ccx_boundary_time));
 	memcpy(&ctx->extraction_end, &setting->extraction_end,sizeof(struct ccx_boundary_time));

--- a/src/lib_ccx/dvd_subtitle_decoder.c
+++ b/src/lib_ccx/dvd_subtitle_decoder.c
@@ -90,12 +90,20 @@ void get_bitmap(struct DVD_Ctx *ctx)
 	h = (ctx->ctrl->coord[3] - ctx->ctrl->coord[2]) + 1;
 	dbg_print(CCX_DMT_VERBOSE, "w:%d h:%d\n", w, h);
 
+	if(w<0 || h<0)
+	{
+		dbg_print(CCX_DMT_VERBOSE, "Width or height has a negative value");
+		return;
+	}
+
 	pos = ctx->ctrl->pixoffset[0];
 	m = 0;
 	nextbyte = ctx->buffer[pos];
 
 	ctx->bitmap = malloc(w*h);
 	buffp = ctx->bitmap;
+	if(!buffp)
+		return;
 	memset(buffp, 0, w*h);
 	x = 0; lineno = 0;
 
@@ -196,6 +204,8 @@ void decode_packet(struct DVD_Ctx *ctx)
 
 		while(seq_end == 0)
 		{
+			if(ctx->pos > ctx->len)
+				break;
 			command = buff[ctx->pos];
 			ctx->pos += 1;
 
@@ -328,7 +338,11 @@ int write_dvd_sub(struct lib_cc_decode *dec_ctx, struct DVD_Ctx *ctx, struct cc_
 
 	w = (ctx->ctrl->coord[1] - ctx->ctrl->coord[0]) + 1;
 	h = (ctx->ctrl->coord[3] - ctx->ctrl->coord[2]) + 1;
-
+	if(w<0 || h<0)
+	{
+		dbg_print(CCX_DMT_VERBOSE, "Width or height has a negative value");
+		return -1;
+	}
 	rect->data0 = malloc(w*h);
 	memcpy(rect->data0, ctx->bitmap, w*h);
 

--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -878,6 +878,13 @@ int ocr_rect(void* arg, struct cc_bitmap *rect, char **str, int bgcolor, int ocr
 		dbg_print(CCX_DMT_DVB, "ocr_rect(): Trying W*H (%d * %d) so size = %d\n",
 				rect->w, rect->h, size);
 
+		if(size<0)
+		{	
+			dbg_print(CCX_DMT_VERBOSE, "Width or height has a negative value");
+			ret = -1;
+			goto end;
+		}
+
 		copy->data = (unsigned char *)malloc(sizeof(unsigned char)*size);
 		for(int i = 0; i < size; i++)
 		{


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---
Issue #1128
Changes:
- checking if pointer isn't NULL in get_bitmap in file dvd_subtitle_decoder.c
- checking in 3 places if the height or width isn't negative value
- setting default value of ctx->is_alloc
- checking if ctx->pos > ctx->len in decode_packet in dvd_subtitle_decoder.c
- changed changes.TXT
