### PR TITLE
[FIX] Change inet_ntop to inet_ntoa for Windows XP compatibility

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -16,6 +16,7 @@
 - Fix: Removed redundant check_configuration_file function
 - Fix: lib_ccx.c: Initialize fatal error logging function before first usage in init_libraries
 - Fix: Added italics, underline, and color rendering support for -out=spupng with EIA608/teletext
+- Fix: Change inet_ntop to inet_ntoa for Windows XP compatibility
 
 0.88 (2019-05-21)
 -----------------

--- a/src/lib_ccx/networking.c
+++ b/src/lib_ccx/networking.c
@@ -335,7 +335,7 @@ int net_udp_read(int socket, void *buffer, size_t length, const char *src_str, c
 	assert(length > 0);
 
 	int i;
-	char ip[50] = "";
+	char ip[15];
 	struct sockaddr_in source_addr;
 	socklen_t len = sizeof(source_addr);
 	/* Get address of host to check for udp network mutlicasting */
@@ -354,7 +354,8 @@ int net_udp_read(int socket, void *buffer, size_t length, const char *src_str, c
 	{
 		do {
 			i = recvfrom(socket, (char *) buffer, length, 0, (struct sockaddr*)&source_addr, &len); /* peek at the data*/
-			inet_ntop(AF_INET, &(source_addr.sin_addr), ip, 50);
+			memset(ip, 0, sizeof(char) * 15);
+			memcpy(ip, inet_ntoa(source_addr.sin_addr), sizeof(ip));
 		} while (strcmp(ip, src_str)!=0);												/* Loop till we find intended source */
 	}
 	else


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [X] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [X] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---
#1116
The change allows the command-line version of ccextractor to be built for Windows XP and run on it as well.  The following occurs without the changes because inet_ntop() is not supported on Windows XP.
![image](https://user-images.githubusercontent.com/21135985/71591804-b2043700-2afb-11ea-98ae-6b13287b20ef.png)

CCX was built on a Windows 10 machine using Visual Studio 2017 targeted for Windows XP and then run on a Windows XP VM. Visual Studio 2019 doesn't support targeting for Windows XP.