### PR TITLE
[FIX] SCC character pair writing

### DIFF
--- a/src/lib_ccx/ccx_encoders_scc.c
+++ b/src/lib_ccx/ccx_encoders_scc.c
@@ -1131,7 +1131,7 @@ void write_character(const int fd, const unsigned char character, const bool dis
 	}
 	else
 	{
-		if (*bytes_written % 2 == 1)
+		if (*bytes_written % 2 == 0)
 			write(fd, " ", 1);
 
 		fdprintf(fd, "%02x", odd_parity(character));

--- a/src/lib_ccx/ccx_encoders_scc.c
+++ b/src/lib_ccx/ccx_encoders_scc.c
@@ -1157,7 +1157,7 @@ void write_control_code(const int fd, const unsigned char channel, const enum co
 	}
 	else
 	{
-		if (*bytes_written)
+		if (*bytes_written % 2 == 0)
 			write(fd, " ", 1);
 
 		fdprintf(fd, "%02x%02x", odd_parity(get_first_byte(channel, code)), odd_parity(get_second_byte(code)));


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [x] I have used CCExtractor just a couple of times.

---

The space was being inserted in the wrong position, so the first character of each caption was being cut off. The last character was also cut off in captions with even lengths.

Thanks to @NilsIrl for reporting this issue.