### PR TITLE
[IMPROVEMENT] Remove warnings

### DIFF
--- a/src/lib_ccx/ccx_encoders_helpers.c
+++ b/src/lib_ccx/ccx_encoders_helpers.c
@@ -84,17 +84,17 @@ int string_cmp(const void *p1, const void *p2)
 	return string_cmp_function(p1, p2, NULL);
 }
 
-void capitalize_word(size_t index, char *word)
+void capitalize_word(size_t index, unsigned char *word)
 {
 	memcpy(word, capitalization_list.words[index], strlen(capitalization_list.words[index]));
 }
 
-void censor_word(size_t index, char *word)
+void censor_word(size_t index, unsigned char *word)
 {
 	memset(word, 0x98, strlen(profane.words[index])); // 0x98 is the asterisk in EIA-608
 }
 
-void call_function_if_match(int line_num, struct eia608_screen *data, struct word_list *list, void (*modification)(size_t, char *))
+void call_function_if_match(int line_num, struct eia608_screen *data, struct word_list *list, void (*modification)(size_t, unsigned char *))
 {
 	char delim[64] = {
 		' ', '\n', '\r', 0x89, 0x99,

--- a/src/lib_ccx/ccx_encoders_splitbysentence.c
+++ b/src/lib_ccx/ccx_encoders_splitbysentence.c
@@ -24,7 +24,7 @@
 #ifdef DEBUG_SBS
 #define LOG_DEBUG(...) fprintf(stdout, __VA_ARGS__)
 #else
-#define LOG_DEBUG ;
+#define LOG_DEBUG(...)
 #endif
 
 #ifdef ENABLE_SHARING


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [X] I have used CCExtractor just a couple of times.

---

Removes the following warnings:

```patch
0a1
> Scanning dependencies of target ccx
201,206d201
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_helpers.c:119:66: warning: pointer targets in passing argument 2 of ‘modification’ differ in signedness [-Wpointer-sign]
<   119 |     modification(index - list->words, data->characters[line_num] + (c - line));
<       |                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
<       |                                                                  |
<       |                                                                  unsigned char *
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_helpers.c:119:66: note: expected ‘char *’ but argument is of type ‘unsigned char *’
300,328d294
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c: In function ‘sbs_init_context’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:75:2: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<    75 | ",
<       |  ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:73:11: warning: statement with no effect [-Wunused-value]
<    73 |  LOG_DEBUG("SBS: init_sbs_context\n\
<       |           ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:81:12: warning: statement with no effect [-Wunused-value]
<    81 |   LOG_DEBUG("SBS: init_sbs_context: INIT\n");
<       |            ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:94:2: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<    94 | ",
<       |  ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:92:11: warning: statement with no effect [-Wunused-value]
<    92 |  LOG_DEBUG("SBS: init_sbs_context: DONE\n\
<       |           ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c: In function ‘sbs_str_autofix’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:108:2: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   108 | ",
<       |  ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:106:11: warning: statement with no effect [-Wunused-value]
<   106 |  LOG_DEBUG("SBS: sbs_str_autofix\n\
<       |           ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:161:2: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   161 | ",
<       |  ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:159:11: warning: statement with no effect [-Wunused-value]
<   159 |  LOG_DEBUG("SBS: sbs_str_autofix\n\
<       |           ^
386,397d351
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:385:2: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   385 | ",
<       |  ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:386:18: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   386 |   context->buffer,
<       |                  ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:387:18: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   387 |   context->buffer,
<       |                  ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:382:11: warning: statement with no effect [-Wunused-value]
<   382 |  LOG_DEBUG("SBS: sbs_strcpy_without_dup: going to append, looking for common part\n\
<       |           ^
417,496d370
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:400:2: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   400 | ",
<       |  ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:401:18: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   401 |   context->buffer,
<       |                  ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:402:6: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   402 |   str,
<       |      ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:403:22: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   403 |   buffer_insert_point,
<       |                      ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:404:16: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   404 |   intersect_len,
<       |                ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:405:10: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   405 |   sbs_len,
<       |          ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:405:10: warning: statement with no effect [-Wunused-value]
<   393 |  LOG_DEBUG("SBS: sbs_strcpy_without_dup: analyze search results\n\
<       |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<   394 | \t buffer:         [%s]\n\
<       | ~~~~~~~~~~~~~~~~~~~~~~~~~~
<   395 | \t string:         [%s]\n\
<       | ~~~~~~~~~~~~~~~~~~~~~~~~~~
<   396 | \t insert point: ->[%s]\n\
<       | ~~~~~~~~~~~~~~~~~~~~~~~~~~
<   397 | \t intersection len[%4d]\n\
<       | ~~~~~~~~~~~~~~~~~~~~~~~~~~~
<   398 | \t sbslen          [%4ld]\n\
<       | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<   399 | \t handled len     [%4zu]\n\
<       | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<   400 | ",
<       | ~~        
<   401 |   context->buffer,
<       |   ~~~~~~~~~~~~~~~~
<   402 |   str,
<       |   ~~~~    
<   403 |   buffer_insert_point,
<       |   ~~~~~~~~~~~~~~~~~~~~
<   404 |   intersect_len,
<       |   ~~~~~~~~~~~~~~
<   405 |   sbs_len,
<       |   ~~~~~~~^
<   406 |   context->handled_len
<       |   ~~~~~~~~~~~~~~~~~~~~
<   407 |  );
<       |  ~        
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:418:12: warning: statement with no effect [-Wunused-value]
<   418 |   LOG_DEBUG("SBS: sbs_strcpy_without_dup: cut buffer by insert point\n");
<       |            ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:432:2: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   432 | ",
<       |  ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:433:19: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   433 |    context->buffer,
<       |                   ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:434:24: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   434 |    context->handled_len,
<       |                        ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:434:24: warning: statement with no effect [-Wunused-value]
<   428 |   LOG_DEBUG("SBS: sbs_strcpy_without_dup: DROP parsed part\n\
<       |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<   429 | \t buffer:         [%s]\n\
<       | ~~~~~~~~~~~~~~~~~~~~~~~~~~
<   430 | \t handled len     [%4zu]\n\
<       | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<   431 | \t new start at  ->[%s]\n\
<       | ~~~~~~~~~~~~~~~~~~~~~~~~~~
<   432 | ",
<       | ~~                      
<   433 |    context->buffer,
<       |    ~~~~~~~~~~~~~~~~     
<   434 |    context->handled_len,
<       |    ~~~~~~~~~~~~~~~~~~~~^
<   435 |    context->buffer + context->handled_len
<       |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<   436 |   );
<       |   ~                     
573,604d446
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:499:2: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   499 | ",
<       |  ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:497:11: warning: statement with no effect [-Wunused-value]
<   497 |  LOG_DEBUG("SBS: sbs_append_string: after sbs init:\n\
<       |           ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:506:2: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   506 | ",
<       |  ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:507:18: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   507 |   context->buffer,
<       |                  ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:508:18: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   508 |   context->buffer,
<       |                  ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:508:18: warning: statement with no effect [-Wunused-value]
<   503 |  LOG_DEBUG("SBS: sbs_append_string: after sbs init:\n\
<       |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<   504 | \tsbs ptr:   [%p][%s]\n\
<       | ~~~~~~~~~~~~~~~~~~~~~~~~
<   505 | \tcur cap:   [%zu]\n\
<       | ~~~~~~~~~~~~~~~~~~~~~
<   506 | ",
<       | ~~                
<   507 |   context->buffer,
<       |   ~~~~~~~~~~~~~~~~
<   508 |   context->buffer,
<       |   ~~~~~~~~~~~~~~~^
<   509 |   context->capacity
<       |   ~~~~~~~~~~~~~~~~~
<   510 |  );
<       |  ~                
625,683d466
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:530:2: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   530 | ",
<       |  ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:531:19: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   531 |    context->buffer,
<       |                   ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:532:21: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   532 |    context->capacity,
<       |                     ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:526:12: warning: statement with no effect [-Wunused-value]
<   526 |   LOG_DEBUG("SBS: sbs_append_string: REALLOC BUF:\n\
<       |            ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:563:2: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   563 | ",
<       |  ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:564:19: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   564 |    context->buffer,
<       |                   ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:565:21: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   565 |    context->capacity,
<       |                     ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:566:21: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   566 |    required_capacity,
<       |                     ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:566:21: warning: statement with no effect [-Wunused-value]
<   558 |   LOG_DEBUG("SBS: sbs_append_string: REALLOC BUF DONE:\n\
<       |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<   559 | \tsbs ptr:   {%p}\n\
<       | ~~~~~~~~~~~~~~~~~~~~ 
<   560 | \tcur cap:   [%zu]\n\
<       | ~~~~~~~~~~~~~~~~~~~~~
<   561 | \treq cap:   [%d]\n\
<       | ~~~~~~~~~~~~~~~~~~~~ 
<   562 | \tbuf:       [%s]\n\
<       | ~~~~~~~~~~~~~~~~~~~~ 
<   563 | ",
<       | ~~                   
<   564 |    context->buffer,
<       |    ~~~~~~~~~~~~~~~~  
<   565 |    context->capacity,
<       |    ~~~~~~~~~~~~~~~~~~
<   566 |    required_capacity,
<       |    ~~~~~~~~~~~~~~~~~^
<   567 |    context->buffer
<       |    ~~~~~~~~~~~~~~~   
<   568 |   );
<       |   ~                  
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:597:2: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   597 | ",
<       |  ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:598:16: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   598 |   bp_last_break,
<       |                ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:599:23: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   599 |   context->handled_len,
<       |                       ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:593:11: warning: statement with no effect [-Wunused-value]
<   593 |  LOG_DEBUG("SBS: BEFORE sentence break.\n\
<       |           ^
710,751d492
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:679:4: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   679 | \n",
<       |    ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:680:23: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   680 |   context->handled_len,
<       |                       ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:681:17: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   681 |   alphanum_total,
<       |                 ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:682:16: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   682 |   anychar_total,
<       |                ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:683:6: warning: left-hand operand of comma expression has no effect [-Wunused-value]
<   683 |   str,
<       |      ^
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:683:6: warning: statement with no effect [-Wunused-value]
<   673 |  LOG_DEBUG("SBS: AFTER sentence break:\
<       |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<   674 | \n\tHandled Len    [%4zu]\
<       | ~~~~~~~~~~~~~~~~~~~~~~~~~~
<   675 | \n\tAlphanum Total [%4ld]\
<       | ~~~~~~~~~~~~~~~~~~~~~~~~~~
<   676 | \n\tOverall chars  [%4ld]\
<       | ~~~~~~~~~~~~~~~~~~~~~~~~~~
<   677 | \n\tSTRING:[%s]\
<       | ~~~~~~~~~~~~~~~~
<   678 | \n\tBUFFER:[%s]\
<       | ~~~~~~~~~~~~~~~~
<   679 | \n",
<       | ~~~~  
<   680 |   context->handled_len,
<       |   ~~~~~~~~~~~~~~~~~~~~~
<   681 |   alphanum_total,
<       |   ~~~~~~~~~~~~~~~
<   682 |   anychar_total,
<       |   ~~~~~~~~~~~~~~
<   683 |   str,
<       |   ~~~^
<   684 |   context->buffer
<       |   ~~~~~~~~~~~~~~~
<   685 |  );
<       |  ~    
762,764d502
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:769:12: warning: statement with no effect [-Wunused-value]
<   769 |   LOG_DEBUG("SBS: reformat_cc_bitmap: string is not empty\n");
<       |            ^
```
