### PR TITLE
[FIX] Added back define to make building on Windows work again

### DIFF
--- a/src/utf8proc/utf8proc.h
+++ b/src/utf8proc/utf8proc.h
@@ -120,6 +120,8 @@ typedef bool utf8proc_bool;
 #endif
 #include <limits.h>
 
+#define UTF8PROC_STATIC
+
 #ifdef UTF8PROC_STATIC
 #  define UTF8PROC_DLLEXPORT
 #else


### PR DESCRIPTION
**My familiarity with the project is as follows (check one):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [X] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Added back the define so that CCExtractor would build properly on Windows:
```
#define UTF8PROC_STATIC
```
in utf8proc.h

Tested on Windows 10 x64 using Visual Studio 2019.