### PR TITLE
[FIX] Fixed paths in MakeFile, fixing the AutoConf compile error

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -18,6 +18,7 @@
 - Fix: General code clean up / reformatting
 - Fix: Fix multiple definitions with new -fno-common default in GCC 10
 - Fix: Mac now builds reproducibly again without errors on the date command (#1230)
+- Fix: Autoconf script builds without error, incorporating the thirdparty libraries
 - Doc: Updated ccextractor.cnf.sample.
 
 0.88 (2019-05-21)

--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -18,7 +18,6 @@
 - Fix: General code clean up / reformatting
 - Fix: Fix multiple definitions with new -fno-common default in GCC 10
 - Fix: Mac now builds reproducibly again without errors on the date command (#1230)
-- Fix: Autoconf script builds without error, incorporating the thirdparty libraries
 - Doc: Updated ccextractor.cnf.sample.
 
 0.88 (2019-05-21)
@@ -1199,4 +1198,3 @@ version of CCExtractor.
 - Added video information (as extracted from sequence header).
 - Some code clean-up.
 - FF sanity check enabled by default.
-

--- a/linux/Makefile.am
+++ b/linux/Makefile.am
@@ -318,7 +318,7 @@ ccextractor_SOURCES = \
 
 ccextractor_CFLAGS = -std=gnu99 -Wno-write-strings -Wno-pointer-sign -D_FILE_OFFSET_BITS=64 -DVERSION_FILE_PRESENT -DFT2_BUILD_LIBRARY -DGPAC_DISABLE_VTT -DGPAC_DISABLE_OD_DUMP
 
-ccextractor_CPPFLAGS =-I../src/lib_ccx/ -I../src/thirdparty/gpacmp4/ -I../src/libpng/ -I../src/thirdparty/zlib/ -I../src/thirdparty/zvbi/ -I../src/thirdparty/lib_hash/ -I../src/thirdparty/protobuf-c/ -I../src/thirdparty -I../src/ -I../src/thirdparty/freetype/include/
+ccextractor_CPPFLAGS =-I../src/lib_ccx/ -I../src/thirdparty/gpacmp4/ -I../src/thirdparty/libpng/ -I../src/thirdparty/zlib/ -I../src/thirdparty/zvbi/ -I../src/thirdparty/lib_hash/ -I../src/thirdparty/protobuf-c/ -I../src/thirdparty -I../src/ -I../src/thirdparty/freetype/include/
 
 
 ccextractor_LDADD=-lm


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [X] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [X] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---
Fix for issue #1241 , changed linux/Makefile.am to run with updated paths of thirdparty libpng .
