### PR TITLE
[FIX] Fix tags displaying incorrectly

### DIFF
--- a/src/lib_ccx/ccx_decoders_608.c
+++ b/src/lib_ccx/ccx_decoders_608.c
@@ -109,7 +109,7 @@ void clear_eia608_cc_buffer(ccx_decoder_608_context *context, struct eia608_scre
 		memset(data->characters[i], ' ', CCX_DECODER_608_SCREEN_WIDTH);
 		data->characters[i][CCX_DECODER_608_SCREEN_WIDTH] = 0;
 
-		for (int j = 0; j < CCX_DECODER_608_SCREEN_WIDTH + 1; j++)
+		for (int j = 0; j < CCX_DECODER_608_SCREEN_WIDTH + 1; ++j)
 		{
 			data->colors[i][j] = context->settings->default_color;
 			data->fonts[i][j] = FONT_REGULAR;
@@ -526,24 +526,39 @@ int roll_up(ccx_decoder_608_context *context)
 		if (j >= 0)
 		{
 			memcpy(use_buffer->characters[j], use_buffer->characters[j + 1], CCX_DECODER_608_SCREEN_WIDTH + 1);
-			memcpy(use_buffer->colors[j], use_buffer->colors[j + 1], CCX_DECODER_608_SCREEN_WIDTH + 1);
-			memcpy(use_buffer->fonts[j], use_buffer->fonts[j + 1], CCX_DECODER_608_SCREEN_WIDTH + 1);
-			use_buffer->row_used[j] = use_buffer->row_used[j + 1];
+
+			for (int i = 0; i < CCX_DECODER_608_SCREEN_WIDTH + 1; ++i)
+			{
+				use_buffer->colors[j][i] = use_buffer->colors[j + 1][i];
+				use_buffer->fonts[j][i] = use_buffer->fonts[j + 1][i];
+			}
+
+			use_buffer->row_used[j]=use_buffer->row_used[j+1];
 		}
 	}
 	for (int j = 0; j < (1 + context->cursor_row - keep_lines); j++)
 	{
 		memset(use_buffer->characters[j], ' ', CCX_DECODER_608_SCREEN_WIDTH);
-		memset(use_buffer->colors[j], context->settings->default_color, CCX_DECODER_608_SCREEN_WIDTH);
-		memset(use_buffer->fonts[j], FONT_REGULAR, CCX_DECODER_608_SCREEN_WIDTH);
 		use_buffer->characters[j][CCX_DECODER_608_SCREEN_WIDTH] = 0;
+
+		for (int i = 0; i < CCX_DECODER_608_SCREEN_WIDTH; ++i)
+		{
+			use_buffer->colors[j][i] = context->settings->default_color;
+			use_buffer->fonts[j][i] = FONT_REGULAR;
+		}
+
 		use_buffer->row_used[j] = 0;
 	}
-	memset(use_buffer->characters[lastrow], ' ', CCX_DECODER_608_SCREEN_WIDTH);
-	memset(use_buffer->colors[lastrow], context->settings->default_color, CCX_DECODER_608_SCREEN_WIDTH);
-	memset(use_buffer->fonts[lastrow], FONT_REGULAR, CCX_DECODER_608_SCREEN_WIDTH);
 
+	memset(use_buffer->characters[lastrow], ' ', CCX_DECODER_608_SCREEN_WIDTH);
 	use_buffer->characters[lastrow][CCX_DECODER_608_SCREEN_WIDTH] = 0;
+
+	for (int i = 0; i < CCX_DECODER_608_SCREEN_WIDTH; ++i)
+	{
+		use_buffer->colors[lastrow][i] = context->settings->default_color;
+		use_buffer->fonts[lastrow][i] = FONT_REGULAR;
+	}
+
 	use_buffer->row_used[lastrow] = 0;
 
 	// Sanity check
@@ -949,9 +964,13 @@ void handle_pac(unsigned char c1, unsigned char c2, ccx_decoder_608_context *con
 			if (use_buffer->row_used[j])
 			{
 				memset(use_buffer->characters[j], ' ', CCX_DECODER_608_SCREEN_WIDTH);
-				memset(use_buffer->colors[j], context->settings->default_color, CCX_DECODER_608_SCREEN_WIDTH);
-				memset(use_buffer->fonts[j], FONT_REGULAR, CCX_DECODER_608_SCREEN_WIDTH);
 				use_buffer->characters[j][CCX_DECODER_608_SCREEN_WIDTH] = 0;
+
+				for (int i = 0; i < CCX_DECODER_608_SCREEN_WIDTH; ++i)
+				{
+					use_buffer->colors[j][i] = context->settings->default_color;
+					use_buffer->fonts[j][i] = FONT_REGULAR;
+				}
 				use_buffer->row_used[j] = 0;
 			}
 		}


### PR DESCRIPTION
This was caused by 19241744d71adeda0f29c553b966236e88312c94, moving from
`unsigned char` to `enums` for colors and fonts. The problem with this is
that each colour isn't one byte next to each other so memcpy and memset
didn't work anymore.

The problem:

```patch
6812,6813c6812,6813
< EDITION OF AMERICA'S NEXT TOP
< <i> MODEL</i> ON WEDNESDAYS.<i>          </i>
---
> EDITION OF<i> AMERICA'S NEXT TOP</i>
> <i> MODEL</i> ON WEDNESDAYS.
6817c6817
< EDITION OF AMERICA'S NEXT TOP
---
> EDITION OF<i> AMERICA'S NEXT TOP</i>
6819c6819
< >><i> THE VAMPIRE DIARIES         </i>
---
> >><i> THE VAMPIRE DIARIES</i>
6824,6825c6824,6825
< >><i> THE VA</i>MPIRE DIARIES
< AND<i> THE SECRET CIRCLE          </i>
---
> >><i> THE VAMPIRE DIARIES</i>
> AND<i> THE SECRET CIRCLE</i>
6829,6831c6829,6831
< >><i> THE VA</i>MPIRE DIARIES
< AND<i> THE S</i>ECRET CIRCLE
< ON THURSDAYS.<i>                  </i>
---
> >><i> THE VAMPIRE DIARIES</i>
> AND<i> THE SECRET CIRCLE</i>
> ON THURSDAYS.
6835c6835
< AND<i> THE S</i>ECRET CIRCLE
---
> AND<i> THE SECRET CIRCLE</i>
```