### PR TITLE
[FIX] Added the option to disable timestamps for WebVTT

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -18,6 +18,7 @@
 - Fix: lib_ccx.c: Initialize fatal error logging function before first usage in init_libraries
 - Fix: Added italics, underline, and color rendering support for -out=spupng with EIA608/teletext
 - Fix: Change inet_ntop to inet_ntoa for Windows XP compatibility
+- FIX: Added an option to disable timestamps for WebVTT (#1127)
 
 0.88 (2019-05-21)
 -----------------

--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -18,7 +18,7 @@
 - Fix: lib_ccx.c: Initialize fatal error logging function before first usage in init_libraries
 - Fix: Added italics, underline, and color rendering support for -out=spupng with EIA608/teletext
 - Fix: Change inet_ntop to inet_ntoa for Windows XP compatibility
-- FIX: Added an option to disable timestamps for WebVTT (#1127)
+- FIX: Added an option to disable timestamps for WebVTT (In response to issue #1127)
 
 0.88 (2019-05-21)
 -----------------

--- a/src/lib_ccx/ccx_common_option.c
+++ b/src/lib_ccx/ccx_common_option.c
@@ -40,6 +40,7 @@ void init_options (struct ccx_s_options *options)
 	options->live_stream=0; // 0 -> A regular file
 	options->messages_target=1; // 1=stdout
 	options->print_file_reports=0;
+	options->no_timestamp_map = 0; // Enable timestamps by default
 	/* Levenshtein's parameters, for string comparison */
 	options->dolevdist = 1; // By default attempt to correct typos
 	options->levdistmincnt=2; // Means 2 fails or less is "the same"...

--- a/src/lib_ccx/ccx_common_option.c
+++ b/src/lib_ccx/ccx_common_option.c
@@ -41,6 +41,7 @@ void init_options (struct ccx_s_options *options)
 	options->messages_target=1; // 1=stdout
 	options->print_file_reports=0;
 	options->no_timestamp_map = 0; // Enable timestamps by default
+	
 	/* Levenshtein's parameters, for string comparison */
 	options->dolevdist = 1; // By default attempt to correct typos
 	options->levdistmincnt=2; // Means 2 fails or less is "the same"...

--- a/src/lib_ccx/ccx_common_option.h
+++ b/src/lib_ccx/ccx_common_option.h
@@ -38,6 +38,7 @@ struct encoder_cfg
 	int force_flush;                     // Force flush on content write
 	int append_mode;                     // Append mode for output files
 	int ucla;                            // 1 if -UCLA used, 0 if not
+	int no_timestamp_map;				 // 1 if timestamps disabled for WebVTT
 
 	enum ccx_encoding_type encoding;
 	enum ccx_output_date_format date_format;
@@ -71,7 +72,7 @@ struct encoder_cfg
 	LLONG subs_delay;                                   // ms to delay (or advance) subs
 	int program_number;
 	unsigned char in_format;
-	int nospupngocr;				                    // 1 if we don't want to OCR bitmaps to add the text as comments in the XML file in spupng
+	int nospupngocr;				                    // 1 if we don't want to OCR bitmaps to add the text as comments in the XML file in spupng	
 
 	// MCC File
 	int force_dropframe;                                // 1 if dropframe frame count should be used. defaults to no drop frame.

--- a/src/lib_ccx/ccx_common_option.h
+++ b/src/lib_ccx/ccx_common_option.h
@@ -115,6 +115,7 @@ struct ccx_s_options // Options from user parameters
                                          >0 -> Live stream with a timeout of this value in seconds */
 	char *filter_profanity_file;         // Extra profanity word file
 	int messages_target;              // 0 = nowhere (quiet), 1=stdout, 2=stderr
+	int no_timestamp_map;             // 1 for no timestamps for WebVTT, 0 for the timestamp header
 	/* Levenshtein's parameters, for string comparison */
 	int dolevdist;					  // 0 => don't attempt to correct typos with this algorithm
 	int levdistmincnt, levdistmaxpct; // Means 2 fails or less is "the same", 10% or less is also "the same"

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -958,6 +958,7 @@ struct encoder_ctx *init_encoder(struct encoder_cfg *opt)
 	ctx->srt_counter = 0;
 	ctx->cea_708_counter = 0;
 	ctx->wrote_webvtt_header = 0;
+	ctx->no_timestamp_map = opt->no_timestamp_map;
 
 	ctx->program_number = opt->program_number;
 	ctx->send_to_srv = opt->send_to_srv;

--- a/src/lib_ccx/ccx_encoders_common.h
+++ b/src/lib_ccx/ccx_encoders_common.h
@@ -82,6 +82,8 @@ struct encoder_ctx
 	int force_flush;
 	/* Keep track of whether -UCLA used */
 	int ucla;
+	/* Disable timestamps for WebVTT */
+	int no_timestamp_map;
 
 	struct ccx_common_timing_ctx *timing; /* Some encoders need access to PTS, such as WebVTT */
 

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -216,7 +216,7 @@ int write_webvtt_header(struct encoder_ctx *context)
 		millis_to_time(context->timing->sync_pts2fts_fts, &h1, &m1, &s1, &ms1);
 		 
 		 // If the user has not disabled the X-TIMESTAMP-MAP header
-		if (!ccx_options.no_timestamp_map)
+		if (!context->no_timestamp_map)
 		{
 			sprintf(header_string, "X-TIMESTAMP-MAP=MPEGTS:%ld,LOCAL:%02u:%02u:%02u.%03u%s",
 				context->timing->sync_pts2fts_pts, h1, m1, s1, ms1,

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -215,7 +215,7 @@ int write_webvtt_header(struct encoder_ctx *context)
 		unsigned h1, m1, s1, ms1;
 		millis_to_time(context->timing->sync_pts2fts_fts, &h1, &m1, &s1, &ms1);
 		 
-		 // If the user has not disabled the X-TIMESTAMP-MAP header
+		 // If the user has not disabled X-TIMESTAMP-MAP
 		if (!context->no_timestamp_map)
 		{
 			sprintf(header_string, "X-TIMESTAMP-MAP=MPEGTS:%ld,LOCAL:%02u:%02u:%02u.%03u%s",

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -214,9 +214,19 @@ int write_webvtt_header(struct encoder_ctx *context)
 		int used;
 		unsigned h1, m1, s1, ms1;
 		millis_to_time(context->timing->sync_pts2fts_fts, &h1, &m1, &s1, &ms1);
-		sprintf(header_string, "X-TIMESTAMP-MAP=MPEGTS:%ld,LOCAL:%02u:%02u:%02u.%03u%s",
-			context->timing->sync_pts2fts_pts, h1, m1, s1, ms1,
-			ccx_options.enc_cfg.line_terminator_lf ? "\n\n" : "\r\n\r\n");
+		 
+		 // If the user has not disabled the X-TIMESTAMP-MAP header
+		if (!ccx_options.no_timestamp_map)
+		{
+			sprintf(header_string, "X-TIMESTAMP-MAP=MPEGTS:%ld,LOCAL:%02u:%02u:%02u.%03u%s",
+				context->timing->sync_pts2fts_pts, h1, m1, s1, ms1,
+				ccx_options.enc_cfg.line_terminator_lf ? "\n\n" : "\r\n\r\n");
+		}
+		else {
+			sprintf(header_string,
+				context->timing->sync_pts2fts_pts, h1, m1, s1, ms1,
+				ccx_options.enc_cfg.line_terminator_lf ? "\n\n" : "\r\n\r\n");
+		}
 		used = encode_line(context, context->buffer, (unsigned char *)header_string);
 		write(context->out->fh, context->buffer, used);
 

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -554,6 +554,7 @@ void print_usage (void)
 	mprint("                       less or equal than the max allowed..\n");
 	mprint("-anvid --analyzevideo  Analyze the video stream even if it's not used for\n");
 	mprint("                       subtitles. This allows to provide video information.\n");
+	mprint("  --no-timestamp-map   Use this flag to disable the X-TIMESTAMP-MAP header for WebVTT\n");
 	mprint("Levenshtein distance:\n\n");
 	mprint("  When processing teletext files CCExtractor tries to correct typos by\n");
 	mprint("  comparing consecutive lines. If line N+1 is almost identical to line N except\n");
@@ -1489,6 +1490,12 @@ int parse_parameters (struct ccx_s_options *opt, int argc, char *argv[])
 		if (strcmp(argv[i], "-nots") == 0 || strcmp(argv[i], "--notypesetting") == 0)
 		{
 			opt->notypesetting = 1;
+			continue;
+		}
+
+		if (strcmp(argv[i], "--no-timestamp-map") == 0 || strcmp(argv[i], "-ntm") == 0)
+		{
+			opt->no_timestamp_map = 1;
 			continue;
 		}
 


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [x] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

In response to issue #1127, this fix adds an option to remove the X-TIMESTAMP-MAP header for WebVTT.
