### PR TITLE
[FIX] Write all SCC characters in pairs (fixes playback in MPV)

### DIFF
--- a/src/lib_ccx/ccx_encoders_scc.c
+++ b/src/lib_ccx/ccx_encoders_scc.c
@@ -1131,7 +1131,7 @@ void write_character(const int fd, const unsigned char character, const bool dis
 	}
 	else
 	{
-		if (*bytes_written)
+		if (*bytes_written % 2 == 1)
 			write(fd, " ", 1);
 
 		fdprintf(fd, "%02x", odd_parity(character));


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [x] I have used CCExtractor just a couple of times.

---

This is how every example appears to be structured, and MPV doesn't display anything without this change.

Before: `e5 f2 e5 20`
After: `e5f2 e520`