### PR TITLE
[IMPROVEMENT] Write CRLF line endings in SCC files

### DIFF
--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -97,7 +97,7 @@ static const char *webvtt_header[] = { "WEBVTT", "\r\n", NULL };
 
 static const char *simple_xml_header = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<captions>\r\n";
 
-static const char CCD_HEADER[] = "SCC_disassembly V1.2\n";
+static const char CCD_HEADER[] = "SCC_disassembly V1.2\r\n";
 static const char SCC_HEADER[] = "Scenarist_SCC V1.0";
 
 void find_limit_characters(const unsigned char *line, int *first_non_blank, int *last_non_blank, int max_len)
@@ -391,8 +391,7 @@ int write_subtitle_file_footer(struct encoder_ctx *ctx, struct ccx_s_write *out)
 			break;
 		case CCX_OF_SCC:
 		case CCX_OF_CCD:
-			// TODO \n vs \r\n
-			ret = write(out->fh, "\n", 1);
+			ret = write(out->fh, "\r\n", 2);
 			break;
 		default: // Nothing to do, no footer on this format
 			break;
@@ -433,7 +432,6 @@ static int write_subtitle_file_header(struct encoder_ctx *ctx, struct ccx_s_writ
 	switch (ctx->write_format)
 	{
 		case CCX_OF_CCD:
-			// TODO: use CRLF on Windows
 			if (write(out->fh, CCD_HEADER, sizeof(CCD_HEADER) - 1) == -1)
 			{
 				mprint("Unable to write CCD header to file\n");
@@ -441,7 +439,6 @@ static int write_subtitle_file_header(struct encoder_ctx *ctx, struct ccx_s_writ
 			}
 			break;
 		case CCX_OF_SCC:
-			// TODO: use CRLF on Windows
 			if (write(out->fh, SCC_HEADER, sizeof(SCC_HEADER) - 1) == -1)
 			{
 				mprint("Unable to write SCC header to file\n");

--- a/src/lib_ccx/ccx_encoders_scc.c
+++ b/src/lib_ccx/ccx_encoders_scc.c
@@ -10,8 +10,6 @@ unsigned char odd_parity(const unsigned char byte)
 	return byte | !(cc608_parity(byte) % 2) << 7;
 }
 
-// TODO: deal with "\n" vs "\r\n"
-
 struct control_code_info {
 	unsigned int byte1_odd;
 	unsigned int byte1_even;
@@ -520,7 +518,7 @@ enum control_code get_font_code(enum font_bits font, enum ccx_decoder_608_color_
 
 void add_timestamp(int fd, LLONG time, const bool disassemble)
 {
-	write(fd, "\n\n", disassemble ? 1 : 2);
+	write(fd, "\r\n\r\n", disassemble ? 2 : 4);
 	unsigned hour, minute, second, milli;
 	millis_to_time(time, &hour, &minute, &second, &milli);
 
@@ -625,7 +623,7 @@ int write_cc_buffer_as_ccd(const struct eia608_screen *data, struct encoder_ctx 
 {
 	if (!context->wrote_ccd_channel_header)
 	{
-		fdprintf(context->out->fh, "CHANNEL %d\n", data->channel);
+		fdprintf(context->out->fh, "CHANNEL %d\r\n", data->channel);
 		context->wrote_ccd_channel_header = true;
 	}
 	return write_cc_buffer_as_scenarist(data, context, true);


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [x] I have used CCExtractor just a couple of times.

---

All the SCC and CCD examples I can find have CRLF line endings. VLC and libavformat (used by MPV) don't care, so just go with the popular convention and switch to CRLF. There's no reason a user would want to choose their line endings in this scenario.

This also adds 2 trailing new lines as is the convention for SCC/CCD files.

This addresses one of the items in #1191. 