### PR TITLE
[IMPROVEMENT] Improve and simplify dprintf implementation

### DIFF
--- a/src/lib_ccx/ccx_common_common.h
+++ b/src/lib_ccx/ccx_common_common.h
@@ -41,7 +41,7 @@
 
 // Declarations
 int cc608_parity(unsigned int byte);
-void fdprintf(int fd, const char *fmt, ...);
+int fdprintf(int fd, const char *fmt, ...);
 void millis_to_time(LLONG milli, unsigned *hours, unsigned *minutes,unsigned *seconds, unsigned *ms);
 void freep(void *arg);
 void dbg_print(LLONG mask, const char *fmt, ...);


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [X] I have used CCExtractor just a couple of times.

---

It now returns a value like the rest of the printf family. It doesn't
brute force the amount of memory that needs to be allocated.

It also removes a warning.

```patch
0a1
> Scanning dependencies of target ccx
60,63d60
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.c: In function ‘fdprintf’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.c:27:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    27 |    write(fd, p, n);
<       |    ^~~~~~~~~~~~~~~
69c66
<     inlined from ‘add_cc_sub_text’ at /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.c:95:3:
---
>     inlined from ‘add_cc_sub_text’ at /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_common_common.c:73:3:

```

I do not believe there should be any performance concerns with this
implementation as it is what `glibc` does (if anything it probably improves performance by a lot):

https://code.woboq.org/userspace/glibc/libio/iovdprintf.c.html
