### PR TITLE
[FIX] Disable BOM in non-Windows build

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -31,8 +31,12 @@ jobs:
       working-directory: ./windows/Release
     - name: Prepare artifacts
       run: mkdir ./windows/artifacts
-    - name: Copy release artifact
-      run: cp ./windows/Release/ccextractorwin.exe ./windows/artifacts/; cp ./windows/Release/ccextractorgui.exe ./windows/artifacts/
+    - name: Copy CCExtractor executable for artifact
+      run: cp ./windows/Release/ccextractorwin.exe ./windows/artifacts/
+    - name: Copy GUI for artifact
+      run: cp ./windows/Release/ccextractorgui.exe ./windows/artifacts/; 
+    - name: Copy DLL's needed to artifact
+      run: cp ./windows/Release/*.dll ./windows/artifacts/
     - uses: actions/upload-artifact@v1
       with:
         name: CCExtractor Windows Non-OCR Release build
@@ -52,8 +56,12 @@ jobs:
       working-directory: ./windows/Debug
     - name: Prepare artifacts
       run: mkdir ./windows/artifacts
-    - name: Copy debug artifacts
-      run: cp ./windows/Debug/ccextractorwin.exe ./windows/artifacts/; cp ./windows/Debug/ccextractorwin.pdb ./windows/artifacts/; cp ./windows/Debug/ccextractorgui.exe ./windows/artifacts/
+    - name: Copy CCExtractor executable and pdb for artifact
+      run: cp ./windows/Debug/ccextractorwin.exe ./windows/artifacts/; cp ./windows/Debug/ccextractorwin.pdb ./windows/artifacts/
+    - name: Copy GUI for artifact
+      run: cp ./windows/Debug/ccextractorgui.exe ./windows/artifacts/; 
+    - name: Copy DLL's needed to artifact
+      run: cp ./windows/Debug/*.dll ./windows/artifacts/
     - uses: actions/upload-artifact@v1
       with:
         name: CCExtractor Windows Non-OCR Debug build
@@ -73,8 +81,12 @@ jobs:
       working-directory: ./windows/Release-Full
     - name: Prepare artifacts
       run: mkdir ./windows/artifacts
-    - name: Copy release artifact
-      run: cp ./windows/Release-Full/ccextractorwinfull.exe ./windows/artifacts/; cp ./windows/Release/ccextractorgui.exe ./windows/artifacts/
+    - name: Copy CCExtractor executable for artifact
+      run: cp ./windows/Release-Full/ccextractorwinfull.exe ./windows/artifacts/
+    - name: Copy GUI for artifact
+      run: cp ./windows/Release/ccextractorgui.exe ./windows/artifacts/; 
+    - name: Copy DLL's needed to artifact
+      run: cp ./windows/Release-Full/*.dll ./windows/artifacts/
     - uses: actions/upload-artifact@v1
       with:
         name: CCExtractor Windows OCR and HardSubX Release build
@@ -94,8 +106,12 @@ jobs:
       working-directory: ./windows/Debug-Full
     - name: Prepare artifacts
       run: mkdir ./windows/artifacts
-    - name: Copy debug artifact
-      run: cp ./windows/Debug-Full/ccextractorwinfull.exe ./windows/artifacts/; cp ./windows/Debug-Full/ccextractorwinfull.pdb ./windows/artifacts/; cp ./windows/Debug/ccextractorgui.exe ./windows/artifacts/
+    - name: Copy CCExtractor executable and pdb for artifact
+      run: cp ./windows/Debug-Full/ccextractorwinfull.exe ./windows/artifacts/; cp ./windows/Debug-Full/ccextractorwinfull.pdb ./windows/artifacts/
+    - name: Copy GUI for artifact
+      run: cp ./windows/Debug/ccextractorgui.exe ./windows/artifacts/; 
+    - name: Copy DLL's needed to artifact
+      run: cp ./windows/Debug-Full/*.dll ./windows/artifacts/
     - uses: actions/upload-artifact@v1
       with:
         name: CCExtractor Windows OCR and HardSubX Debug build

--- a/src/lib_ccx/ccx_common_option.c
+++ b/src/lib_ccx/ccx_common_option.c
@@ -132,7 +132,11 @@ void init_options(struct ccx_s_options *options)
 	options->enc_cfg.start_credits_text = NULL;
 	options->enc_cfg.end_credits_text = NULL;
 	options->enc_cfg.encoding = CCX_ENC_UTF_8;
-	options->enc_cfg.no_bom = 0; // Use BOM by default.
+#ifdef _WIN32
+	options->enc_cfg.no_bom = 0; // Use BOM by default for windows only
+#else
+	options->enc_cfg.no_bom = 1; 
+#endif
 	options->enc_cfg.services_charsets = NULL;
 	options->enc_cfg.all_services_charset = NULL;
 	options->enc_cfg.with_semaphore = 0;


### PR DESCRIPTION
- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [X] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [X] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

about bom In the ccextractor help :
```

                 -bom: Append a BOM (Byte Order Mark) to output files.
                       Note that most text processing tools in linux will not
                       like BOM.
                       This is the default in Windows builds.
                       -nobom: Do not append a BOM (Byte Order Mark) to output
                       files. Note that this may break files when using
                       Windows. This is the default in non-Windows builds.
```
Currently, bom is also enabled in non-Windows builds. This PR fixes this issue.
