### PR TITLE
[IMPROVEMENT] Removed redundant check_configuration_file function

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -11,6 +11,7 @@
 - Fix: Resolve bunch of compilation's warnings.
 - Fix: Segmentation fault on VOB #1128
 - Fix: Hang while processing video #1121
+- Fix: Removed redundant check_configuration_file function
 
 0.88 (2019-05-21)
 -----------------

--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -444,11 +444,6 @@ struct ccx_s_options* api_init_options()
     return &ccx_options;
 }
 
-void check_configuration_file(struct ccx_s_options api_options)
-{
-    parse_configuration(&api_options);
-}
-
 #ifdef PYTHON_API
 int compile_params(struct ccx_s_options *api_options,int argc)
 {
@@ -510,7 +505,7 @@ int main(int argc, char* argv[])
     setlocale(LC_ALL, ""); // Supports non-English CCs
 
     struct ccx_s_options* api_options = api_init_options();
-    check_configuration_file(*api_options); 
+    parse_configuration(api_options);
     // If "ccextractor.cnf" is present, takes options from it.
     // See docs/ccextractor.cnf.sample for more info.
 

--- a/src/ccextractor.h
+++ b/src/ccextractor.h
@@ -46,7 +46,7 @@ struct lib_ccx_ctx *signal_ctx;
 //volatile int terminate_asap = 0;
 
 struct ccx_s_options* api_init_options();
-void check_configuration_file(struct ccx_s_options api_options);
+
 int api_start(struct ccx_s_options api_options);
 
 


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

The `check_configuration_file` function takes in a dereferenced `ccx_s_options` struct as `api_options`, and calls `parse_configuration` by taking a reference to `api_options` . However, the only call to `check_configuration_file` is made by dereferencing a `ccx_s_options` struct, meaning `parse_configuration` can be called directly. Hence, there is no use for `check_configuration_file`, meaning it can be safely deleted.