### PR TITLE
[IMPROVEMENT] Remove freep warning

### DIFF
--- a/src/gpacmp4/mp4.c
+++ b/src/gpacmp4/mp4.c
@@ -688,7 +688,7 @@ int processmp4 (struct lib_ccx_ctx *ctx, struct ccx_s_mp4Cfg *cfg, char *file)
 
 	}
 
-	freep(&dec_ctx->xds_ctx);
+	freep(dec_ctx->xds_ctx);
 
 	mprint("\nClosing media: ");
 	gf_isom_close(f);

--- a/src/lib_ccx/avc_functions.c
+++ b/src/lib_ccx/avc_functions.c
@@ -26,7 +26,7 @@ void dinit_avc(struct avc_ctx **ctx)
 		mprint ("Total caption blocks received: %d\n", lctx->ccblocks_in_avc_total);
 		mprint ("Total caption blocks lost: %d\n", lctx->ccblocks_in_avc_lost);
 	}
-	freep(&lctx->cc_data);
+	freep(lctx->cc_data);
 	freep(ctx);
 }
 

--- a/src/lib_ccx/ccx_common_common.c
+++ b/src/lib_ccx/ccx_common_common.c
@@ -58,16 +58,6 @@ void millis_to_time(LLONG milli, unsigned *hours, unsigned *minutes,
 	*hours = (int)milli;
 }
 
-/* Frees the given pointer */
-void freep(void **arg)
-{
-	if (arg)
-	{
-		free(*arg);
-		*arg = NULL;
-	}
-}
-
 int add_cc_sub_text(struct cc_subtitle *sub, char *str, LLONG start_time,
 		LLONG end_time, char *info, char *mode, enum ccx_encoding_type e_type)
 {

--- a/src/lib_ccx/ccx_common_common.h
+++ b/src/lib_ccx/ccx_common_common.h
@@ -42,7 +42,9 @@
 // Declarations
 void fdprintf(int fd, const char *fmt, ...);
 void millis_to_time(LLONG milli, unsigned *hours, unsigned *minutes,unsigned *seconds, unsigned *ms);
-void freep(void **arg);
+
+#define freep(ptr) do { free(ptr); ptr = NULL; } while (0);
+
 void dbg_print(LLONG mask, const char *fmt, ...);
 unsigned char *debug_608_to_ASC(unsigned char *ccdata, int channel);
 int add_cc_sub_text(struct cc_subtitle *sub, char *str, LLONG start_time,

--- a/src/lib_ccx/ccx_decoders_common.c
+++ b/src/lib_ccx/ccx_decoders_common.c
@@ -534,32 +534,32 @@ void free_encoder_context(struct encoder_ctx *ctx)
 	if (!ctx)
 		return;
 
-	freep(&ctx->first_input_file);
-	freep(&ctx->buffer);
-	freep(&ctx->out);
-	freep(&ctx->timing);
-	freep(&ctx->transcript_settings);
-	freep(&ctx->subline);
-	freep(&ctx->start_credits_text);
-	freep(&ctx->end_credits_text);
-	freep(&ctx->prev);
-    freep(&ctx->last_string);
-	freep(&ctx);
+	freep(ctx->first_input_file);
+	freep(ctx->buffer);
+	freep(ctx->out);
+	freep(ctx->timing);
+	freep(ctx->transcript_settings);
+	freep(ctx->subline);
+	freep(ctx->start_credits_text);
+	freep(ctx->end_credits_text);
+	freep(ctx->prev);
+	freep(ctx->last_string);
+	freep(ctx);
 }
 void free_decoder_context(struct lib_cc_decode *ctx)
 {
 	if (!ctx)
 		return;
 
-	freep(&ctx->context_cc608_field_1);
-	freep(&ctx->context_cc608_field_2);
-	freep(&ctx->timing);
-	freep(&ctx->avc_ctx);
-	freep(&ctx->private_data);
-	freep(&ctx->dtvcc);
-	freep(&ctx->xds_ctx);
-	freep(&ctx->vbi_decoder);
-	freep(&ctx);
+	freep(ctx->context_cc608_field_1);
+	freep(ctx->context_cc608_field_2);
+	freep(ctx->timing);
+	freep(ctx->avc_ctx);
+	freep(ctx->private_data);
+	freep(ctx->dtvcc);
+	freep(ctx->xds_ctx);
+	freep(ctx->vbi_decoder);
+	freep(ctx);
 }
 void free_subtitle(struct cc_subtitle* sub)
 {
@@ -571,10 +571,10 @@ void free_subtitle(struct cc_subtitle* sub)
 		struct cc_bitmap *bitmap=(struct cc_bitmap *) sub->data;
 		if (bitmap)
 		{
-			freep(&bitmap->data0);
-			freep(&bitmap->data1);
+			freep(bitmap->data0);
+			freep(bitmap->data1);
 		}
 	}
-	freep(&sub->data);
-	freep(&sub);
+	freep(sub->data);
+	freep(sub);
 }

--- a/src/lib_ccx/ccx_decoders_xds.c
+++ b/src/lib_ccx/ccx_decoders_xds.c
@@ -131,7 +131,7 @@ int write_xds_string(struct cc_subtitle *sub, struct ccx_decoders_xds_context *c
 	data = (struct eia608_screen *) realloc(sub->data,( sub->nb_data + 1 ) * sizeof(*data));
 	if (!data)
 	{
-		freep(&sub->data);
+		freep(sub->data);
 		sub->nb_data = 0;
 		ccx_common_logging.log_ftn("No Memory left");
 		return -1;

--- a/src/lib_ccx/ccx_demuxer.c
+++ b/src/lib_ccx/ccx_demuxer.c
@@ -276,7 +276,7 @@ void ccx_demuxer_delete(struct ccx_demuxer **ctx)
 	struct ccx_demuxer *lctx = *ctx;
 	int i;
 	dinit_cap(lctx);
-	freep(&lctx->last_pat_payload);
+	freep(lctx->last_pat_payload);
 	for (i = 0; i < MAX_PSI_PID; i++)
 	{
 		if(lctx->PID_buffers[i]!=NULL && lctx->PID_buffers[i]->buffer!=NULL)
@@ -285,17 +285,17 @@ void ccx_demuxer_delete(struct ccx_demuxer **ctx)
 			lctx->PID_buffers[i]->buffer=NULL;
 			lctx->PID_buffers[i]->buffer_length=0;
 		}
-		freep(&lctx->PID_buffers[i]);
+		freep(lctx->PID_buffers[i]);
 	}
 	for (i = 0; i < MAX_PID; i++)
 	{
 		if( lctx->PIDs_programs[i])
-			freep(lctx->PIDs_programs + i);
+			freep(lctx->PIDs_programs[i]);
 	}
 	if (lctx->fh_out_elementarystream != NULL)
 		fclose (lctx->fh_out_elementarystream);
 
-	freep(&lctx->filebuffer);
+	freep(lctx->filebuffer);
 	freep(ctx);
 }
 

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -584,14 +584,14 @@ int write_cc_subtitle_as_simplexml(struct cc_subtitle *sub, struct encoder_ctx *
 
 		} while ( (str = strtok_r(NULL, "\r\n", &save_str) ));
 
-		freep(&sub->data);
+		freep(sub->data);
 		lsub = sub;
 		sub = sub->next;
 	}
 	while(lsub != osub)
 	{
 		sub = lsub->prev;
-		freep(&lsub);
+		freep(lsub);
 		lsub = sub;
 	}
 
@@ -644,7 +644,7 @@ int write_cc_bitmap_as_simplexml(struct cc_subtitle *sub, struct encoder_ctx *co
 	int ret = 0;
 
 	sub->nb_data = 0;
-	freep(&sub->data);
+	freep(sub->data);
 	return ret;
 }
 
@@ -764,7 +764,7 @@ static void dinit_output_ctx(struct encoder_ctx *ctx)
 	int i;
 	for(i = 0; i < ctx->nb_out; i++)
 		dinit_write(ctx->out + i);
-	freep(&ctx->out);
+	freep(ctx->out);
 
 	if (ctx->dtvcc_extract)
 	{
@@ -846,8 +846,8 @@ static int init_output_ctx(struct encoder_ctx *ctx, struct encoder_cfg *cfg)
 			}
 		}
 
-		freep(&basefilename);
-		freep(&extension);
+		freep(basefilename);
+		freep(extension);
 	}
 
 	if (cfg->cc_to_stdout == CCX_TRUE)
@@ -927,8 +927,8 @@ void dinit_encoder(struct encoder_ctx **arg, LLONG current_fts)
 
 	free_encoder_context(ctx->prev);
 	dinit_output_ctx(ctx);
-	freep(&ctx->subline);
-	freep(&ctx->buffer);
+	freep(ctx->subline);
+	freep(ctx->buffer);
 	ctx->capacity = 0;
 	freep(arg);
 }
@@ -973,7 +973,7 @@ struct encoder_ctx *init_encoder(struct encoder_cfg *opt)
 	ret = init_output_ctx(ctx, opt);
 	if (ret != EXIT_OK)
 	{
-		freep(&ctx->buffer);
+		freep(ctx->buffer);
 		free(ctx);
 		return NULL;
 	}
@@ -1012,8 +1012,8 @@ struct encoder_ctx *init_encoder(struct encoder_cfg *opt)
 	ctx->subline = (unsigned char *) malloc (SUBLINESIZE);
 	if(!ctx->subline)
 	{
-		freep(&ctx->out);
-		freep(&ctx->buffer);
+		freep(ctx->out);
+		freep(ctx->buffer);
 		free(ctx);
 		return NULL;
 	}
@@ -1128,7 +1128,7 @@ int encode_sub(struct encoder_ctx *context, struct cc_subtitle *sub)
 							mprint("WARNING:Loss of data\n");
 						}
 					}
-					freep(&data->xds_str);
+					freep(data->xds_str);
 					write_newline(context, 0);
 					continue;
 				}
@@ -1203,7 +1203,7 @@ int encode_sub(struct encoder_ctx *context, struct cc_subtitle *sub)
 					write_cc_buffer_to_gui(sub->data, context);
 #endif // PYTHON_API
 			}
-			freep(&sub->data);
+			freep(sub->data);
 		}
 		if (sub->type == CC_BITMAP)
 		{
@@ -1311,7 +1311,7 @@ int encode_sub(struct encoder_ctx *context, struct cc_subtitle *sub)
 		}
 
 	if (!sub->nb_data)
-		freep(&sub->data);
+		freep(sub->data);
 	if (wrote_something && context->force_flush)
 		fsync(context->out->fh); // Don't buffer
 	return wrote_something;

--- a/src/lib_ccx/ccx_encoders_curl.c
+++ b/src/lib_ccx/ccx_encoders_curl.c
@@ -78,7 +78,7 @@ int write_cc_bitmap_as_libcurl(struct cc_subtitle *sub, struct encoder_ctx *cont
 				mprint("curl_easy_perform() failed: %s\n",
 				curl_easy_strerror(res));
 		}
-		freep(&str);
+		freep(str);
 	}
 	for (i = 0, rect = sub->data; i < sub->nb_data; i++, rect++)
 	{
@@ -87,7 +87,7 @@ int write_cc_bitmap_as_libcurl(struct cc_subtitle *sub, struct encoder_ctx *cont
 	}
 #endif
 	sub->nb_data = 0;
-	freep(&sub->data);
+	freep(sub->data);
 	return ret;
 
 }

--- a/src/lib_ccx/ccx_encoders_sami.c
+++ b/src/lib_ccx/ccx_encoders_sami.c
@@ -163,7 +163,7 @@ int write_cc_bitmap_as_sami(struct cc_subtitle *sub, struct encoder_ctx *context
 #endif
 
 	sub->nb_data = 0;
-	freep(&sub->data);
+	freep(sub->data);
 	return ret;
 }
 
@@ -177,7 +177,7 @@ int write_cc_subtitle_as_sami(struct cc_subtitle *sub, struct encoder_ctx *conte
 		if(sub->type == CC_TEXT)
 		{
 			ret = write_stringz_as_sami(sub->data, context, sub->start_time, sub->end_time);
-			freep(&sub->data);
+			freep(sub->data);
 			sub->nb_data = 0;
 		}
 		lsub = sub;
@@ -186,7 +186,7 @@ int write_cc_subtitle_as_sami(struct cc_subtitle *sub, struct encoder_ctx *conte
 	while(lsub != osub)
 	{
 		sub = lsub->prev;
-		freep(&lsub);
+		freep(lsub);
 		lsub = sub;
 	}
 

--- a/src/lib_ccx/ccx_encoders_smptett.c
+++ b/src/lib_ccx/ccx_encoders_smptett.c
@@ -147,13 +147,13 @@ int write_cc_bitmap_as_smptett(struct cc_subtitle *sub, struct encoder_ctx *cont
 	}
 	for (i = 0, rect = sub->data; i < sub->nb_data; i++, rect++)
 	{
-		freep(&rect->data0);
-		freep(&rect->data1);
+		freep(rect->data0);
+		freep(rect->data1);
 	}
 #endif
 
 	sub->nb_data = 0;
-	freep(&sub->data);
+	freep(sub->data);
 	return ret;
 
 }
@@ -168,7 +168,7 @@ int write_cc_subtitle_as_smptett(struct cc_subtitle *sub, struct encoder_ctx *co
 		if(sub->type == CC_TEXT)
 		{
 			write_stringz_as_smptett(sub->data, context, sub->start_time, sub->end_time);
-			freep(&sub->data);
+			freep(sub->data);
 			sub->nb_data = 0;
 		}
 		lsub = sub;
@@ -177,7 +177,7 @@ int write_cc_subtitle_as_smptett(struct cc_subtitle *sub, struct encoder_ctx *co
 	while(lsub != osub)
 	{
 		sub = lsub->prev;
-		freep(&lsub);
+		freep(lsub);
 		lsub = sub;
 	}
 
@@ -422,8 +422,8 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
 				used = encode_line(context, context->buffer, (unsigned char*) str);
 				//write (wb->fh, enc_buffer,enc_buffer_used);
 				
-				freep(&final);
-				freep(&temp);
+				freep(final);
+				freep(temp);
 	
 			}
 		}

--- a/src/lib_ccx/ccx_encoders_splitbysentence.c
+++ b/src/lib_ccx/ccx_encoders_splitbysentence.c
@@ -772,17 +772,17 @@ struct cc_subtitle * reformat_cc_bitmap_through_sentence_buffer(struct cc_subtit
 		{
 			resub = sbs_append_string(str, ms_start, ms_end, sbs_init_context());
 		}
-		freep(&str);
+		freep(str);
 	}
 
 	for(i = 0, rect = sub->data; i < sub->nb_data; i++, rect++)
 	{
-		freep(&rect->data0);
-		freep(&rect->data1);
+		freep(rect->data0);
+		freep(rect->data1);
 	}
 #endif
 	sub->nb_data = 0;
-	freep(&sub->data);
+	freep(sub->data);
 
 	return resub;
 }

--- a/src/lib_ccx/ccx_encoders_spupng.c
+++ b/src/lib_ccx/ccx_encoders_spupng.c
@@ -310,8 +310,8 @@ int save_spupng(const char *filename, uint8_t *bitmap, int w, int h,
 end: if (row_pointer)
 {
 	for (i = 0; i < h; i++)
-		freep(&row_pointer[i]);
-	freep(&row_pointer);
+		freep(row_pointer[i]);
+	freep(row_pointer);
 }
 	 png_destroy_write_struct(&png_ptr, &info_ptr);
 	 if (f)
@@ -453,12 +453,12 @@ int write_cc_bitmap_as_spupng(struct cc_subtitle *sub, struct encoder_ctx *conte
 		if (str)
 		{
 			write_spucomment(sp, str);
-			freep(&str);
+			freep(str);
 		}
 	}
 #endif
 	save_spupng(filename, pbuf, width, height, palette, alpha, rect[0].nb_colors);
-	freep(&pbuf);
+	freep(pbuf);
 
 
 end:
@@ -467,14 +467,14 @@ end:
 
 	for (i = 0, rect = sub->data; i < sub->nb_data; i++, rect++)
 	{
-		freep(&rect->data0);
-		freep(&rect->data1);
+		freep(rect->data0);
+		freep(rect->data1);
 	}
 	sub->nb_data = 0;
-	freep(&sub->data);
-	freep(&palette);
-	freep(&alpha);
-	freep(&pbuf);
+	freep(sub->data);
+	freep(palette);
+	freep(alpha);
+	freep(pbuf);
 	return ret;
 }
 

--- a/src/lib_ccx/ccx_encoders_srt.c
+++ b/src/lib_ccx/ccx_encoders_srt.c
@@ -120,20 +120,20 @@ int write_cc_bitmap_as_srt(struct cc_subtitle *sub, struct encoder_ctx *context)
                 write (context->out->fh, str, len);
                 write (context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
             }
-            freep(&str);
+            freep(str);
         }
 	}
 	for(i = 0, rect = sub->data; i < sub->nb_data; i++, rect++)
 	{
 		if (rect)
 		{
-			freep(&rect->data0);
-			freep(&rect->data1);
+			freep(rect->data0);
+			freep(rect->data1);
 		}
 	}
 #endif
 	sub->nb_data = 0;
-	freep(&sub->data);
+	freep(sub->data);
 	return ret;
 
 }
@@ -149,7 +149,7 @@ int write_cc_subtitle_as_srt(struct cc_subtitle *sub,struct encoder_ctx *context
 		if(sub->type == CC_TEXT)
 		{
 			ret = write_stringz_as_srt(sub->data, context, sub->start_time, sub->end_time);
-			freep(&sub->data);
+			freep(sub->data);
 			sub->nb_data = 0;
 			ret = 1;
 		}
@@ -159,7 +159,7 @@ int write_cc_subtitle_as_srt(struct cc_subtitle *sub,struct encoder_ctx *context
 	while(lsub != osub)
 	{
 		sub = lsub->prev;
-		freep(&lsub);
+		freep(lsub);
 		lsub = sub;
 	}
 

--- a/src/lib_ccx/ccx_encoders_ssa.c
+++ b/src/lib_ccx/ccx_encoders_ssa.c
@@ -117,16 +117,16 @@ int write_cc_bitmap_as_ssa(struct cc_subtitle *sub, struct encoder_ctx *context)
 			write (context->out->fh, str, len);
 			write (context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 		}
-		freep(&str);
+		freep(str);
 	}
 	for(i = 0, rect = sub->data; i < sub->nb_data; i++, rect++)
 	{
-		freep(&rect->data0);
-		freep(&rect->data1);
+		freep(rect->data0);
+		freep(rect->data1);
 	}
 #endif
 	sub->nb_data = 0;
-	freep(&sub->data);
+	freep(sub->data);
 	return ret;
 }
 
@@ -141,7 +141,7 @@ int write_cc_subtitle_as_ssa(struct cc_subtitle *sub,struct encoder_ctx *context
 		if(sub->type == CC_TEXT)
 		{
 			ret = write_stringz_as_ssa(sub->data, context, sub->start_time, sub->end_time);
-			freep(&sub->data);
+			freep(sub->data);
 			sub->nb_data = 0;
 			ret = 1;
 		}
@@ -151,7 +151,7 @@ int write_cc_subtitle_as_ssa(struct cc_subtitle *sub,struct encoder_ctx *context
 	while(lsub != osub)
 	{
 		sub = lsub->prev;
-		freep(&lsub);
+		freep(lsub);
 		lsub = sub;
 	}
 

--- a/src/lib_ccx/ccx_encoders_transcript.c
+++ b/src/lib_ccx/ccx_encoders_transcript.c
@@ -104,7 +104,7 @@ int write_cc_bitmap_as_transcript(struct cc_subtitle *sub, struct encoder_ctx *c
 #endif
 
 	sub->nb_data = 0;
-	freep(&sub->data);
+	freep(sub->data);
 	return ret;
 
 }
@@ -219,7 +219,7 @@ int write_cc_subtitle_as_transcript(struct cc_subtitle *sub, struct encoder_ctx 
 
 		} while ((str = strtok_r(NULL, "\r\n", &save_str)));
 
-		freep(&sub->data);
+		freep(sub->data);
 		lsub = sub;
 		sub = sub->next;
 	}
@@ -227,7 +227,7 @@ int write_cc_subtitle_as_transcript(struct cc_subtitle *sub, struct encoder_ctx 
 	while (lsub != osub)
 	{
 		sub = lsub->prev;
-		freep(&lsub);
+		freep(lsub);
 		lsub = sub;
 	}
 

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -300,16 +300,16 @@ int write_cc_bitmap_as_webvtt(struct cc_subtitle *sub, struct encoder_ctx *conte
 			write(context->out->fh, str, len);
 			write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 		}
-		freep(&str);
+		freep(str);
 	}
 	for (i = 0, rect = sub->data; i < sub->nb_data; i++, rect++)
 	{
-		freep(&rect->data0);
-		freep(&rect->data1);
+		freep(rect->data0);
+		freep(rect->data1);
 	}
 #endif
 	sub->nb_data = 0;
-	freep(&sub->data);
+	freep(sub->data);
 	return ret;
 
 }
@@ -325,7 +325,7 @@ int write_cc_subtitle_as_webvtt(struct cc_subtitle *sub, struct encoder_ctx *con
 		if (sub->type == CC_TEXT)
 		{
 			ret = write_stringz_as_webvtt(sub->data, context, sub->start_time, sub->end_time);
-			freep(&sub->data);
+			freep(sub->data);
 			sub->nb_data = 0;
 		}
 		lsub = sub;
@@ -334,7 +334,7 @@ int write_cc_subtitle_as_webvtt(struct cc_subtitle *sub, struct encoder_ctx *con
 	while (lsub != osub)
 	{
 		sub = lsub->prev;
-		freep(&lsub);
+		freep(lsub);
 		lsub = sub;
 	}
 

--- a/src/lib_ccx/ccx_gxf.c
+++ b/src/lib_ccx/ccx_gxf.c
@@ -1729,6 +1729,6 @@ void ccx_gxf_delete(struct ccx_demuxer *arg)
 {
 	struct ccx_gxf *ctx = arg->private_data;
 
-	freep(&ctx->cdp);
-	freep(&arg->private_data);
+	freep(ctx->cdp);
+	freep(arg->private_data);
 }

--- a/src/lib_ccx/dvb_subtitle_decoder.c
+++ b/src/lib_ccx/dvb_subtitle_decoder.c
@@ -539,7 +539,7 @@ int dvbsub_close_decoder(void **dvb_ctx)
 
 	delete_cluts(ctx);
 
-	freep(&ctx->display_definition);
+	freep(ctx->display_definition);
 
 	while (ctx->display_list)
 	{
@@ -1278,7 +1278,7 @@ static void dvbsub_parse_region_segment(void*dvb_ctx, const uint8_t *buf,
 	
 	if (region->width * region->height != region->buf_size)
 	{
-		freep(&region->pbuf);
+		freep(region->pbuf);
 		region->buf_size = region->width * region->height;
 		region->pbuf = (uint8_t*) malloc(region->buf_size);
 		fill = 1;
@@ -1709,7 +1709,7 @@ void dvbsub_handle_display_segment(struct encoder_ctx *enc_ctx,
 	dec_ctx->prev = NULL;
 	dec_ctx->prev = copy_decoder_context(dec_ctx);
 
-	freep(&dec_ctx->prev->private_data);
+	freep(dec_ctx->prev->private_data);
 	dec_ctx->prev->private_data = malloc(sizeof(struct DVBSubContext));
 	memcpy(dec_ctx->prev->private_data, dec_ctx->private_data, sizeof(struct DVBSubContext));
 	/* copy previous subtitle */

--- a/src/lib_ccx/lib_ccx.c
+++ b/src/lib_ccx/lib_ccx.c
@@ -239,16 +239,16 @@ void dinit_libraries( struct lib_ccx_ctx **ctx)
 
 	// free EPG memory
 	EPG_free(lctx);
-	freep(&lctx->freport.data_from_608);
-	freep(&lctx->freport.data_from_708);
+	freep(lctx->freport.data_from_608);
+	freep(lctx->freport.data_from_708);
 	ccx_demuxer_delete(&lctx->demux_ctx);
 	dinit_decoder_setting(&lctx->dec_global_setting);
-	freep(&ccx_options.enc_cfg.output_filename);
-	freep(&lctx->basefilename);
-	freep(&lctx->pesheaderbuf);
+	freep(ccx_options.enc_cfg.output_filename);
+	freep(lctx->basefilename);
+	freep(lctx->pesheaderbuf);
 	for(i = 0;i < lctx->num_input_files;i++)
-		freep(&lctx->inputfile[i]);
-	freep(&lctx->inputfile);
+		freep(lctx->inputfile[i]);
+	freep(lctx->inputfile);
 	freep(ctx);
 }
 
@@ -383,7 +383,7 @@ struct encoder_ctx *update_encoder_list_cinfo(struct lib_ccx_ctx *ctx, struct ca
 
 			len = strlen(ctx->basefilename) + 10 + strlen(extension);
 
-			freep(&ccx_options.enc_cfg.output_filename);
+			freep(ccx_options.enc_cfg.output_filename);
 			ccx_options.enc_cfg.output_filename = malloc(len);
 
 			sprintf(ccx_options.enc_cfg.output_filename, "%s_%06d%s", ctx->basefilename, ctx->segment_counter+1, extension);
@@ -408,7 +408,7 @@ struct encoder_ctx *update_encoder_list_cinfo(struct lib_ccx_ctx *ctx, struct ca
 		ccx_options.enc_cfg.output_filename = malloc(len);
 		if (!ccx_options.enc_cfg.output_filename)
 		{
-			freep(&extension);
+			freep(extension);
 			return NULL;
 		}
 
@@ -416,21 +416,21 @@ struct encoder_ctx *update_encoder_list_cinfo(struct lib_ccx_ctx *ctx, struct ca
 		enc_ctx = init_encoder(&ccx_options.enc_cfg);
 		if (!enc_ctx)
 		{
-			freep(&extension);
-			freep(&ccx_options.enc_cfg.output_filename);
+			freep(extension);
+			freep(ccx_options.enc_cfg.output_filename);
 			return NULL;
 		}
 
 		list_add_tail( &(enc_ctx->list), &(ctx->enc_ctx_head) );
-		freep(&extension);
-		freep(&ccx_options.enc_cfg.output_filename);
+		freep(extension);
+		freep(ccx_options.enc_cfg.output_filename);
 	}
 	// DVB related
 	enc_ctx->prev = NULL;
 	if (cinfo)
 		if (cinfo->codec == CCX_CODEC_DVB)
 			enc_ctx->write_previous = 0;
-	freep(&extension);
+	freep(extension);
 	return enc_ctx;
 }
 

--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -591,9 +591,9 @@ char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* i
 
 				h0=h;
 
-				freep(&histogram);
-				freep(&mcit);
-				freep(&iot);
+				freep(histogram);
+				freep(mcit);
+				freep(iot);
 				TessDeleteText(word);
 			} while (TessPageIteratorNext((TessPageIterator *)ri,level));
 
@@ -840,9 +840,9 @@ static int quantize_map(png_byte *alpha, png_color *palette,
 			i, palette[i].red, palette[i].green, palette[i].blue, alpha[i]);
 	}
 #endif
-	end: freep(&histogram);
-	freep(&mcit);
-	freep(&iot);
+	end: freep(histogram);
+	freep(mcit);
+	freep(iot);
 	return ret;
 }
 
@@ -918,12 +918,12 @@ int ocr_rect(void* arg, struct cc_bitmap *rect, char **str, int bgcolor, int ocr
 		*str = ocr_bitmap(arg, palette, alpha, rect->data0, rect->w, rect->h, copy);
 
 end:
-	freep(&palette);
-	freep(&alpha);
-	freep(&copy->palette);
-	freep(&copy->alpha);
-	freep(&copy->data);
-	freep(&copy);
+	freep(palette);
+	freep(alpha);
+	freep(copy->palette);
+	freep(copy->alpha);
+	freep(copy->data);
+	freep(copy);
 	return ret;
 
 }

--- a/src/lib_ccx/output.c
+++ b/src/lib_ccx/output.c
@@ -14,10 +14,10 @@ void dinit_write(struct ccx_s_write *wb)
 #else
         if (wb->fh > 0)
             close(wb->fh);
-        freep(&wb->filename);
+        freep(wb->filename);
         if (wb->with_semaphore && wb->semaphore_filename)
             unlink(wb->semaphore_filename);
-        freep(&wb->semaphore_filename);
+        freep(wb->semaphore_filename);
 #endif
 }
 

--- a/src/lib_ccx/params_dump.c
+++ b/src/lib_ccx/params_dump.c
@@ -417,7 +417,7 @@ void print_file_report(struct lib_ccx_ctx *ctx)
 		printf("MPEG-4 Timed Text tracks count: %d\n", ctx->freport.mp4_cc_track_cnt);
 	}
 
-	freep(&ctx->freport.data_from_608);
+	freep(ctx->freport.data_from_608);
 	memset(&ctx->freport, 0, sizeof (struct file_report));
 #undef Y_N
 }

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -1613,7 +1613,7 @@ void telxcc_close(void **ctx, struct cc_subtitle *sub)
 		telxcc_dump_prev_page(ttext, sub);
 
 	}
-	freep(&ttext->ucs2_buffer_cur);
-	freep(&ttext->page_buffer_cur);
+	freep(ttext->ucs2_buffer_cur);
+	freep(ttext->page_buffer_cur);
 	freep(ctx);
 }

--- a/src/lib_ccx/ts_functions.c
+++ b/src/lib_ccx/ts_functions.c
@@ -590,7 +590,7 @@ void cinfo_cremation(struct ccx_demuxer *ctx, struct demuxer_data **data)
 	list_for_each_entry(iter, &ctx->cinfo_tree.all_stream, all_stream, struct cap_info)
 	{
 		copy_capbuf_demux_data(ctx, data, iter);
-		freep(&iter->capbuf);
+		freep(iter->capbuf);
 	}
 }
 
@@ -733,8 +733,8 @@ uint64_t get_video_min_pts(struct ccx_demuxer *context)
 		p++;
 	}
 
-	freep(&ctx);
-	freep(&pts_array);
+	freep(ctx);
+	freep(pts_array);
 
 	return min_pts;
 }
@@ -958,7 +958,7 @@ long ts_readstream(struct ccx_demuxer *ctx, struct demuxer_data **data)
 
 			if (cinfo->capbuflen > 0)
 			{
-				freep(&cinfo->capbuf);
+				freep(cinfo->capbuf);
 				cinfo->capbufsize = 0;
 				cinfo->capbuflen = 0;
 				delete_demuxer_data_node_by_pid(data, cinfo->pid);

--- a/src/lib_ccx/ts_info.c
+++ b/src/lib_ccx/ts_info.c
@@ -268,7 +268,7 @@ void dinit_cap (struct ccx_demuxer *ctx)
 	{
 		iter = list_entry(ctx->cinfo_tree.all_stream.next, struct cap_info, all_stream);
 		list_del(&iter->all_stream);
-		freep(&iter->capbuf);
+		freep(iter->capbuf);
 		free(iter);
 	}
 	INIT_LIST_HEAD(&ctx->cinfo_tree.all_stream);

--- a/src/lib_ccx/ts_tables_epg.c
+++ b/src/lib_ccx/ts_tables_epg.c
@@ -303,10 +303,10 @@ void EPG_output(struct lib_ccx_ctx *ctx)
 	if(!f)
 	{
 		dbg_print (CCX_DMT_GENERIC_NOTICES, "\rUnable to open %s\n", filename);
-        	freep(&filename);
+		freep(filename);
 		return;
 	}
-	freep(&filename);
+	freep(filename);
 
 	fprintf(f, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE tv SYSTEM \"xmltv.dtd\">\n\n<tv>\n");
 	for(i=0; i<ctx->demux_ctx->nb_program; i++)


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [X] I have used CCExtractor just a couple of times.

---

Change `freep` into a macro to remove all the warnings it generated.