### PR TITLE
[FIX] Fix minor memory leak in OCR code

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -21,6 +21,7 @@
 - Fix: Change inet_ntop to inet_ntoa for Windows XP compatibility
 - FIX: Added an option to disable timestamps for WebVTT (In response to issue #1127)
 - FIX: Add FT_Done_Face to destroy face objects after they're used
+- Fix: Fixed a small OCR memory leak
 
 0.88 (2019-05-21)
 -----------------

--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -565,6 +565,7 @@ char* ocr_bitmap(void* arg, png_color *palette,png_byte *alpha, unsigned char* i
 							memset(text_out,0,strlen(text_out_copy)+strlen(substr)+1);
 							strcpy(text_out,substr);
 							strcpy(text_out+strlen(substr),text_out_copy);
+							free(text_out_copy);
 							written_tag = 1;
 						}
 						free(substr);


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [x] I absolutely love CCExtractor, but have not contributed previously.

---

This leak was detected by Valgrind:

```
==1203168== 2,880 bytes in 57 blocks are definitely lost in loss record 3 of 4
==1203168==    at 0x483877F: malloc (vg_replace_malloc.c:309)
==1203168==    by 0x51ADBEE: strdup (in /usr/lib/libc-2.30.so)
==1203168==    by 0x24D1F8: ocr_bitmap (ocr.c:569)
==1203168==    by 0x24E25B: ocr_rect (ocr.c:907)
==1203168==    by 0x284832: write_dvb_sub (dvb_subtitle_decoder.c:1665)
==1203168==    by 0x284B7A: dvbsub_handle_display_segment (dvb_subtitle_decoder.c:1720)
==1203168==    by 0x285024: dvbsub_decode (dvb_subtitle_decoder.c:1828)
==1203168==    by 0x2406AF: process_data (general_loop.c:648)
==1203168==    by 0x2416D0: general_loop (general_loop.c:1025)
==1203168==    by 0x1AC89A: api_start (ccextractor.c:214)
==1203168==    by 0x16EC03: main (ccextractor.c:536)
```