### PR TITLE
[FIX] segfault on windows

### DIFF
--- a/src/lib_ccx/ccx_decoders_structs.h
+++ b/src/lib_ccx/ccx_decoders_structs.h
@@ -85,8 +85,8 @@ struct eia608_screen // A CC buffer
 	/** format of data inside this structure */
 	enum ccx_eia608_format format;
 	unsigned char characters[15][33];
-	enum ccx_decoder_608_color_code colors[15][33];
-	enum font_bits fonts[15][33]; // Extra char at the end for a 0
+	unsigned char colors[15][33];
+	unsigned char fonts[15][33]; // Extra char at the end for a 0
 	int row_used[15];            // Any data in row?
 	int empty;                   // Buffer completely empty?
 	/** start time of this CC buffer */

--- a/src/lib_ccx/ccx_encoders_helpers.c
+++ b/src/lib_ccx/ccx_encoders_helpers.c
@@ -220,7 +220,7 @@ int clever_capitalize(struct encoder_ctx *context, int line_num, struct eia608_s
 // Encodes a generic string. Note that since we use the encoders for closed caption
 // data, text would have to be encoded as CCs... so using special characters here
 // is a bad idea.
-unsigned encode_line(struct encoder_ctx *ctx, unsigned char *buffer, unsigned char *text)
+unsigned encode_line(struct encoder_ctx *ctx, unsigned char *buffer, const unsigned char *text)
 {
 	unsigned bytes = 0;
 	while (*text)
@@ -295,7 +295,7 @@ unsigned char *close_tag(struct encoder_ctx *ctx, unsigned char *buffer, char *t
 
 unsigned get_decoder_line_encoded(struct encoder_ctx *ctx, unsigned char *buffer, int line_num, struct eia608_screen *data)
 {
-	enum ccx_decoder_608_color_code color = COL_WHITE;
+	unsigned char color = COL_WHITE;
 	int underlined = 0;
 	int italics = 0;
 	int changed_font = 0;
@@ -309,7 +309,7 @@ unsigned get_decoder_line_encoded(struct encoder_ctx *ctx, unsigned char *buffer
 	for (int i = first; i <= last; i++)
 	{
 		// Handle color
-		enum ccx_decoder_608_color_code its_color = data->colors[line_num][i];
+		unsigned char its_color = data->colors[line_num][i];
 		// Check if the colour has changed
 		if (its_color != color && !ctx->no_font_color &&
 			!(color == COL_USERDEFINED && its_color == COL_WHITE)) // Don't replace user defined with white

--- a/src/lib_ccx/ccx_encoders_helpers.h
+++ b/src/lib_ccx/ccx_encoders_helpers.h
@@ -38,7 +38,7 @@ int add_word(struct word_list *list, const char *word);
 int add_builtin_words(const char *builtin[], struct word_list *list);
 void correct_spelling_and_censor_words_608(struct encoder_ctx *context, int line_number, struct eia608_screen *data);
 
-unsigned encode_line (struct encoder_ctx *ctx, unsigned char *buffer, unsigned char *text);
+unsigned encode_line(struct encoder_ctx *ctx, unsigned char *buffer, const unsigned char *text);
 
 void shell_sort(void *base, int nb, size_t size, int(*compar)(const void*p1, const void *p2, void*arg), void *arg);
 


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [X] I am an active contributor to CCExtractor.

---

Fixes seg fault on windows. Unfortunately we loose a bit of semantics :( with the enum.

This is more acceptable as it reverts some stuff from the SCC & CCD PR.