### PR TITLE
[FIX] X-TIMESTAMP-MAP doesnt show up with DVB subs.

### DIFF
--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -1269,6 +1269,7 @@ int encode_sub(struct encoder_ctx *context, struct cc_subtitle *sub)
 				case CCX_OF_WEBVTT:
 					if (!context->startcredits_displayed && context->start_credits_text != NULL)
 						try_to_add_start_credits(context, sub->start_time);
+					 write_webvtt_header(context); 
 					wrote_something = write_cc_bitmap_as_webvtt(sub, context);
 					break;
 				case CCX_OF_SAMI:


### PR DESCRIPTION
Fix #1166 
CCExtractor version: 0.88

In raising this pull request, I confirm the following (please check boxes):

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
My familiarity with the project is as follows (check one):
.
- [X] I have used CCExtractor just a couple of times.
Arguments used:
```ruby
./ccextractor -datapid 0xc37 -out=webvtt files/test1_dvbsub.ts
```
Video link:http://akini.mbnet.fi/videos/test1_dvbsub.ts
ADD XTIMESTAMP-MAP to webvtt files.
