### PR TITLE
Update ccx_encoders_common.c

### DIFF
--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -93,7 +93,7 @@ static const char *smptett_header = "<?xml version=\"1.0\" encoding=\"UTF-8\" st
 			"  <body>\n"
 			"    <div>\n";
 
-static const char *webvtt_header[] = {"WEBVTT","\r\n","\r\n","STYLE","\r\n","\r\n",NULL};
+static const char *webvtt_header[] = {"WEBVTT","\r\n","\r\n",NULL};
 
 static const char *simple_xml_header = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<captions>\r\n";
 


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [*] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [*] I have checked that another pull request for this purpose does not exist.
- [*] I have considered, and confirmed that this submission will be valuable to others.
- [*] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [*] I give this submission freely, and claim no ownership to its content.
- [*] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [* ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---
Hello,
I would ask about your python solution found here:

"jakubvojacek commented on 20 Jul 2018
I got it working (not in ccextractor but using a small python script). Already got over 100 channels with subtitles working and seems to be quite stable."

Im facing the same problem with live webvtt subs extraction and packaging after with Shaka.
Would be appreciated, for your help.

Regards:
Vasil Bonev
vasil.bonev72@gmail.com


{pull request content here}
