### PR TITLE
[IMPROVEMENT] Add SCC color output support

### DIFF
--- a/src/lib_ccx/ccx_decoders_structs.h
+++ b/src/lib_ccx/ccx_decoders_structs.h
@@ -70,7 +70,10 @@ enum ccx_decoder_608_color_code
 	COL_MAGENTA = 6,
 	COL_USERDEFINED = 7,
 	COL_BLACK = 8,
-	COL_TRANSPARENT = 9
+	COL_TRANSPARENT = 9,
+
+	// Must keep at end
+	COL_MAX
 };
 
 /**


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [x] I have used CCExtractor just a couple of times.

---

This adds support for all colors defined [here](http://www.theneitherworld.com/mcpoodle/SCC_TOOLS/DOCS/CC_CODES.HTML), as well as their italic variants. **Note that I have not tested the output** because MPV doesn't appear to support SCC colors, VLC freezes while trying to open any SCC file, and I haven't been able to find any other players that support SCC. It looks fine with a visual comparison to the examples from #1120, but an actual test would be nice to have before merging.