### PR TITLE
[IMPROVEMENT] Add noreturn attribute to fatal

### DIFF
--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -250,6 +250,7 @@ int myth_loop(struct lib_ccx_ctx *ctx);
 int matroska_loop(struct lib_ccx_ctx *ctx);
 
 // utility.c
+__attribute__ ((noreturn))
 void fatal(int exit_code, const char *fmt, ...);
 void mprint (const char *fmt, ...);
 void sleep_secs (int secs);

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -250,7 +250,11 @@ int myth_loop(struct lib_ccx_ctx *ctx);
 int matroska_loop(struct lib_ccx_ctx *ctx);
 
 // utility.c
+#if defined(__GNUC__)
 __attribute__ ((noreturn))
+#elif defined(_MSC_VER)
+__declspec(noreturn)
+#endif
 void fatal(int exit_code, const char *fmt, ...);
 void mprint (const char *fmt, ...);
 void sleep_secs (int secs);


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [X] I have used CCExtractor just a couple of times.

---

Removes the following warnings:

```patch
52a52,55
> /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/asf_functions.c: In function ‘asf_readval’:
> /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/asf_functions.c:39:9: warning: ‘rval’ may be used uninitialized in this function [-Wmaybe-uninitialized]
>   return rval;
>          ^~~~
1652a1656,1663
> /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/general_loop.c: In function ‘process_data’:
> /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/general_loop.c:741:5: warning: ‘got’ may be used uninitialized in this function [-Wmaybe-uninitialized]
>   if (got > data_node->len)
>      ^
> /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/general_loop.c: In function ‘general_loop’:
> /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/general_loop.c:896:9: warning: ‘get_more_data’ may be used uninitialized in this function [-Wmaybe-uninitialized]
>    ret = get_more_data(ctx, &datalist);
>          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
