### PR TITLE
[IMPROVEMENT] Remove the need for the push to be on the master branch

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -2,7 +2,6 @@ name: Build CCExtractor on Linux
 
 on:
   push:
-    branches: master
     paths:
     - '.github/workflows/build_linux.yml'
     - '**.c'

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -2,7 +2,6 @@ name: Build CCExtractor on Windows
 
 on:
   push:
-    branches: master
     paths:
     - '.github/workflows/build_windows.yml'
     - '**.c'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,7 +1,6 @@
 name: Format sourcecode
 on:
   push:
-    branches: master
     paths:
     - '.github/workflows/format.yml'
     - 'src/**.c'


### PR DESCRIPTION
This is because contributors don't have branches called master it isn't
possible to manually trigger workflows as suggested by
https://github.community/t5/GitHub-Actions/GitHub-Actions-Manual-Trigger-Approvals/m-p/31517.

**My familiarity with the project is as follows (check one):**

- [X] I absolutely hate CCExtractor, but have not contributed previously. :joy: (just kidding)