### PR TITLE
[IMPROVEMENT] Remove freep warnings

### DIFF
--- a/src/lib_ccx/ccx_common_common.c
+++ b/src/lib_ccx/ccx_common_common.c
@@ -59,12 +59,13 @@ void millis_to_time(LLONG milli, unsigned *hours, unsigned *minutes,
 }
 
 /* Frees the given pointer */
-void freep(void **arg)
+void freep(void *arg)
 {
-	if (arg)
+	void **ptr = arg;
+	if (*ptr)
 	{
-		free(*arg);
-		*arg = NULL;
+		free(*ptr);
+		*ptr = NULL;
 	}
 }
 

--- a/src/lib_ccx/ccx_common_common.h
+++ b/src/lib_ccx/ccx_common_common.h
@@ -42,7 +42,7 @@
 // Declarations
 void fdprintf(int fd, const char *fmt, ...);
 void millis_to_time(LLONG milli, unsigned *hours, unsigned *minutes,unsigned *seconds, unsigned *ms);
-void freep(void **arg);
+void freep(void *arg);
 void dbg_print(LLONG mask, const char *fmt, ...);
 unsigned char *debug_608_to_ASC(unsigned char *ccdata, int channel);
 int add_cc_sub_text(struct cc_subtitle *sub, char *str, LLONG start_time,


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [X] I have used CCExtractor just a couple of times.

---

Unfortunately, pointers to pointers in C don't really work. The only way is to just cast the pointer.

diff of the output:

```patch
58,74d57
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/avc_functions.c: In function ‘dinit_avc’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/avc_functions.c:29:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&lctx->cc_data);
<         ^~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/avc_functions.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/avc_functions.c:30:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(ctx);
<         ^~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/avc_functions.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct avc_ctx **’
<  void freep(void **arg);
<             ~~~~~~~^~~
85,92d67
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_timing.c: In function ‘dinit_timing_ctx’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_timing.c:42:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(arg);
<         ^~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_timing.c:4:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct ccx_common_timing_ctx **’
<  void freep(void **arg);
<             ~~~~~~~^~~
166,316d140
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c: In function ‘dinit_cc_decode’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:232:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(ctx);
<         ^~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct lib_cc_decode **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c: In function ‘free_encoder_context’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:537:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx->first_input_file);
<         ^~~~~~~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:538:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx->buffer);
<         ^~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:539:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx->out);
<         ^~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct ccx_s_write **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:540:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx->timing);
<         ^~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct ccx_common_timing_ctx **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:541:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx->transcript_settings);
<         ^~~~~~~~~~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct ccx_encoders_transcript_format **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:542:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx->subline);
<         ^~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:543:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx->start_credits_text);
<         ^~~~~~~~~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:544:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx->end_credits_text);
<         ^~~~~~~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:545:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx->prev);
<         ^~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct encoder_ctx **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:546:11: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<      freep(&ctx->last_string);
<            ^~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:547:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx);
<         ^~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct encoder_ctx **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c: In function ‘free_decoder_context’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:556:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx->timing);
<         ^~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct ccx_common_timing_ctx **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:557:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx->avc_ctx);
<         ^~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct avc_ctx **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:559:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx->dtvcc);
<         ^~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘ccx_dtvcc_ctx **’ {aka ‘struct ccx_dtvcc_ctx **’}
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:560:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx->xds_ctx);
<         ^~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct ccx_decoders_xds_context **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:561:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx->vbi_decoder);
<         ^~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct ccx_decoder_vbi_ctx **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:562:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx);
<         ^~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct lib_cc_decode **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c: In function ‘free_subtitle’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:574:10: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<     freep(&bitmap->data0);
<           ^~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:575:10: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<     freep(&bitmap->data1);
<           ^~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:579:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&sub);
<         ^~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct cc_subtitle **’
<  void freep(void **arg);
<             ~~~~~~~^~~
326,333d149
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_vbi.c: In function ‘delete_decoder_vbi’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_vbi.c:13:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(arg);
<         ^~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_vbi.c:4:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct ccx_decoder_vbi_ctx **’
<  void freep(void **arg);
<             ~~~~~~~^~~
336,376d151
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_demuxer.c: In function ‘ccx_demuxer_delete’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_demuxer.c:279:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&lctx->last_pat_payload);
<         ^~~~~~~~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_demuxer.c:3:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_demuxer.c:288:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&lctx->PID_buffers[i]);
<          ^~~~~~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_demuxer.c:3:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct PSI_buffer **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_demuxer.c:293:30: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<     freep(lctx->PIDs_programs + i);
<           ~~~~~~~~~~~~~~~~~~~~^~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_demuxer.c:3:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct PMT_entry **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_demuxer.c:298:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&lctx->filebuffer);
<         ^~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_demuxer.c:3:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_demuxer.c:299:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(ctx);
<         ^~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_demuxer.c:3:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct ccx_demuxer **’
<  void freep(void **arg);
<             ~~~~~~~^~~
379,386d153
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_dtvcc.c: In function ‘ccx_dtvcc_free’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_dtvcc.c:146:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(ctx_ptr);
<         ^~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_dtvcc.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘ccx_dtvcc_ctx **’ {aka ‘struct ccx_dtvcc_ctx **’}
<  void freep(void **arg);
<             ~~~~~~~^~~
388,481d154
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c: In function ‘write_cc_subtitle_as_simplexml’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:594:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&lsub);
<          ^~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_helpers.h:4,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct cc_subtitle **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c: In function ‘dinit_output_ctx’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:767:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx->out);
<         ^~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_helpers.h:4,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct ccx_s_write **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c: In function ‘init_output_ctx’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:849:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&basefilename);
<          ^~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_helpers.h:4,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:850:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&extension);
<          ^~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_helpers.h:4,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c: In function ‘dinit_encoder’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:930:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx->subline);
<         ^~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_helpers.h:4,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:931:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx->buffer);
<         ^~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_helpers.h:4,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:933:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(arg);
<         ^~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_helpers.h:4,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct encoder_ctx **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c: In function ‘init_encoder’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:976:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&ctx->buffer);
<          ^~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_helpers.h:4,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:1015:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&ctx->out);
<          ^~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_helpers.h:4,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct ccx_s_write **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:1016:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&ctx->buffer);
<          ^~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_helpers.h:4,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c: In function ‘encode_sub’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:1131:12: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<       freep(&data->xds_str);
<             ^~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_helpers.h:4,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_common.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
533,541d205
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_sami.c: In function ‘write_cc_subtitle_as_sami’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_sami.c:189:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&lsub);
<          ^~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_sami.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct cc_subtitle **’
<  void freep(void **arg);
<             ~~~~~~~^~~
581,623d244
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c: In function ‘write_cc_bitmap_as_smptett’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:150:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&rect->data0);
<          ^~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:24:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:151:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&rect->data1);
<          ^~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:24:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c: In function ‘write_cc_subtitle_as_smptett’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:180:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&lsub);
<          ^~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:24:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct cc_subtitle **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c: In function ‘write_cc_buffer_as_smptett’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:425:11: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<      freep(&final);
<            ^~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:24:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:426:11: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<      freep(&temp);
<            ^~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:24:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
1104,1127d724
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:775:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&str);
<          ^~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:17:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:780:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&rect->data0);
<          ^~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:17:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:781:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&rect->data1);
<          ^~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:17:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
1132,1146d728
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c: In function ‘save_spupng’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c:313:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&row_pointer[i]);
<          ^~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘png_byte **’ {aka ‘unsigned char **’}
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c:314:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&row_pointer);
<         ^~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘png_byte ***’ {aka ‘unsigned char ***’}
<  void freep(void **arg);
<             ~~~~~~~^~~
1155,1203d736
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c:456:10: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<     freep(&str);
<           ^~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c:461:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&pbuf);
<         ^~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘uint8_t **’ {aka ‘unsigned char **’}
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c:470:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&rect->data0);
<          ^~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c:471:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&rect->data1);
<          ^~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c:475:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&palette);
<         ^~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘png_color **’ {aka ‘struct png_color_struct **’}
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c:476:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&alpha);
<         ^~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘png_byte **’ {aka ‘unsigned char **’}
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c:477:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&pbuf);
<         ^~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘uint8_t **’ {aka ‘unsigned char **’}
<  void freep(void **arg);
<             ~~~~~~~^~~
1249,1281d781
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:123:19: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<              freep(&str);
<                    ^~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:130:10: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<     freep(&rect->data0);
<           ^~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:131:10: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<     freep(&rect->data1);
<           ^~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c: In function ‘write_cc_subtitle_as_srt’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:162:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&lsub);
<          ^~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct cc_subtitle **’
<  void freep(void **arg);
<             ~~~~~~~^~~
1339,1371d838
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:120:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&str);
<          ^~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:124:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&rect->data0);
<          ^~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:125:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&rect->data1);
<          ^~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c: In function ‘write_cc_subtitle_as_ssa’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:154:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&lsub);
<          ^~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct cc_subtitle **’
<  void freep(void **arg);
<             ~~~~~~~^~~
1429,1438d895
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_transcript.c: In function ‘write_cc_subtitle_as_transcript’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_transcript.c:230:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&lsub);
<          ^~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_helpers.h:4,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_transcript.c:9:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct cc_subtitle **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_transcript.c: In function ‘write_cc_bitmap_as_transcript’:
1451,1483d907
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:303:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&str);
<          ^~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:307:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&rect->data0);
<          ^~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:308:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&rect->data1);
<          ^~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c: In function ‘write_cc_subtitle_as_webvtt’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:337:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&lsub);
<          ^~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct cc_subtitle **’
<  void freep(void **arg);
<             ~~~~~~~^~~
1555,1564d978
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_gxf.c: In function ‘ccx_gxf_delete’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_gxf.c:1732:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx->cdp);
<         ^~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_gxf.h:5,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_gxf.c:13:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
1601,1620d1014
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/dvb_subtitle_decoder.c: In function ‘dvbsub_close_decoder’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/dvb_subtitle_decoder.c:542:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx->display_definition);
<         ^~~~~~~~~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/dvb_subtitle_decoder.h:21,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/dvb_subtitle_decoder.c:25:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘DVBSubDisplayDefinition **’ {aka ‘struct DVBSubDisplayDefinition **’}
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/dvb_subtitle_decoder.c: In function ‘dvbsub_parse_region_segment’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/dvb_subtitle_decoder.c:1281:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&region->pbuf);
<          ^~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/dvb_subtitle_decoder.h:21,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/dvb_subtitle_decoder.c:25:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘uint8_t **’ {aka ‘unsigned char **’}
<  void freep(void **arg);
<             ~~~~~~~^~~
1671,1801d1064
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c: In function ‘dinit_decoder_setting’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:41:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(setting);
<         ^~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct ccx_decoders_common_settings_t **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c: In function ‘dinit_libraries’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:242:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&lctx->freport.data_from_608);
<         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct ccx_decoder_608_report **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:243:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&lctx->freport.data_from_708);
<         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct ccx_decoder_dtvcc_report **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:246:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ccx_options.enc_cfg.output_filename);
<         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:247:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&lctx->basefilename);
<         ^~~~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:248:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&lctx->pesheaderbuf);
<         ^~~~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:250:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&lctx->inputfile[i]);
<          ^~~~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:251:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&lctx->inputfile);
<         ^~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char ***’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:252:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(ctx);
<         ^~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct lib_ccx_ctx **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c: In function ‘update_encoder_list_cinfo’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:386:10: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<     freep(&ccx_options.enc_cfg.output_filename);
<           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:411:10: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<     freep(&extension);
<           ^~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:419:10: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<     freep(&extension);
<           ^~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:420:10: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<     freep(&ccx_options.enc_cfg.output_filename);
<           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:425:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&extension);
<          ^~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:426:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&ccx_options.enc_cfg.output_filename);
<          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:433:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&extension);
<         ^~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
1995,2093d1257
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c: In function ‘ocr_bitmap’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:594:11: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<      freep(&histogram);
<            ^~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘uint32_t **’ {aka ‘unsigned int **’}
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:595:11: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<      freep(&mcit);
<            ^~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘uint32_t **’ {aka ‘unsigned int **’}
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:596:11: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<      freep(&iot);
<            ^~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘uint8_t **’ {aka ‘unsigned char **’}
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c: In function ‘quantize_map’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:843:13: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   end: freep(&histogram);
<              ^~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘uint32_t **’ {aka ‘unsigned int **’}
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:844:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&mcit);
<         ^~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘uint32_t **’ {aka ‘unsigned int **’}
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:845:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&iot);
<         ^~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘uint8_t **’ {aka ‘unsigned char **’}
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c: In function ‘ocr_rect’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:921:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&palette);
<         ^~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘png_color **’ {aka ‘struct png_color_struct **’}
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:922:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&alpha);
<         ^~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘png_byte **’ {aka ‘unsigned char **’}
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:923:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&copy->palette);
<         ^~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘png_color **’ {aka ‘struct png_color_struct **’}
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:924:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&copy->alpha);
<         ^~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘png_byte **’ {aka ‘unsigned char **’}
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:925:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&copy->data);
<         ^~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:926:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&copy);
<         ^~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct image_copy **’
<  void freep(void **arg);
<             ~~~~~~~^~~
2095,2111d1258
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/output.c: In function ‘dinit_write’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/output.c:17:15: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<          freep(&wb->filename);
<                ^~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/output.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/output.c:20:15: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<          freep(&wb->semaphore_filename);
<                ^~~~~~~~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/output.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
2146,2153d1292
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/params_dump.c:420:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx->freport.data_from_608);
<         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/params_dump.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct ccx_decoder_608_report **’
<  void freep(void **arg);
<             ~~~~~~~^~~
2161,2177d1299
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/telxcc.c: In function ‘telxcc_close’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/telxcc.c:1616:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ttext->ucs2_buffer_cur);
<         ^~~~~~~~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/telxcc.c:31:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘uint64_t **’ {aka ‘long unsigned int **’}
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/telxcc.c:1617:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ttext->page_buffer_cur);
<         ^~~~~~~~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/telxcc.c:31:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
2195,2203d1316
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ts_functions.c: In function ‘cinfo_cremation’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ts_functions.c:593:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&iter->capbuf);
<          ^~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ts_functions.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
2211,2227d1323
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ts_functions.c: In function ‘get_video_min_pts’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ts_functions.c:736:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&ctx);
<         ^~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ts_functions.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct ccx_demuxer **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ts_functions.c:737:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&pts_array);
<         ^~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ts_functions.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘uint64_t **’ {aka ‘long unsigned int **’}
<  void freep(void **arg);
<             ~~~~~~~^~~
2229,2236d1324
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ts_functions.c:961:11: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<      freep(&cinfo->capbuf);
<            ^~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ts_functions.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
2241,2248d1328
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ts_info.c: In function ‘dinit_cap’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ts_info.c:271:9: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<    freep(&iter->capbuf);
<          ^~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ts_info.c:2:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘unsigned char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
2251,2267d1330
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ts_tables_epg.c: In function ‘EPG_output’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ts_tables_epg.c:306:16: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<           freep(&filename);
<                 ^~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ts_tables_epg.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ts_tables_epg.c:309:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&filename);
<         ^~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ts_tables_epg.c:1:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘char **’
<  void freep(void **arg);
<             ~~~~~~~^~~
2386,2394d1448
< /home/nils/Documents/codein2019/ccextractor/src/gpacmp4/mp4.c: In function ‘processmp4’:
< /home/nils/Documents/codein2019/ccextractor/src/gpacmp4/mp4.c:691:8: warning: passing argument 1 of ‘freep’ from incompatible pointer type [-Wincompatible-pointer-types]
<   freep(&dec_ctx->xds_ctx);
<         ^~~~~~~~~~~~~~~~~
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/lib_ccx.h:9,
<                  from /home/nils/Documents/codein2019/ccextractor/src/gpacmp4/mp4.c:6:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.h:45:19: note: expected ‘void **’ but argument is of type ‘struct ccx_decoders_xds_context **’
<  void freep(void **arg);
<             ~~~~~~~^~~
2397,2398d1450
<   static struct cc_subtitle last_sub;
<                             ^~~~~~~~
2512d1563
< Scanning dependencies of target ccextractor
```