### PR TITLE
[FIX] Fix multiple definitions with new -fno-common default in GCC 10

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -16,6 +16,7 @@
 - Fix: lib_ccx.c: Initialize fatal error logging function before first usage in init_libraries
 - Fix: A few (minor) memory leaks around the code.
 - Fix: General code clean up / reformatting
+- Fix: Fix multiple definitions with new -fno-common default in GCC 10
 - Doc: Updated ccextractor.cnf.sample.
 
 0.88 (2019-05-21)

--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -9,6 +9,9 @@ License: GPL 2.0
 
 volatile int terminate_asap = 0;
 
+struct ccx_s_options ccx_options;
+struct lib_ccx_ctx *signal_ctx;
+
 void sigusr1_handler(int sig)
 {
 	mprint("Caught SIGUSR1. Filename Change Requested\n");

--- a/src/ccextractor.h
+++ b/src/ccextractor.h
@@ -41,8 +41,8 @@ char * api_param(struct ccx_s_options* api_options, int count);
 #endif
 
 
-struct ccx_s_options ccx_options;
-struct lib_ccx_ctx *signal_ctx;
+extern struct ccx_s_options ccx_options;
+extern struct lib_ccx_ctx *signal_ctx;
 //volatile int terminate_asap = 0;
 
 struct ccx_s_options* api_init_options();

--- a/src/lib_ccx/ccx_decoders_708.h
+++ b/src/lib_ccx/ccx_decoders_708.h
@@ -371,7 +371,7 @@ void ccx_dtvcc_process_service_block(ccx_dtvcc_ctx *dtvcc,
 									 unsigned char *data,
 									 int data_length);
 
-ccx_dtvcc_pen_color ccx_dtvcc_default_pen_color;
-ccx_dtvcc_pen_attribs ccx_dtvcc_default_pen_attribs;
+extern ccx_dtvcc_pen_color ccx_dtvcc_default_pen_color;
+extern ccx_dtvcc_pen_attribs ccx_dtvcc_default_pen_attribs;
 
 #endif


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [X] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [X] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

GCC 10 defaults to `-fno-common`, which results in multiple definitions of a few variables; this is mentioned in the [GCC 10 release notes](https://gcc.gnu.org/gcc-10/changes.html) and the [GCC 10 porting guide](https://gcc.gnu.org/gcc-10/porting_to.html). Closes #1225.