### PR TITLE
[FIX] EIA-608 screen clearing fix

### DIFF
--- a/src/lib_ccx/ccx_decoders_608.c
+++ b/src/lib_ccx/ccx_decoders_608.c
@@ -104,7 +104,7 @@ const char *color_text[MAX_COLOR][2]=
 
 void clear_eia608_cc_buffer(ccx_decoder_608_context *context, struct eia608_screen *data)
 {
-	for (int i = 0;i<15;i++)
+	for (int i = 0;i<CCX_DECODER_608_SCREEN_ROWS;i++)
 	{
 		memset(data->characters[i], ' ', CCX_DECODER_608_SCREEN_WIDTH);
 		data->characters[i][CCX_DECODER_608_SCREEN_WIDTH] = 0;
@@ -379,7 +379,7 @@ int write_cc_line(ccx_decoder_608_context *context, struct cc_subtitle *sub)
 		sub->datatype = CC_DATATYPE_GENERIC;
 		sub->nb_data++;
 
-		for(i = 0; i < 15; i++)
+		for(i = 0; i < CCX_DECODER_608_SCREEN_ROWS; i++)
 		{
 			if(i == context->cursor_row)
 				data->row_used[i] = 1;
@@ -446,7 +446,7 @@ int check_roll_up(ccx_decoder_608_context *context)
 	if (use_buffer->row_used[0]) // If top line is used it will go off the screen no matter what
 		return 1;
 	int rows_orig=0; // Number of rows in use right now
-	for (int i=0;i<15;i++)
+	for (int i=0;i<CCX_DECODER_608_SCREEN_ROWS;i++)
 	{
 		if (use_buffer->row_used[i])
 		{
@@ -500,7 +500,7 @@ int roll_up(ccx_decoder_608_context *context)
 	int firstrow=-1, lastrow=-1;
 	// Look for the last line used
 	int rows_orig=0; // Number of rows in use right now
-	for (int i=0;i<15;i++)
+	for (int i=0;i<CCX_DECODER_608_SCREEN_ROWS;i++)
 	{
 		if (use_buffer->row_used[i])
 		{
@@ -543,7 +543,7 @@ int roll_up(ccx_decoder_608_context *context)
 
 	// Sanity check
 	int rows_now=0;
-	for (int i=0;i<15;i++)
+	for (int i=0;i<CCX_DECODER_608_SCREEN_ROWS;i++)
 		if (use_buffer->row_used[i])
 			rows_now++;
 	if (rows_now>keep_lines)
@@ -732,7 +732,7 @@ void handle_command(unsigned char c1, const unsigned char c2, ccx_decoder_608_co
 			if (context->mode == MODE_POPON) // CFS: Not sure about this. Is there a valid reason for CR in popup?
 			{
 				context->cursor_column = 0;
-				if (context->cursor_row<15)
+				if (context->cursor_row<CCX_DECODER_608_SCREEN_ROWS)
 					context->cursor_row++;
 				break;
 			}
@@ -939,7 +939,7 @@ void handle_pac(unsigned char c1, unsigned char c2, ccx_decoder_608_context *con
 		   buffer around instead) but it's better than leaving old characters in the buffer */
 		struct eia608_screen *use_buffer = get_writing_buffer(context); // &wb->data608->buffer1;
 
-		for (int j=row;j<15;j++)
+		for (int j=row;j<CCX_DECODER_608_SCREEN_ROWS;j++)
 		{
 			if (use_buffer->row_used[j])
 			{

--- a/src/lib_ccx/ccx_decoders_608.c
+++ b/src/lib_ccx/ccx_decoders_608.c
@@ -108,8 +108,13 @@ void clear_eia608_cc_buffer(ccx_decoder_608_context *context, struct eia608_scre
 	{
 		memset(data->characters[i], ' ', CCX_DECODER_608_SCREEN_WIDTH);
 		data->characters[i][CCX_DECODER_608_SCREEN_WIDTH] = 0;
-		memset(data->colors[i], context->settings->default_color, CCX_DECODER_608_SCREEN_WIDTH + 1);
-		memset(data->fonts[i], FONT_REGULAR, CCX_DECODER_608_SCREEN_WIDTH + 1);
+
+		for (int j = 0; j < CCX_DECODER_608_SCREEN_WIDTH + 1; j++)
+		{
+			data->colors[i][j] = context->settings->default_color;
+			data->fonts[i][j] = FONT_REGULAR;
+		}
+
 		data->row_used[i]=0;
 	}
 	data->empty=1;

--- a/src/lib_ccx/ccx_decoders_structs.h
+++ b/src/lib_ccx/ccx_decoders_structs.h
@@ -84,9 +84,9 @@ struct eia608_screen // A CC buffer
 {
 	/** format of data inside this structure */
 	enum ccx_eia608_format format;
-	unsigned char characters[15][33];
-	enum ccx_decoder_608_color_code colors[15][33];
-	enum font_bits fonts[15][33]; // Extra char at the end for a 0
+	unsigned char characters[15][CCX_DECODER_608_SCREEN_WIDTH + 1];
+	enum ccx_decoder_608_color_code colors[15][CCX_DECODER_608_SCREEN_WIDTH + 1];
+	enum font_bits fonts[15][CCX_DECODER_608_SCREEN_WIDTH + 1]; // Extra char at the end for a 0
 	int row_used[15];            // Any data in row?
 	int empty;                   // Buffer completely empty?
 	/** start time of this CC buffer */

--- a/src/lib_ccx/ccx_decoders_structs.h
+++ b/src/lib_ccx/ccx_decoders_structs.h
@@ -8,6 +8,7 @@
 #include "list.h"
 #include "ccx_decoders_708.h"
 // Define max width in characters/columns on the screen
+#define CCX_DECODER_608_SCREEN_ROWS 15
 #define CCX_DECODER_608_SCREEN_WIDTH 32
 #define MAXBFRAMES 50
 #define SORTBUF (2*MAXBFRAMES+1)
@@ -84,10 +85,10 @@ struct eia608_screen // A CC buffer
 {
 	/** format of data inside this structure */
 	enum ccx_eia608_format format;
-	unsigned char characters[15][CCX_DECODER_608_SCREEN_WIDTH + 1];
-	enum ccx_decoder_608_color_code colors[15][CCX_DECODER_608_SCREEN_WIDTH + 1];
-	enum font_bits fonts[15][CCX_DECODER_608_SCREEN_WIDTH + 1]; // Extra char at the end for a 0
-	int row_used[15];            // Any data in row?
+	unsigned char characters[CCX_DECODER_608_SCREEN_ROWS][CCX_DECODER_608_SCREEN_WIDTH + 1];
+	enum ccx_decoder_608_color_code colors[CCX_DECODER_608_SCREEN_ROWS][CCX_DECODER_608_SCREEN_WIDTH + 1];
+	enum font_bits fonts[CCX_DECODER_608_SCREEN_ROWS][CCX_DECODER_608_SCREEN_WIDTH + 1]; // Extra char at the end for a 0
+	int row_used[CCX_DECODER_608_SCREEN_ROWS];            // Any data in row?
 	int empty;                   // Buffer completely empty?
 	/** start time of this CC buffer */
 	LLONG start_time;


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [x] I have used CCExtractor just a couple of times.

---

This adds a constant with the maximum number of screen rows and replaces hard-coded occurrences of it with the new constant, as hard-coding array lengths everywhere is unclear and prone to breakage. The array lengths in the screen struct were also replaced with constants where applicable.

The cleanup directly ties in with the fix in question, which is to initialize the colora nd font arrays properly using a loop rather than `memset`. The commit message goes into more detail regarding this issue.

GCC 9.2.0 issues a warning here:
```
src/lib_ccx/ccx_decoders_608.c: In function ‘clear_eia608_cc_buffer’:
src/lib_ccx/ccx_decoders_608.c:111:3: warning: ‘memset’ used with length equal to number of elements without multiplication by element size [-Wmemset-elt-size]
  111 |   memset(data->colors[i], context->settings->default_color, CCX_DECODER_608_SCREEN_WIDTH + 1);
      |   ^~~~~~
src/lib_ccx/ccx_decoders_608.c:112:3: warning: ‘memset’ used with length equal to number of elements without multiplication by element size [-Wmemset-elt-size]
  112 |   memset(data->fonts[i], FONT_REGULAR, CCX_DECODER_608_SCREEN_WIDTH + 1);
      |   ^~~~~~
```