### PR TITLE
[FIX] documentation typo

### DIFF
--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -626,7 +626,7 @@ void print_usage (void)
 	mprint("                       Use one line per word. Lines starting with # are\n");
 	mprint("                       considered comments and discarded.\n\n");
 	mprint("                 --kf: Censors profane words from subtitles.\n");
-	mprint("--profanity_file <file>: Add the contents of <file> to the list of words that.\n");
+	mprint("--profanity-file <file>: Add the contents of <file> to the list of words that.\n");
 	mprint("                         must be censored. The content of <file>, follows the\n");
 	mprint("                         same syntax as for the capitalization file\n");
 	mprint("-sbs --splitbysentence: Split output text so each frame contains a complete\n");


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [X] I am an active contributor to CCExtractor.

---

typo

https://github.com/CCExtractor/ccextractor/blob/7b038ab64905750b7da5320b599504b1ca890aab/src/lib_ccx/params.c#L1942