### PR TITLE
[FIX] Clang warning fixes

### DIFF
--- a/src/lib_ccx/ccx_common_timing.c
+++ b/src/lib_ccx/ccx_common_timing.c
@@ -1,3 +1,4 @@
+#include "lib_ccx.h"
 #include "ccx_common_timing.h"
 #include "ccx_common_constants.h"
 #include "ccx_common_structs.h"
@@ -272,7 +273,7 @@ LLONG get_fts(struct ccx_common_timing_ctx *ctx, int current_field)
 			fts = ctx->fts_now + ctx->fts_global + cb_708 * 1001 / 30;
 			break;
 		default:
-			ccx_common_logging.fatal_ftn(CCX_COMMON_EXIT_BUG_BUG, "get_fts: unhandled branch");
+			fatal(CCX_COMMON_EXIT_BUG_BUG, "get_fts: unhandled branch");
 	}
 	//	ccx_common_logging.debug_ftn(CCX_DMT_TIME, "[FTS] "
 	//			"fts: %llu, fts_now: %llu, fts_global: %llu, current_field: %llu, cb_708: %llu\n",

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -173,10 +173,10 @@ int change_utf8_encoding(unsigned char *dest, unsigned char *src, int len, enum 
 				{
 					if ((src[1] & 0x40) == 0)
 					{
-						c = utf8_to_latin1_map((((unsigned int)(src[0] & 0x1F)) << 6)
+						int cp = utf8_to_latin1_map((((unsigned int)(src[0] & 0x1F)) << 6)
 							| ((unsigned int)(src[1] & 0x3F)));
-						if (c < 256)
-							*dest++ = c;
+						if (cp < 256)
+							*dest++ = cp;
 						else
 							*dest++ = '?';
 					}
@@ -187,11 +187,11 @@ int change_utf8_encoding(unsigned char *dest, unsigned char *src, int len, enum 
 				{
 					if ((src[1] & 0x40) == 0 && (src[2] & 0x40) == 0)
 					{
-						c = utf8_to_latin1_map((((unsigned int)(src[0] & 0x0F)) << 12)
+						int cp = utf8_to_latin1_map((((unsigned int)(src[0] & 0x0F)) << 12)
 							| (((unsigned int)(src[1] & 0x3F)) << 6)
 							| ((unsigned int)(src[2] & 0x3F)));
-						if (c < 256)
-							*dest++ = c;
+						if (cp < 256)
+							*dest++ = cp;
 						else
 							*dest++ = '?';
 					}
@@ -202,12 +202,12 @@ int change_utf8_encoding(unsigned char *dest, unsigned char *src, int len, enum 
 						(src[2] & 0x40) == 0 &&
 						(src[3] & 0x40) == 0)
 					{
-						c = utf8_to_latin1_map((((unsigned int)(src[0] & 0x07)) << 18)
+						int cp = utf8_to_latin1_map((((unsigned int)(src[0] & 0x07)) << 18)
 							| (((unsigned int)(src[1] & 0x3F)) << 12)
 							| (((unsigned int)(src[2] & 0x3F)) << 6)
 							| ((unsigned int)(src[3] & 0x3F)));
-						if (c < 256)
-							*(dest++) = c;
+						if (cp < 256)
+							*(dest++) = cp;
 						else
 							*dest++ = '?';
 					}
@@ -221,13 +221,13 @@ int change_utf8_encoding(unsigned char *dest, unsigned char *src, int len, enum 
 						(src[3] & 0x40) == 0 &&
 						(src[4] & 0x40) == 0)
 					{
-						c = utf8_to_latin1_map((((unsigned int)(src[0] & 0x03)) << 24U)
+						int cp = utf8_to_latin1_map((((unsigned int)(src[0] & 0x03)) << 24U)
 							| (((unsigned int)(src[1] & 0x3F)) << 18U)
 							| (((unsigned int)(src[2] & 0x3F)) << 12U)
 							| (((unsigned int)(src[3] & 0x3F)) << 6U)
 							| ((unsigned int)(src[4] & 0x3FU)));
-						if (c < 256)
-							*(dest++) = c;
+						if (cp < 256)
+							*(dest++) = cp;
 						else
 							*dest++ = '?';
 					}

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -1154,7 +1154,7 @@ int encode_sub(struct encoder_ctx *context, struct cc_subtitle *sub)
 				}
 
 				for (int i = 0; i < CCX_DECODER_608_SCREEN_ROWS; ++i)
-					correct_spelling_and_censor_words(context, (char *)data->characters[i], CCX_DECODER_608_SCREEN_WIDTH);
+					correct_spelling_and_censor_words(context, data->characters[i], CCX_DECODER_608_SCREEN_WIDTH);
 
 #ifdef PYTHON_API
 				pass_cc_buffer_to_python(data, context);
@@ -1239,7 +1239,7 @@ int encode_sub(struct encoder_ctx *context, struct cc_subtitle *sub)
 				if (rect->ocr_text)
 				{
 					int len = strlen(rect->ocr_text);
-					correct_spelling_and_censor_words(context, rect->ocr_text, len);
+					correct_spelling_and_censor_words(context, (unsigned char *)rect->ocr_text, len);
 					for (int i = 0; i < len; ++i)
 					{
 						if ((unsigned char)rect->ocr_text[i] == 0x98) // asterisk in 608 encoding

--- a/src/lib_ccx/ccx_encoders_helpers.c
+++ b/src/lib_ccx/ccx_encoders_helpers.c
@@ -84,19 +84,19 @@ int string_cmp(const void *p1, const void *p2)
 	return string_cmp_function(p1, p2, NULL);
 }
 
-void capitalize_word(size_t index, char *word)
+void capitalize_word(size_t index, unsigned char *word)
 {
 	memcpy(word, capitalization_list.words[index], strlen(capitalization_list.words[index]));
 }
 
-void censor_word(size_t index, char *word)
+void censor_word(size_t index, unsigned char *word)
 {
 	memset(word, 0x98, strlen(profane.words[index])); // 0x98 is the asterisk in EIA-608
 }
 
-void call_function_if_match(char *line, struct word_list *list, void (*modification)(size_t, char *))
+void call_function_if_match(unsigned char *line, struct word_list *list, void (*modification)(size_t, unsigned char *))
 {
-	char delim[64] = {
+	unsigned char delim[64] = {
 		' ', '\n', '\r', 0x89, 0x99,
 		'!', '"', '#', '%', '&',
 		'\'', '(', ')', ';', '<',
@@ -105,18 +105,18 @@ void call_function_if_match(char *line, struct word_list *list, void (*modificat
 		'.', '/', ':', '^', '_',
 		'{', '|', '}', '~', '\0' };
 
-	char *line_token = strdup(line);
-	char *c = strtok(line_token, delim);
+	unsigned char *line_token = strdup(line);
+	unsigned char *c = strtok(line_token, delim);
 
 	if (c != NULL)
 	{
 		do
 		{
-			char **index = bsearch(&c, list->words, list->len, sizeof(*list->words), string_cmp);
+			unsigned char **index = bsearch(&c, list->words, list->len, sizeof(*list->words), string_cmp);
 
 			if (index)
 			{
-				modification(index - list->words, line + (c - line_token));
+				modification(index - (unsigned char **)list->words, line + (c - line_token));
 			}
 		} while ((c = strtok(NULL, delim)) != NULL);
 	}
@@ -170,7 +170,7 @@ int is_all_caps(struct encoder_ctx *context, int line_num, struct eia608_screen 
 	return (saw_upper && !saw_lower); // 1 if we've seen upper and not lower, 0 otherwise
 }
 
-int clever_capitalize(struct encoder_ctx *context, char *line, unsigned int length)
+int clever_capitalize(struct encoder_ctx *context, unsigned char *line, unsigned int length)
 {
 	// CFS: Tried doing to clever (see below) but some channels do all uppercase except for
 	// notes for deaf people (such as "(narrator)" which messes things up.
@@ -445,7 +445,7 @@ int add_builtin_words(const char *builtin[], struct word_list *list)
 	return 0;
 }
 
-void correct_spelling_and_censor_words(struct encoder_ctx *context, char *line, unsigned int length)
+void correct_spelling_and_censor_words(struct encoder_ctx *context, unsigned char *line, unsigned int length)
 {
 	if (context->sentence_cap)
 	{

--- a/src/lib_ccx/ccx_encoders_helpers.h
+++ b/src/lib_ccx/ccx_encoders_helpers.h
@@ -34,7 +34,7 @@ int string_cmp_function(const void *p1, const void *p2, void *arg);
 int add_word(struct word_list *list, const char *word);
 
 int add_builtin_words(const char *builtin[], struct word_list *list);
-void correct_spelling_and_censor_words(struct encoder_ctx *context, char *line, unsigned int length);
+void correct_spelling_and_censor_words(struct encoder_ctx *context, unsigned char *line, unsigned int length);
 
 unsigned encode_line (struct encoder_ctx *ctx, unsigned char *buffer, unsigned char *text);
 

--- a/src/lib_ccx/ccx_gxf.c
+++ b/src/lib_ccx/ccx_gxf.c
@@ -415,15 +415,13 @@ static int parse_material_sec(struct ccx_demuxer *demux, int len)
 		switch (tag)
 		{
 			case MAT_NAME:
-				result = buffered_read(demux, (unsigned char *)ctx->media_name, MIN(tag_len, STR_LEN));
+				result = buffered_read(demux, (unsigned char *)ctx->media_name, tag_len);
 				demux->past += tag_len;
-				if (result != MIN(tag_len, STR_LEN))
+				if (result != tag_len)
 				{
 					ret = CCX_EOF;
 					goto error;
 				}
-				if (tag_len > STR_LEN)
-					buffered_skip(demux, tag_len - STR_LEN);
 				break;
 			case MAT_FIRST_FIELD:
 				ctx->first_field_nb = buffered_get_be32(demux);
@@ -532,15 +530,13 @@ static int parse_mpeg525_track_desc(struct ccx_demuxer *demux, int len)
 		switch (tag)
 		{
 			case TRACK_NAME:
-				result = buffered_read(demux, (unsigned char *)vid_track->track_name, MIN(tag_len, STR_LEN));
+				result = buffered_read(demux, (unsigned char *)vid_track->track_name, tag_len);
 				demux->past += tag_len;
-				if (result != MIN(tag_len, STR_LEN))
+				if (result != tag_len)
 				{
 					ret = CCX_EOF;
 					goto error;
 				}
-				if (tag_len > STR_LEN)
-					buffered_skip(demux, tag_len - STR_LEN);
 				break;
 			case TRACK_VER:
 				vid_track->fs_version = buffered_get_be32(demux);
@@ -607,15 +603,13 @@ static int parse_ad_track_desc(struct ccx_demuxer *demux, int len)
 		switch (tag)
 		{
 			case TRACK_NAME:
-				result = buffered_read(demux, (unsigned char *)ad_track->track_name, MIN(tag_len, STR_LEN));
+				result = buffered_read(demux, (unsigned char *)ad_track->track_name, tag_len);
 				demux->past += tag_len;
-				if (result != MIN(tag_len, STR_LEN))
+				if (result != tag_len)
 				{
 					ret = CCX_EOF;
 					goto error;
 				}
-				if (tag_len > STR_LEN)
-					buffered_skip(demux, tag_len - STR_LEN);
 				break;
 			case TRACK_AUX:
 				result = buffered_read(demux, (unsigned char *)auxi_info, 8);

--- a/src/lib_ccx/ccx_gxf.c
+++ b/src/lib_ccx/ccx_gxf.c
@@ -1401,8 +1401,8 @@ static int parse_media(struct ccx_demuxer *demux, int len, struct demuxer_data *
 	 * These values shall be sent starting with the ancillary data field from the lowest number video line continuing to
 	 * higher video line numbers. Within each line the ancillary data fields shall not be reordered.
 	 */
-	unsigned char first_field_nb;
-	unsigned char last_field_nb;
+	unsigned char first_field_nb = 0;
+	unsigned char last_field_nb = 0;
 
 	/**
 	 *  see description of set_mpeg_frame_desc for details

--- a/src/lib_ccx/file_buffer.h
+++ b/src/lib_ccx/file_buffer.h
@@ -70,7 +70,7 @@ static size_t inline buffered_read(struct ccx_demuxer *ctx, unsigned char *buffe
  */
 static size_t inline buffered_read_byte(struct ccx_demuxer *ctx, unsigned char *buffer)
 {
-	size_t result;
+	size_t result = 0;
 	if (ctx->bytesinbuffer - ctx->filebuffer_pos)
 	{
 		if (buffer)

--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -1,3 +1,4 @@
+#include <math.h>
 #include "png.h"
 #include "lib_ccx.h"
 #ifdef ENABLE_OCR
@@ -526,7 +527,7 @@ char *ocr_bitmap(void *arg, png_color *palette, png_byte *alpha, unsigned char *
 				else if (max == g_avg) h = 60 * ((b_avg - r_avg) / (max - min)) + 120;
 				else h = 60 * ((r_avg - g_avg) / (max - min)) + 240;
 
-				if (abs(h - h0) > 50) // Color has changed
+				if (fabsf(h - h0) > 50) // Color has changed
 				{
 					// Write <font> tags for SRT and WebVTT
 					if (ccx_options.write_format == CCX_OF_SRT ||

--- a/src/lib_ccx/ocr.h
+++ b/src/lib_ccx/ocr.h
@@ -1,6 +1,7 @@
 #ifndef OCR_H
 #define OCR_H
 #include <png.h>
+#include "ccx_encoders_common.h"
 
 struct image_copy //A copy of the original OCR image, used for color detection
 {

--- a/src/lib_ccx/ts_functions.c
+++ b/src/lib_ccx/ts_functions.c
@@ -120,7 +120,7 @@ void pes_header_dump(uint8_t *buffer, long len)
 		last_pts = pts;
 	}
 }
-enum ccx_stream_type get_buffer_type(struct cap_info *cinfo)
+enum ccx_bufferdata_type get_buffer_type(struct cap_info *cinfo)
 {
 	if (cinfo->stream == CCX_STREAM_TYPE_VIDEO_MPEG2)
 	{

--- a/src/lib_ccx/utility.c
+++ b/src/lib_ccx/utility.c
@@ -606,18 +606,12 @@ size_t utf16_to_utf8(unsigned short utf16_char, unsigned char *out)
 		out[1] = (unsigned char)((utf16_char >> 0 & 0x3F) | 0x80);
 		return 2;
 	}
-	else if (utf16_char < 0x010000) {
+	else
+	{
 		out[0] = (unsigned char)((utf16_char >> 12 & 0x0F) | 0xE0);
 		out[1] = (unsigned char)((utf16_char >> 6 & 0x3F) | 0x80);
 		out[2] = (unsigned char)((utf16_char >> 0 & 0x3F) | 0x80);
 		return 3;
-	}
-	else if (utf16_char < 0x110000) {
-		out[0] = (unsigned char)((utf16_char >> 18 & 0x07) | 0xF0);
-		out[1] = (unsigned char)((utf16_char >> 12 & 0x3F) | 0x80);
-		out[2] = (unsigned char)((utf16_char >> 6 & 0x3F) | 0x80);
-		out[3] = (unsigned char)((utf16_char >> 0 & 0x3F) | 0x80);
-		return 4;
 	}
 	return 0;
 }


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [x] I have used CCExtractor just a couple of times.

---

This fixes all warnings reported by Clang 9.0.1 in the core CCExtractor code, excluding vendored libraries.

These changes combined with #1204 make all of the core code build with zero warnings on the latest stable versions of both GCC and Clang at the time of writing, both with and without OCR enabled.