### PR TITLE
[FIX] Stop searching for tessdata

### DIFF
--- a/src/lib_ccx/hardsubx.c
+++ b/src/lib_ccx/hardsubx.c
@@ -225,37 +225,17 @@ struct lib_hardsubx_ctx* _init_hardsubx(struct ccx_s_options *options)
     char* lang = options->ocrlang;
     if(!lang) lang = "eng"; // English is default language
 
-    tessdata_path = probe_tessdata_location(lang);
-    if(!tessdata_path)
-    {
-        if (strcmp(lang, "eng") == 0)
-        {
-            mprint("eng.traineddata not found! No Switching Possible\n");
-            return NULL;
-        }
-        mprint("%s.traineddata not found! Switching to English\n", lang);
-        lang = "eng";
-        tessdata_path = probe_tessdata_location("eng");
-        if(!tessdata_path)
-        {
-            mprint("eng.traineddata not found! No Switching Possible\n");
-            return NULL;
-        }
-    }
-
     int ret = -1;
 
     if (!strncmp("4.", TessVersion(), 2))
     {
-        char tess_path [1024];
-        snprintf(tess_path, 1024, "%s%s%s", tessdata_path, "/", "tessdata");
         //ccx_options.ocr_oem are deprecated and only supported mode is OEM_LSTM_ONLY
-        ret = TessBaseAPIInit4(ctx->tess_handle, tess_path, lang, 1, NULL, 0, &pars_vec,
+        ret = TessBaseAPIInit4(ctx->tess_handle, NULL, lang, 1, NULL, 0, &pars_vec,
             &pars_values, 1, false);
     }
     else
     {
-        ret = TessBaseAPIInit4(ctx->tess_handle, tessdata_path, lang, ccx_options.ocr_oem, NULL, 0, &pars_vec,
+        ret = TessBaseAPIInit4(ctx->tess_handle, NULL, lang, ccx_options.ocr_oem, NULL, 0, &pars_vec,
             &pars_values, 1, false);
     }
 
@@ -263,6 +243,8 @@ struct lib_hardsubx_ctx* _init_hardsubx(struct ccx_s_options *options)
 	free(pars_values);
 	if(ret != 0)
 	{
+		// TODO: this is not necessarily the reason, tesseract might have not
+		// been able to find trained data
 		fatal(EXIT_NOT_ENOUGH_MEMORY, "Not enough memory to initialize Tesseract");
 	}
 

--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -134,7 +134,7 @@ void* init_ocr(int lang_index)
 {
 	int ret = -1;
 	struct ocrCtx* ctx;
-	const char* lang = NULL, *tessdata_path = NULL;
+	const char* lang = NULL;
 
 	ctx = (struct ocrCtx*)malloc(sizeof(struct ocrCtx));
 	if(!ctx)
@@ -144,29 +144,10 @@ void* init_ocr(int lang_index)
 		lang = ccx_options.ocrlang;
 	else
 	{
+		/* if language was undefined use english */
 		if(lang_index == 0)
 			lang_index = 1;
 		lang = language[lang_index];
-	}
-	/* if language was undefined use english */
-
-	tessdata_path = probe_tessdata_location(lang);
-	if(!tessdata_path)
-	{
-		if (lang_index == 1)
-		{
-			mprint("eng.traineddata not found! No Switching Possible\n");
-			return NULL;
-		}
-		mprint("%s.traineddata not found! Switching to English\n", lang);
-		lang_index = 1;
-		lang = language[lang_index];
-		tessdata_path = probe_tessdata_location(lang);
-		if(!tessdata_path)
-		{
-			mprint("eng.traineddata not found! No Switching Possible\n");
-			return NULL;
-		}
 	}
 
 	char* pars_vec = strdup("debug_file");
@@ -176,14 +157,13 @@ void* init_ocr(int lang_index)
 	if (!strncmp("4.", TessVersion(), 2))
 	{
 		char tess_path [1024];
-		snprintf(tess_path, 1024, "%s%s%s", tessdata_path, "/", "tessdata");
 		//ccx_options.ocr_oem are deprecated and only supported mode is OEM_LSTM_ONLY
-		ret = TessBaseAPIInit4(ctx->api, tess_path, lang, 1, NULL, 0, &pars_vec,
+		ret = TessBaseAPIInit4(ctx->api, NULL, lang, 1, NULL, 0, &pars_vec,
 			&pars_values, 1, false);
 	}
 	else
 	{
-		ret = TessBaseAPIInit4(ctx->api, tessdata_path, lang, ccx_options.ocr_oem, NULL, 0, &pars_vec,
+		ret = TessBaseAPIInit4(ctx->api, NULL, lang, ccx_options.ocr_oem, NULL, 0, &pars_vec,
 			&pars_values, 1, false);
 	}
 


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [x] I have used CCExtractor just a couple of times.

---

Removes logic in ccextractor that looks for `tessdata`, in favor of passing `NULL` to tesseract and let it find the directory.

This means that it fixes:
* Fix #1162 
* OCR on NixOS

