### PR TITLE
[IMPROVEMENT] Remove useless nulling of pointer

### DIFF
--- a/src/gpacmp4/mp4.c
+++ b/src/gpacmp4/mp4.c
@@ -689,7 +689,6 @@ int processmp4 (struct lib_ccx_ctx *ctx, struct ccx_s_mp4Cfg *cfg, char *file)
 	}
 
 	freep(&dec_ctx->xds_ctx);
-	dec_ctx->xds_ctx=NULL;
 
 	mprint("\nClosing media: ");
 	gf_isom_close(f);


### PR DESCRIPTION
`freep` already nulls the pointer.

Follow up to #1169