### PR TITLE
[IMPROVEMENT] Remove warning when calling paraof_ocrtext

### DIFF
--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -950,7 +950,7 @@ int compare_rect_by_ypos(const void*p1, const void *p2, void*arg)
 	return -1;
 }
 
-void add_ocrtext2str(char *dest, char *src, const char *crlf, unsigned crlf_length)
+void add_ocrtext2str(char *dest, char *src, const unsigned char *crlf, unsigned crlf_length)
 {
 	char *line_scan;
 	int char_found;
@@ -996,7 +996,7 @@ void add_ocrtext2str(char *dest, char *src, const char *crlf, unsigned crlf_leng
  * for all text detected from rectangles
  */
 
-char *paraof_ocrtext(struct cc_subtitle *sub, const char *crlf, unsigned crlf_length)
+char *paraof_ocrtext(struct cc_subtitle *sub, const unsigned char *crlf, unsigned crlf_length)
 {
 	int i;
 	int len = 0;

--- a/src/lib_ccx/ocr.h
+++ b/src/lib_ccx/ocr.h
@@ -16,6 +16,6 @@ char* probe_tessdata_location_string(char* lang);
 void* init_ocr(int lang_index);
 char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* indata,int w, int h, struct image_copy *copy);
 int ocr_rect(void* arg, struct cc_bitmap *rect, char **str, int bgcolor, int ocr_quantmode);
-char *paraof_ocrtext(struct cc_subtitle *sub, const char *crlf, unsigned crlf_length);
+char *paraof_ocrtext(struct cc_subtitle *sub, const unsigned char *crlf, unsigned crlf_length);
 
 #endif


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [X] I have used CCExtractor just a couple of times.

---

Removes warnings:

```patch
0a1
> Scanning dependencies of target ccx
550,558d550
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:765:35: warning: pointer targets in passing argument 2 of ‘paraof_ocrtext’ differ in signedness [-Wpointer-sign]
<   765 |  str = paraof_ocrtext(sub, context->encoded_crlf, context->encoded_crlf_length);
<       |                            ~~~~~~~^~~~~~~~~~~~~~
<       |                                   |
<       |                                   unsigned char *
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_splitbysentence.c:18:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.h:19:7: note: expected ‘const char *’ but argument is of type ‘unsigned char *’
<    19 | char *paraof_ocrtext(struct cc_subtitle *sub, const char *crlf, unsigned crlf_length);
<       |       ^~~~~~~~~~~~~~
571,580d562
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c: In function ‘write_cc_bitmap_as_spupng’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c:452:36: warning: pointer targets in passing argument 2 of ‘paraof_ocrtext’ differ in signedness [-Wpointer-sign]
<   452 |   str = paraof_ocrtext(sub, context->encoded_crlf, context->encoded_crlf_length);
<       |                             ~~~~~~~^~~~~~~~~~~~~~
<       |                                    |
<       |                                    unsigned char *
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_spupng.c:12:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.h:19:7: note: expected ‘const char *’ but argument is of type ‘unsigned char *’
<    19 | char *paraof_ocrtext(struct cc_subtitle *sub, const char *crlf, unsigned crlf_length);
<       |       ^~~~~~~~~~~~~~
620,629d601
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c: In function ‘write_cc_bitmap_as_srt’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:100:35: warning: pointer targets in passing argument 2 of ‘paraof_ocrtext’ differ in signedness [-Wpointer-sign]
<   100 |  str = paraof_ocrtext(sub, context->encoded_crlf, context->encoded_crlf_length);
<       |                            ~~~~~~~^~~~~~~~~~~~~~
<       |                                   |
<       |                                   unsigned char *
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:6:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.h:19:7: note: expected ‘const char *’ but argument is of type ‘unsigned char *’
<    19 | char *paraof_ocrtext(struct cc_subtitle *sub, const char *crlf, unsigned crlf_length);
<       |       ^~~~~~~~~~~~~~
679,688d650
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c: In function ‘write_cc_bitmap_as_ssa’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:94:35: warning: pointer targets in passing argument 2 of ‘paraof_ocrtext’ differ in signedness [-Wpointer-sign]
<    94 |  str = paraof_ocrtext(sub, context->encoded_crlf, context->encoded_crlf_length);
<       |                            ~~~~~~~^~~~~~~~~~~~~~
<       |                                   |
<       |                                   unsigned char *
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:6:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.h:19:7: note: expected ‘const char *’ but argument is of type ‘unsigned char *’
<    19 | char *paraof_ocrtext(struct cc_subtitle *sub, const char *crlf, unsigned crlf_length);
<       |       ^~~~~~~~~~~~~~
730,738d691
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_transcript.c:35:39: warning: pointer targets in passing argument 2 of ‘paraof_ocrtext’ differ in signedness [-Wpointer-sign]
<    35 |    token = paraof_ocrtext(sub, context->encoded_crlf, context->encoded_crlf_length);
<       |                                ~~~~~~~^~~~~~~~~~~~~~
<       |                                       |
<       |                                       unsigned char *
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_transcript.c:4:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.h:19:7: note: expected ‘const char *’ but argument is of type ‘unsigned char *’
<    19 | char *paraof_ocrtext(struct cc_subtitle *sub, const char *crlf, unsigned crlf_length);
<       |       ^~~~~~~~~~~~~~
754,763d706
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c: In function ‘write_cc_bitmap_as_webvtt’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:287:35: warning: pointer targets in passing argument 2 of ‘paraof_ocrtext’ differ in signedness [-Wpointer-sign]
<   287 |  str = paraof_ocrtext(sub, context->encoded_crlf, context->encoded_crlf_length);
<       |                            ~~~~~~~^~~~~~~~~~~~~~
<       |                                   |
<       |                                   unsigned char *
< In file included from /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:6:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ocr.h:19:7: note: expected ‘const char *’ but argument is of type ‘unsigned char *’
<    19 | char *paraof_ocrtext(struct cc_subtitle *sub, const char *crlf, unsigned crlf_length);
<       |       ^~~~~~~~~~~~~~
```
