### PR TITLE
[FIX] Add FT_Done_Face to destroy face objects after they're used

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -19,6 +19,7 @@
 - Fix: Added italics, underline, and color rendering support for -out=spupng with EIA608/teletext
 - Fix: Change inet_ntop to inet_ntoa for Windows XP compatibility
 - FIX: Added an option to disable timestamps for WebVTT (In response to issue #1127)
+- FIX: Add FT_Done_Face to destroy face objects after they're used
 
 0.88 (2019-05-21)
 -----------------

--- a/src/lib_ccx/ccx_encoders_spupng.c
+++ b/src/lib_ccx/ccx_encoders_spupng.c
@@ -924,6 +924,8 @@ int spupng_export_string2png(struct spupng_t *sp, char *str, FILE* output)
 	write_image(buffer, output, canvas_width, canvas_height);
 	free(tmp);
 	free(buffer);
+	FT_Done_Face(face_regular);
+	FT_Done_Face(face_italics);
 	return 1;
 }
 


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [X] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [X] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

For large files (>~1 GB), the out=spupng option would stop prematurely because the FT_Face objects used by the spupng_export_string2png() function were never destroyed.
