### PR TITLE
[FIX] -Wunused-result warnings

### DIFF
--- a/src/lib_ccx/ccx_decoders_708_output.c
+++ b/src/lib_ccx/ccx_decoders_708_output.c
@@ -1,6 +1,7 @@
 #include "ccx_decoders_708_output.h"
 #include "ccx_decoders_708.h"
 #include "ccx_encoders_common.h"
+#include "lib_ccx.h"
 #include "utility.h"
 #include "ccx_common_common.h"
 
@@ -191,13 +192,15 @@ void _dtvcc_write_row(ccx_dtvcc_writer_ctx *writer, ccx_dtvcc_service_decoder *d
 						   "conversion failed: %s\n",
 						   strerror(errno));
 
-		write(fd, encoded_buf_start, encoded_buf - encoded_buf_start);
+		if (write(fd, encoded_buf_start, encoded_buf - encoded_buf_start) == -1)
+			fatal(IO_ERROR, "writing to file");
 
 		free(encoded_buf_start);
 	}
 	else
 	{
-		write(fd, buf, buf_len);
+		if (write(fd, buf, buf_len) == -1)
+			fatal(IO_ERROR, "writing to file");
 	}
 }
 
@@ -221,19 +224,22 @@ void ccx_dtvcc_write_srt(ccx_dtvcc_writer_ctx *writer, ccx_dtvcc_service_decoder
 			  "%02u:%02u:%02u,%03u", buf + strlen(buf));
 	sprintf(buf + strlen(buf), "%s", (char *)encoder->encoded_crlf);
 
-	write(encoder->dtvcc_writers[tv->service_number - 1].fd, buf, strlen(buf));
+	if (write(encoder->dtvcc_writers[tv->service_number - 1].fd, buf, strlen(buf)) == -1)
+		fatal(IO_ERROR, "writing to file");
 
 	for (int i = 0; i < CCX_DTVCC_SCREENGRID_ROWS; i++)
 	{
 		if (!_dtvcc_is_row_empty(tv, i))
 		{
 			_dtvcc_write_row(writer, decoder, i, encoder, 1);
-			write(encoder->dtvcc_writers[tv->service_number - 1].fd,
-			      encoder->encoded_crlf, encoder->encoded_crlf_length);
+			if (write(encoder->dtvcc_writers[tv->service_number - 1].fd,
+				  encoder->encoded_crlf, encoder->encoded_crlf_length) == -1)
+				fatal(IO_ERROR, "writing to file");
 		}
 	}
-	write(encoder->dtvcc_writers[tv->service_number - 1].fd,
-	      encoder->encoded_crlf, encoder->encoded_crlf_length);
+	if (write(encoder->dtvcc_writers[tv->service_number - 1].fd,
+		  encoder->encoded_crlf, encoder->encoded_crlf_length) == -1)
+		fatal(IO_ERROR, "writing to file");
 }
 
 void ccx_dtvcc_write_debug(dtvcc_tv_screen *tv)
@@ -289,12 +295,15 @@ void ccx_dtvcc_write_transcript(ccx_dtvcc_writer_ctx *writer, ccx_dtvcc_service_
 			if (encoder->transcript_settings->showMode)
 				sprintf(buf + strlen(buf), "POP|"); //TODO caption mode(pop, rollup, etc.)
 
-			if (strlen(buf))
-				write(encoder->dtvcc_writers[tv->service_number - 1].fd, buf, strlen(buf));
+			const size_t buf_len = strlen(buf);
+			if (buf_len != 0)
+				if (write(encoder->dtvcc_writers[tv->service_number - 1].fd, buf, buf_len) == -1)
+					fatal(IO_ERROR, "writing to file");
 
 			_dtvcc_write_row(writer, decoder, i, encoder, 0);
-			write(encoder->dtvcc_writers[tv->service_number - 1].fd,
-			      encoder->encoded_crlf, encoder->encoded_crlf_length);
+			if (write(encoder->dtvcc_writers[tv->service_number - 1].fd,
+				  encoder->encoded_crlf, encoder->encoded_crlf_length) == -1)
+				fatal(IO_ERROR, "writing to file");
 		}
 	}
 }
@@ -321,16 +330,19 @@ void _dtvcc_write_sami_header(dtvcc_tv_screen *tv, struct encoder_ctx *encoder)
 	buf_len += sprintf(buf + buf_len, "</head>%s%s", encoder->encoded_crlf, encoder->encoded_crlf);
 	buf_len += sprintf(buf + buf_len, "<body>%s", encoder->encoded_crlf);
 
-	write(encoder->dtvcc_writers[tv->service_number - 1].fd, buf, buf_len);
+	if (write(encoder->dtvcc_writers[tv->service_number - 1].fd, buf, buf_len) == -1)
+		fatal(IO_ERROR, "writing to file");
 }
 
 void _dtvcc_write_sami_footer(dtvcc_tv_screen *tv, struct encoder_ctx *encoder)
 {
 	char *buf = (char *)encoder->buffer;
 	sprintf(buf, "</body></sami>");
-	write(encoder->dtvcc_writers[tv->service_number - 1].fd, buf, strlen(buf));
-	write(encoder->dtvcc_writers[tv->service_number - 1].fd,
-	      encoder->encoded_crlf, encoder->encoded_crlf_length);
+	if (write(encoder->dtvcc_writers[tv->service_number - 1].fd, buf, strlen(buf)) == -1)
+		fatal(IO_ERROR, "writing to file");
+	if (write(encoder->dtvcc_writers[tv->service_number - 1].fd,
+		  encoder->encoded_crlf, encoder->encoded_crlf_length) == -1)
+		fatal(IO_ERROR, "writing to file");
 }
 
 void ccx_dtvcc_write_sami(ccx_dtvcc_writer_ctx *writer, ccx_dtvcc_service_decoder *decoder, struct encoder_ctx *encoder)
@@ -351,24 +363,28 @@ void ccx_dtvcc_write_sami(ccx_dtvcc_writer_ctx *writer, ccx_dtvcc_service_decode
 	sprintf(buf, "<sync start=%llu><p class=\"unknowncc\">%s",
 		(unsigned long long)tv->time_ms_show + encoder->subs_delay,
 		encoder->encoded_crlf);
-	write(encoder->dtvcc_writers[tv->service_number - 1].fd, buf, strlen(buf));
+	if (write(encoder->dtvcc_writers[tv->service_number - 1].fd, buf, strlen(buf)) == -1)
+		fatal(IO_ERROR, "writing to file");
 
 	for (int i = 0; i < CCX_DTVCC_SCREENGRID_ROWS; i++)
 	{
 		if (!_dtvcc_is_row_empty(tv, i))
 		{
 			_dtvcc_write_row(writer, decoder, i, encoder, 1);
-			write(encoder->dtvcc_writers[tv->service_number - 1].fd,
-			      encoder->encoded_br, encoder->encoded_br_length);
-			write(encoder->dtvcc_writers[tv->service_number - 1].fd,
-			      encoder->encoded_crlf, encoder->encoded_crlf_length);
+			if (write(encoder->dtvcc_writers[tv->service_number - 1].fd,
+				  encoder->encoded_br, encoder->encoded_br_length) == -1)
+				fatal(IO_ERROR, "writing to file");
+			if (write(encoder->dtvcc_writers[tv->service_number - 1].fd,
+				  encoder->encoded_crlf, encoder->encoded_crlf_length) == -1)
+				fatal(IO_ERROR, "writing to file");
 		}
 	}
 
 	sprintf(buf, "<sync start=%llu><p class=\"unknowncc\">&nbsp;</p></sync>%s%s",
 		(unsigned long long)tv->time_ms_hide + encoder->subs_delay,
 		encoder->encoded_crlf, encoder->encoded_crlf);
-	write(encoder->dtvcc_writers[tv->service_number - 1].fd, buf, strlen(buf));
+	if (write(encoder->dtvcc_writers[tv->service_number - 1].fd, buf, strlen(buf)) == -1)
+		fatal(IO_ERROR, "writing to file");
 }
 
 void _ccx_dtvcc_write(ccx_dtvcc_writer_ctx *writer, ccx_dtvcc_service_decoder *decoder, struct encoder_ctx *encoder)
@@ -488,7 +504,8 @@ void ccx_dtvcc_writer_output(ccx_dtvcc_writer_ctx *writer, ccx_dtvcc_service_dec
 			    CCX_COMMON_EXIT_FILE_CREATION_FAILED, "[CEA-708] Failed to open a file\n");
 		}
 		if (!encoder->no_bom)
-			write(writer->fd, UTF8_BOM, sizeof(UTF8_BOM));
+			if (write(writer->fd, UTF8_BOM, sizeof(UTF8_BOM)) == -1)
+				fatal(IO_ERROR, "writing to file");
 	}
 
 	_ccx_dtvcc_write(writer, decoder, encoder);

--- a/src/lib_ccx/ccx_encoders_g608.c
+++ b/src/lib_ccx/ccx_encoders_g608.c
@@ -16,32 +16,25 @@ int write_cc_buffer_as_g608(struct eia608_screen *data, struct encoder_ctx *cont
 	context->srt_counter++;
 	sprintf(timeline, "%u%s", context->srt_counter, context->encoded_crlf);
 	used = encode_line(context, context->buffer, (unsigned char *)timeline);
-	if (write(context->out->fh, context->buffer, used) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(context->out->fh, context->buffer, used);
 	sprintf(timeline, "%02u:%02u:%02u,%03u --> %02u:%02u:%02u,%03u%s",
 		h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
 	used = encode_line(context, context->buffer, (unsigned char *)timeline);
 
-	if (write(context->out->fh, context->buffer, used) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(context->out->fh, context->buffer, used);
 	for (int i = 0; i < 15; i++)
 	{
 		int length = get_line_encoded(context, context->subline, i, data);
-		if (write(context->out->fh, context->subline, length) == -1)
-			fatal(IO_ERROR, "writing to file");
+		write_wrapped(context->out->fh, context->subline, length);
 
 		length = get_color_encoded(context, context->subline, i, data);
-		if (write(context->out->fh, context->subline, length) == -1)
-			fatal(IO_ERROR, "writing to file");
+		write_wrapped(context->out->fh, context->subline, length);
 
 		length = get_font_encoded(context, context->subline, i, data);
-		if (write(context->out->fh, context->subline, length) == -1)
-			fatal(IO_ERROR, "writing to file");
-		if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
-			fatal(IO_ERROR, "writing to file");
+		write_wrapped(context->out->fh, context->subline, length);
+		write_wrapped(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 		wrote_something = 1;
 	}
-	if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 	return wrote_something;
 }

--- a/src/lib_ccx/ccx_encoders_g608.c
+++ b/src/lib_ccx/ccx_encoders_g608.c
@@ -16,25 +16,32 @@ int write_cc_buffer_as_g608(struct eia608_screen *data, struct encoder_ctx *cont
 	context->srt_counter++;
 	sprintf(timeline, "%u%s", context->srt_counter, context->encoded_crlf);
 	used = encode_line(context, context->buffer, (unsigned char *)timeline);
-	write(context->out->fh, context->buffer, used);
+	if (write(context->out->fh, context->buffer, used) == -1)
+		fatal(IO_ERROR, "writing to file");
 	sprintf(timeline, "%02u:%02u:%02u,%03u --> %02u:%02u:%02u,%03u%s",
 		h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
 	used = encode_line(context, context->buffer, (unsigned char *)timeline);
 
-	write(context->out->fh, context->buffer, used);
+	if (write(context->out->fh, context->buffer, used) == -1)
+		fatal(IO_ERROR, "writing to file");
 	for (int i = 0; i < 15; i++)
 	{
 		int length = get_line_encoded(context, context->subline, i, data);
-		write(context->out->fh, context->subline, length);
+		if (write(context->out->fh, context->subline, length) == -1)
+			fatal(IO_ERROR, "writing to file");
 
 		length = get_color_encoded(context, context->subline, i, data);
-		write(context->out->fh, context->subline, length);
+		if (write(context->out->fh, context->subline, length) == -1)
+			fatal(IO_ERROR, "writing to file");
 
 		length = get_font_encoded(context, context->subline, i, data);
-		write(context->out->fh, context->subline, length);
-		write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
+		if (write(context->out->fh, context->subline, length) == -1)
+			fatal(IO_ERROR, "writing to file");
+		if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
+			fatal(IO_ERROR, "writing to file");
 		wrote_something = 1;
 	}
-	write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
+	if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
+		fatal(IO_ERROR, "writing to file");
 	return wrote_something;
 }

--- a/src/lib_ccx/ccx_encoders_mcc.c
+++ b/src/lib_ccx/ccx_encoders_mcc.c
@@ -4,7 +4,6 @@
 #include <stdarg.h>
 
 #include "ccx_encoders_mcc.h"
-#include "lib_ccx.h"
 
 #define MORE_DEBUG CCX_FALSE
 
@@ -157,8 +156,7 @@ boolean mcc_encode_cc_data(struct encoder_ctx *enc_ctx, struct lib_cc_decode *de
 
 	strcat(compressed_data_buffer, "\n");
 
-	if (write(enc_ctx->out->fh, compressed_data_buffer, strlen(compressed_data_buffer)) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(enc_ctx->out->fh, compressed_data_buffer, strlen(compressed_data_buffer));
 
 	free(compressed_data_buffer);
 
@@ -723,6 +721,5 @@ static void byte_to_ascii(uint8 hex_byte, uint8 *msn, uint8 *lsn)
 
 static void write_string(int fh, char *string)
 {
-	if (write(fh, string, strlen(string)) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(fh, string, strlen(string));
 }

--- a/src/lib_ccx/ccx_encoders_mcc.c
+++ b/src/lib_ccx/ccx_encoders_mcc.c
@@ -4,6 +4,7 @@
 #include <stdarg.h>
 
 #include "ccx_encoders_mcc.h"
+#include "lib_ccx.h"
 
 #define MORE_DEBUG CCX_FALSE
 
@@ -156,7 +157,8 @@ boolean mcc_encode_cc_data(struct encoder_ctx *enc_ctx, struct lib_cc_decode *de
 
 	strcat(compressed_data_buffer, "\n");
 
-	write(enc_ctx->out->fh, compressed_data_buffer, strlen(compressed_data_buffer));
+	if (write(enc_ctx->out->fh, compressed_data_buffer, strlen(compressed_data_buffer)) == -1)
+		fatal(IO_ERROR, "writing to file");
 
 	free(compressed_data_buffer);
 
@@ -721,5 +723,6 @@ static void byte_to_ascii(uint8 hex_byte, uint8 *msn, uint8 *lsn)
 
 static void write_string(int fh, char *string)
 {
-	write(fh, string, strlen(string));
+	if (write(fh, string, strlen(string)) == -1)
+		fatal(IO_ERROR, "writing to file");
 }

--- a/src/lib_ccx/ccx_encoders_sami.c
+++ b/src/lib_ccx/ccx_encoders_sami.c
@@ -129,8 +129,7 @@ int write_cc_bitmap_as_sami(struct cc_subtitle *sub, struct encoder_ctx *context
 	{
 		sprintf(buf,
 			"<SYNC start=%llu><P class=\"UNKNOWNCC\">\r\n", (unsigned long long)sub->start_time);
-		if (write(context->out->fh, buf, strlen(buf)) == -1)
-			fatal(IO_ERROR, "writing to file");
+		write_wrapped(context->out->fh, buf, strlen(buf));
 		for (int i = sub->nb_data - 1; i >= 0; i--)
 		{
 			if (rect[i].ocr_text && *(rect[i].ocr_text))
@@ -140,26 +139,21 @@ int write_cc_bitmap_as_sami(struct cc_subtitle *sub, struct encoder_ctx *context
 					token = strtok(rect[i].ocr_text, "\r\n");
 					sprintf(buf, "%s", token);
 					token = strtok(NULL, "\r\n");
-					if (write(context->out->fh, buf, strlen(buf)) == -1)
-						fatal(IO_ERROR, "writing to file");
+					write_wrapped(context->out->fh, buf, strlen(buf));
 					if (i != 0)
-						if (write(context->out->fh, context->encoded_br, context->encoded_br_length) == -1)
-							fatal(IO_ERROR, "writing to file");
-					if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
-						fatal(IO_ERROR, "writing to file");
+						write_wrapped(context->out->fh, context->encoded_br, context->encoded_br_length);
+					write_wrapped(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 				}
 			}
 		}
 		sprintf(buf, "</P></SYNC>\r\n");
-		if (write(context->out->fh, buf, strlen(buf)) == -1)
-			fatal(IO_ERROR, "writing to file");
+		write_wrapped(context->out->fh, buf, strlen(buf));
 	}
 	else //we write an empty subtitle to clear the old one
 	{
 		sprintf(buf,
 			"<SYNC start=%llu><P class=\"UNKNOWNCC\">&nbsp;</P></SYNC>\r\n\r\n", (unsigned long long)sub->start_time);
-		if (write(context->out->fh, buf, strlen(buf)) == -1)
-			fatal(IO_ERROR, "writing to file");
+		write_wrapped(context->out->fh, buf, strlen(buf));
 	}
 #endif
 
@@ -207,8 +201,7 @@ int write_cc_buffer_as_sami(struct eia608_screen *data, struct encoder_ctx *cont
 		dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
 	}
 	used = encode_line(context, context->buffer, (unsigned char *)str);
-	if (write(context->out->fh, context->buffer, used) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(context->out->fh, context->buffer, used);
 	for (int i = 0; i < 15; i++)
 	{
 		if (data->row_used[i])
@@ -219,14 +212,11 @@ int write_cc_buffer_as_sami(struct eia608_screen *data, struct encoder_ctx *cont
 				dbg_print(CCX_DMT_DECODER_608, "\r");
 				dbg_print(CCX_DMT_DECODER_608, "%s\n", context->subline);
 			}
-			if (write(context->out->fh, context->subline, length) == -1)
-				fatal(IO_ERROR, "writing to file");
+			write_wrapped(context->out->fh, context->subline, length);
 			wrote_something = 1;
 			if (i != 14)
-				if (write(context->out->fh, context->encoded_br, context->encoded_br_length) == -1)
-					fatal(IO_ERROR, "writing to file");
-			if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
-				fatal(IO_ERROR, "writing to file");
+				write_wrapped(context->out->fh, context->encoded_br, context->encoded_br_length);
+			write_wrapped(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 		}
 	}
 	sprintf((char *)str, "</P></SYNC>\r\n");
@@ -235,8 +225,7 @@ int write_cc_buffer_as_sami(struct eia608_screen *data, struct encoder_ctx *cont
 		dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
 	}
 	used = encode_line(context, context->buffer, (unsigned char *)str);
-	if (write(context->out->fh, context->buffer, used) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(context->out->fh, context->buffer, used);
 	sprintf((char *)str,
 		"<SYNC start=%llu><P class=\"UNKNOWNCC\">&nbsp;</P></SYNC>\r\n\r\n",
 		(unsigned long long)data->end_time - 1); // - 1 to prevent overlap
@@ -245,7 +234,6 @@ int write_cc_buffer_as_sami(struct eia608_screen *data, struct encoder_ctx *cont
 		dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
 	}
 	used = encode_line(context, context->buffer, (unsigned char *)str);
-	if (write(context->out->fh, context->buffer, used) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(context->out->fh, context->buffer, used);
 	return wrote_something;
 }

--- a/src/lib_ccx/ccx_encoders_scc.c
+++ b/src/lib_ccx/ccx_encoders_scc.c
@@ -419,14 +419,12 @@ void add_padding(int fd, const char disassemble)
 
 	if (disassemble)
 	{
-		if (write(fd, "_", 1) == -1)
-			fatal(IO_ERROR, "writing to file");
+		write_wrapped(fd, "_", 1);
 	}
 	else
 	{
 		// 0x80 == odd_parity(0x00)
-		if (write(fd, "80", 2) == -1)
-			fatal(IO_ERROR, "writing to file");
+		write_wrapped(fd, "80", 2);
 	}
 }
 
@@ -443,14 +441,12 @@ void write_character(const int fd, const unsigned char character, const bool dis
 {
 	if (disassemble)
 	{
-		if (write(fd, &character, 1) == -1)
-			fatal(IO_ERROR, "writing to file");
+		write_wrapped(fd, &character, 1);
 	}
 	else
 	{
 		if (*bytes_written % 2 == 0)
-			if (write(fd, " ", 1) == -1)
-				fatal(IO_ERROR, "writing to file");
+			write_wrapped(fd, " ", 1);
 
 		fdprintf(fd, "%02x", odd_parity(character));
 	}
@@ -471,14 +467,12 @@ void write_control_code(const int fd, const unsigned char channel, const enum co
 	{
 		unsigned int length;
 		const char *assembly_code = disassemble_code(code, &length);
-		if (write(fd, assembly_code, length) == -1)
-			fatal(IO_ERROR, "writing to file");
+		write_wrapped(fd, assembly_code, length);
 	}
 	else
 	{
 		if (*bytes_written % 2 == 0)
-			if (write(fd, " ", 1) == -1)
-				fatal(IO_ERROR, "writing to file");
+			write_wrapped(fd, " ", 1);
 
 		fdprintf(fd, "%02x%02x", odd_parity(get_first_byte(channel, code)), odd_parity(get_second_byte(code)));
 	}
@@ -527,11 +521,9 @@ enum control_code get_font_code(enum font_bits font, enum ccx_decoder_608_color_
 
 void add_timestamp(const struct encoder_ctx *context, LLONG time, const bool disassemble)
 {
-	if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 	if (!disassemble)
-		if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
-			fatal(IO_ERROR, "writing to file");
+		write_wrapped(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 
 	unsigned hour, minute, second, milli;
 	millis_to_time(time, &hour, &minute, &second, &milli);

--- a/src/lib_ccx/ccx_encoders_scc.c
+++ b/src/lib_ccx/ccx_encoders_scc.c
@@ -419,11 +419,14 @@ void add_padding(int fd, const char disassemble)
 
 	if (disassemble)
 	{
-		write(fd, "_", 1);
+		if (write(fd, "_", 1) == -1)
+			fatal(IO_ERROR, "writing to file");
 	}
 	else
 	{
-		write(fd, "80", 2); // 0x80 == odd_parity(0x00)
+		// 0x80 == odd_parity(0x00)
+		if (write(fd, "80", 2) == -1)
+			fatal(IO_ERROR, "writing to file");
 	}
 }
 
@@ -440,12 +443,14 @@ void write_character(const int fd, const unsigned char character, const bool dis
 {
 	if (disassemble)
 	{
-		write(fd, &character, 1);
+		if (write(fd, &character, 1) == -1)
+			fatal(IO_ERROR, "writing to file");
 	}
 	else
 	{
 		if (*bytes_written % 2 == 0)
-			write(fd, " ", 1);
+			if (write(fd, " ", 1) == -1)
+				fatal(IO_ERROR, "writing to file");
 
 		fdprintf(fd, "%02x", odd_parity(character));
 	}
@@ -466,12 +471,14 @@ void write_control_code(const int fd, const unsigned char channel, const enum co
 	{
 		unsigned int length;
 		const char *assembly_code = disassemble_code(code, &length);
-		write(fd, assembly_code, length);
+		if (write(fd, assembly_code, length) == -1)
+			fatal(IO_ERROR, "writing to file");
 	}
 	else
 	{
 		if (*bytes_written % 2 == 0)
-			write(fd, " ", 1);
+			if (write(fd, " ", 1) == -1)
+				fatal(IO_ERROR, "writing to file");
 
 		fdprintf(fd, "%02x%02x", odd_parity(get_first_byte(channel, code)), odd_parity(get_second_byte(code)));
 	}
@@ -520,9 +527,11 @@ enum control_code get_font_code(enum font_bits font, enum ccx_decoder_608_color_
 
 void add_timestamp(const struct encoder_ctx *context, LLONG time, const bool disassemble)
 {
-	write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
+	if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
+		fatal(IO_ERROR, "writing to file");
 	if (!disassemble)
-		write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
+		if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
+			fatal(IO_ERROR, "writing to file");
 
 	unsigned hour, minute, second, milli;
 	millis_to_time(time, &hour, &minute, &second, &milli);

--- a/src/lib_ccx/ccx_encoders_smptett.c
+++ b/src/lib_ccx/ccx_encoders_smptett.c
@@ -53,8 +53,7 @@ void write_stringz_as_smptett(char *string, struct encoder_ctx *context, LLONG m
 		dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
 	}
 	used = encode_line(context, context->buffer, (unsigned char *)str);
-	if (write(context->out->fh, context->buffer, used) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(context->out->fh, context->buffer, used);
 	// Scan for \n in the string and replace it with a 0
 	while (pos_r < len)
 	{
@@ -81,12 +80,10 @@ void write_stringz_as_smptett(char *string, struct encoder_ctx *context, LLONG m
 			dbg_print(CCX_DMT_DECODER_608, "\r");
 			dbg_print(CCX_DMT_DECODER_608, "%s\n", context->subline);
 		}
-		if (write(context->out->fh, el, u) == -1)
-			fatal(IO_ERROR, "writing to file");
+		write_wrapped(context->out->fh, el, u);
 		//write (wb->fh, encoded_br, encoded_br_length);
 
-		if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
-			fatal(IO_ERROR, "writing to file");
+		write_wrapped(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 		begin += strlen((const char *)begin) + 1;
 	}
 
@@ -96,16 +93,14 @@ void write_stringz_as_smptett(char *string, struct encoder_ctx *context, LLONG m
 		dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
 	}
 	used = encode_line(context, context->buffer, (unsigned char *)str);
-	if (write(context->out->fh, context->buffer, used) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(context->out->fh, context->buffer, used);
 	sprintf((char *)str, "<p begin=\"%02u:%02u:%02u.%03u\">\n\n", h2, m2, s2, ms2);
 	if (context->encoding != CCX_ENC_UNICODE)
 	{
 		dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
 	}
 	used = encode_line(context, context->buffer, (unsigned char *)str);
-	if (write(context->out->fh, context->buffer, used) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(context->out->fh, context->buffer, used);
 	sprintf((char *)str, "</p>\n");
 	free(el);
 	free(unescaped);
@@ -139,16 +134,12 @@ int write_cc_bitmap_as_smptett(struct cc_subtitle *sub, struct encoder_ctx *cont
 				millis_to_time(sub->start_time, &h1, &m1, &s1, &ms1);
 				millis_to_time(sub->end_time - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
 				sprintf((char *)context->buffer, "<p begin=\"%02u:%02u:%02u.%03u\" end=\"%02u:%02u:%02u.%03u\">\n", h1, m1, s1, ms1, h2, m2, s2, ms2);
-				if (write(context->out->fh, buf, strlen(buf)) == -1)
-					fatal(IO_ERROR, "writing to file");
+				write_wrapped(context->out->fh, buf, strlen(buf));
 				len = strlen(rect[i].ocr_text);
-				if (write(context->out->fh, rect[i].ocr_text, len) == -1)
-					fatal(IO_ERROR, "writing to file");
-				if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
-					fatal(IO_ERROR, "writing to file");
+				write_wrapped(context->out->fh, rect[i].ocr_text, len);
+				write_wrapped(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 				sprintf(buf, "</p>\n");
-				if (write(context->out->fh, buf, strlen(buf)) == -1)
-					fatal(IO_ERROR, "writing to file");
+				write_wrapped(context->out->fh, buf, strlen(buf));
 			}
 		}
 	}
@@ -240,8 +231,7 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
 					dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
 				}
 				used = encode_line(context, context->buffer, (unsigned char *)str);
-				if (write(context->out->fh, context->buffer, used) == -1)
-					fatal(IO_ERROR, "writing to file");
+				write_wrapped(context->out->fh, context->buffer, used);
 				// Trimming subs because the position is defined by "tts:origin"
 				int old_trim_subs = context->trim_subs;
 				context->trim_subs = 1;
@@ -398,11 +388,9 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
 					}
 				}
 
-				if (write(context->out->fh, final, strlen(final)) == -1)
-					fatal(IO_ERROR, "writing to file");
+				write_wrapped(context->out->fh, final, strlen(final));
 
-				if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
-					fatal(IO_ERROR, "writing to file");
+				write_wrapped(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 				context->trim_subs = old_trim_subs;
 
 				sprintf(str, "        <style tts:backgroundColor=\"#000000FF\" tts:fontSize=\"18px\"/></span>\n      </p>\n");
@@ -411,8 +399,7 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
 					dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
 				}
 				used = encode_line(context, context->buffer, (unsigned char *)str);
-				if (write(context->out->fh, context->buffer, used) == -1)
-					fatal(IO_ERROR, "writing to file");
+				write_wrapped(context->out->fh, context->buffer, used);
 
 				if (context->encoding != CCX_ENC_UNICODE)
 				{

--- a/src/lib_ccx/ccx_encoders_smptett.c
+++ b/src/lib_ccx/ccx_encoders_smptett.c
@@ -53,7 +53,8 @@ void write_stringz_as_smptett(char *string, struct encoder_ctx *context, LLONG m
 		dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
 	}
 	used = encode_line(context, context->buffer, (unsigned char *)str);
-	write(context->out->fh, context->buffer, used);
+	if (write(context->out->fh, context->buffer, used) == -1)
+		fatal(IO_ERROR, "writing to file");
 	// Scan for \n in the string and replace it with a 0
 	while (pos_r < len)
 	{
@@ -80,10 +81,12 @@ void write_stringz_as_smptett(char *string, struct encoder_ctx *context, LLONG m
 			dbg_print(CCX_DMT_DECODER_608, "\r");
 			dbg_print(CCX_DMT_DECODER_608, "%s\n", context->subline);
 		}
-		write(context->out->fh, el, u);
+		if (write(context->out->fh, el, u) == -1)
+			fatal(IO_ERROR, "writing to file");
 		//write (wb->fh, encoded_br, encoded_br_length);
 
-		write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
+		if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
+			fatal(IO_ERROR, "writing to file");
 		begin += strlen((const char *)begin) + 1;
 	}
 
@@ -93,14 +96,16 @@ void write_stringz_as_smptett(char *string, struct encoder_ctx *context, LLONG m
 		dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
 	}
 	used = encode_line(context, context->buffer, (unsigned char *)str);
-	write(context->out->fh, context->buffer, used);
+	if (write(context->out->fh, context->buffer, used) == -1)
+		fatal(IO_ERROR, "writing to file");
 	sprintf((char *)str, "<p begin=\"%02u:%02u:%02u.%03u\">\n\n", h2, m2, s2, ms2);
 	if (context->encoding != CCX_ENC_UNICODE)
 	{
 		dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
 	}
 	used = encode_line(context, context->buffer, (unsigned char *)str);
-	write(context->out->fh, context->buffer, used);
+	if (write(context->out->fh, context->buffer, used) == -1)
+		fatal(IO_ERROR, "writing to file");
 	sprintf((char *)str, "</p>\n");
 	free(el);
 	free(unescaped);
@@ -134,12 +139,16 @@ int write_cc_bitmap_as_smptett(struct cc_subtitle *sub, struct encoder_ctx *cont
 				millis_to_time(sub->start_time, &h1, &m1, &s1, &ms1);
 				millis_to_time(sub->end_time - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
 				sprintf((char *)context->buffer, "<p begin=\"%02u:%02u:%02u.%03u\" end=\"%02u:%02u:%02u.%03u\">\n", h1, m1, s1, ms1, h2, m2, s2, ms2);
-				write(context->out->fh, buf, strlen(buf));
+				if (write(context->out->fh, buf, strlen(buf)) == -1)
+					fatal(IO_ERROR, "writing to file");
 				len = strlen(rect[i].ocr_text);
-				write(context->out->fh, rect[i].ocr_text, len);
-				write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
+				if (write(context->out->fh, rect[i].ocr_text, len) == -1)
+					fatal(IO_ERROR, "writing to file");
+				if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
+					fatal(IO_ERROR, "writing to file");
 				sprintf(buf, "</p>\n");
-				write(context->out->fh, buf, strlen(buf));
+				if (write(context->out->fh, buf, strlen(buf)) == -1)
+					fatal(IO_ERROR, "writing to file");
 			}
 		}
 	}
@@ -231,7 +240,8 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
 					dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
 				}
 				used = encode_line(context, context->buffer, (unsigned char *)str);
-				write(context->out->fh, context->buffer, used);
+				if (write(context->out->fh, context->buffer, used) == -1)
+					fatal(IO_ERROR, "writing to file");
 				// Trimming subs because the position is defined by "tts:origin"
 				int old_trim_subs = context->trim_subs;
 				context->trim_subs = 1;
@@ -388,9 +398,11 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
 					}
 				}
 
-				write(context->out->fh, final, strlen(final));
+				if (write(context->out->fh, final, strlen(final)) == -1)
+					fatal(IO_ERROR, "writing to file");
 
-				write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
+				if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
+					fatal(IO_ERROR, "writing to file");
 				context->trim_subs = old_trim_subs;
 
 				sprintf(str, "        <style tts:backgroundColor=\"#000000FF\" tts:fontSize=\"18px\"/></span>\n      </p>\n");
@@ -399,7 +411,8 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
 					dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
 				}
 				used = encode_line(context, context->buffer, (unsigned char *)str);
-				write(context->out->fh, context->buffer, used);
+				if (write(context->out->fh, context->buffer, used) == -1)
+					fatal(IO_ERROR, "writing to file");
 
 				if (context->encoding != CCX_ENC_UNICODE)
 				{

--- a/src/lib_ccx/ccx_encoders_srt.c
+++ b/src/lib_ccx/ccx_encoders_srt.c
@@ -23,14 +23,16 @@ int write_stringz_as_srt(char *string, struct encoder_ctx *context, LLONG ms_sta
 	context->srt_counter++;
 	sprintf(timeline, "%u%s", context->srt_counter, context->encoded_crlf);
 	used = encode_line(context, context->buffer, (unsigned char *)timeline);
-	write(context->out->fh, context->buffer, used);
+	if (write(context->out->fh, context->buffer, used) == -1)
+		fatal(IO_ERROR, "writing to file");
 	sprintf(timeline, "%02u:%02u:%02u,%03u --> %02u:%02u:%02u,%03u%s",
 		h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
 	used = encode_line(context, context->buffer, (unsigned char *)timeline);
 	dbg_print(CCX_DMT_DECODER_608, "\n- - - SRT caption - - -\n");
 	dbg_print(CCX_DMT_DECODER_608, "%s", timeline);
 
-	write(context->out->fh, context->buffer, used);
+	if (write(context->out->fh, context->buffer, used) == -1)
+		fatal(IO_ERROR, "writing to file");
 	int len = strlen(string);
 	unsigned char *unescaped = (unsigned char *)malloc(len + 1);
 	unsigned char *el = (unsigned char *)malloc(len * 3 + 1); // Be generous
@@ -64,14 +66,17 @@ int write_stringz_as_srt(char *string, struct encoder_ctx *context, LLONG ms_sta
 			dbg_print(CCX_DMT_DECODER_608, "\r");
 			dbg_print(CCX_DMT_DECODER_608, "%s\n", context->subline);
 		}
-		write(context->out->fh, el, u);
-		write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
+		if (write(context->out->fh, el, u) == -1)
+			fatal(IO_ERROR, "writing to file");
+		if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
+			fatal(IO_ERROR, "writing to file");
 		begin += strlen((const char *)begin) + 1;
 	}
 
 	dbg_print(CCX_DMT_DECODER_608, "- - - - - - - - - - - -\r\n");
 
-	write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
+	if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
+		fatal(IO_ERROR, "writing to file");
 	free(el);
 	free(unescaped);
 
@@ -114,14 +119,18 @@ int write_cc_bitmap_as_srt(struct cc_subtitle *sub, struct encoder_ctx *context)
 				context->srt_counter++;
 				sprintf(timeline, "%u%s", context->srt_counter, context->encoded_crlf);
 				used = encode_line(context, context->buffer, (unsigned char *)timeline);
-				write(context->out->fh, context->buffer, used);
+				if (write(context->out->fh, context->buffer, used) == -1)
+					fatal(IO_ERROR, "writing to file");
 				sprintf(timeline, "%02u:%02u:%02u,%03u --> %02u:%02u:%02u,%03u%s",
 					h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
 				used = encode_line(context, context->buffer, (unsigned char *)timeline);
-				write(context->out->fh, context->buffer, used);
+				if (write(context->out->fh, context->buffer, used) == -1)
+					fatal(IO_ERROR, "writing to file");
 				len = strlen(str);
-				write(context->out->fh, str, len);
-				write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
+				if (write(context->out->fh, str, len) == -1)
+					fatal(IO_ERROR, "writing to file");
+				if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
+					fatal(IO_ERROR, "writing to file");
 			}
 			freep(&str);
 		}
@@ -198,12 +207,14 @@ int write_cc_buffer_as_srt(struct eia608_screen *data, struct encoder_ctx *conte
 	++context->srt_counter;
 	sprintf(timeline, "%u%s", context->srt_counter, context->encoded_crlf);
 	used = encode_line(context, context->buffer, (unsigned char *)timeline);
-	write(context->out->fh, context->buffer, used);
+	if (write(context->out->fh, context->buffer, used) == -1)
+		fatal(IO_ERROR, "writing to file");
 
 	sprintf(timeline, "%02u:%02u:%02u,%03u --> %02u:%02u:%02u,%03u%s",
 		h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
 	used = encode_line(context, context->buffer, (unsigned char *)timeline);
-	write(context->out->fh, context->buffer, used);
+	if (write(context->out->fh, context->buffer, used) == -1)
+		fatal(IO_ERROR, "writing to file");
 
 	dbg_print(CCX_DMT_DECODER_608, "\n- - - SRT caption ( %d) - - -\n", context->srt_counter);
 	dbg_print(CCX_DMT_DECODER_608, "%s", timeline);
@@ -262,7 +273,8 @@ int write_cc_buffer_as_srt(struct eia608_screen *data, struct encoder_ctx *conte
 					do_dash = 0;
 
 				if (do_dash)
-					write(context->out->fh, "- ", 2);
+					if (write(context->out->fh, "- ", 2) == -1)
+						fatal(IO_ERROR, "writing to file");
 				prev_line_start = first;
 				prev_line_end = last;
 				prev_line_center1 = center1;
@@ -274,8 +286,10 @@ int write_cc_buffer_as_srt(struct eia608_screen *data, struct encoder_ctx *conte
 				dbg_print(CCX_DMT_DECODER_608, "\r");
 				dbg_print(CCX_DMT_DECODER_608, "%s\n", context->subline);
 			}
-			write(context->out->fh, context->subline, length);
-			write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
+			if (write(context->out->fh, context->subline, length) == -1)
+				fatal(IO_ERROR, "writing to file");
+			if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
+				fatal(IO_ERROR, "writing to file");
 			wrote_something = 1;
 			// fprintf (wb->fh,context->encoded_crlf);
 		}
@@ -283,7 +297,8 @@ int write_cc_buffer_as_srt(struct eia608_screen *data, struct encoder_ctx *conte
 	dbg_print(CCX_DMT_DECODER_608, "- - - - - - - - - - - -\r\n");
 
 	// fprintf (wb->fh, context->encoded_crlf);
-	write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
+	if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
+		fatal(IO_ERROR, "writing to file");
 	//printf("$ = %s\n",context->encoded_crlf);
 	return wrote_something;
 }

--- a/src/lib_ccx/ccx_encoders_srt.c
+++ b/src/lib_ccx/ccx_encoders_srt.c
@@ -23,16 +23,14 @@ int write_stringz_as_srt(char *string, struct encoder_ctx *context, LLONG ms_sta
 	context->srt_counter++;
 	sprintf(timeline, "%u%s", context->srt_counter, context->encoded_crlf);
 	used = encode_line(context, context->buffer, (unsigned char *)timeline);
-	if (write(context->out->fh, context->buffer, used) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(context->out->fh, context->buffer, used);
 	sprintf(timeline, "%02u:%02u:%02u,%03u --> %02u:%02u:%02u,%03u%s",
 		h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
 	used = encode_line(context, context->buffer, (unsigned char *)timeline);
 	dbg_print(CCX_DMT_DECODER_608, "\n- - - SRT caption - - -\n");
 	dbg_print(CCX_DMT_DECODER_608, "%s", timeline);
 
-	if (write(context->out->fh, context->buffer, used) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(context->out->fh, context->buffer, used);
 	int len = strlen(string);
 	unsigned char *unescaped = (unsigned char *)malloc(len + 1);
 	unsigned char *el = (unsigned char *)malloc(len * 3 + 1); // Be generous
@@ -66,17 +64,14 @@ int write_stringz_as_srt(char *string, struct encoder_ctx *context, LLONG ms_sta
 			dbg_print(CCX_DMT_DECODER_608, "\r");
 			dbg_print(CCX_DMT_DECODER_608, "%s\n", context->subline);
 		}
-		if (write(context->out->fh, el, u) == -1)
-			fatal(IO_ERROR, "writing to file");
-		if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
-			fatal(IO_ERROR, "writing to file");
+		write_wrapped(context->out->fh, el, u);
+		write_wrapped(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 		begin += strlen((const char *)begin) + 1;
 	}
 
 	dbg_print(CCX_DMT_DECODER_608, "- - - - - - - - - - - -\r\n");
 
-	if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 	free(el);
 	free(unescaped);
 
@@ -119,18 +114,14 @@ int write_cc_bitmap_as_srt(struct cc_subtitle *sub, struct encoder_ctx *context)
 				context->srt_counter++;
 				sprintf(timeline, "%u%s", context->srt_counter, context->encoded_crlf);
 				used = encode_line(context, context->buffer, (unsigned char *)timeline);
-				if (write(context->out->fh, context->buffer, used) == -1)
-					fatal(IO_ERROR, "writing to file");
+				write_wrapped(context->out->fh, context->buffer, used);
 				sprintf(timeline, "%02u:%02u:%02u,%03u --> %02u:%02u:%02u,%03u%s",
 					h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
 				used = encode_line(context, context->buffer, (unsigned char *)timeline);
-				if (write(context->out->fh, context->buffer, used) == -1)
-					fatal(IO_ERROR, "writing to file");
+				write_wrapped(context->out->fh, context->buffer, used);
 				len = strlen(str);
-				if (write(context->out->fh, str, len) == -1)
-					fatal(IO_ERROR, "writing to file");
-				if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
-					fatal(IO_ERROR, "writing to file");
+				write_wrapped(context->out->fh, str, len);
+				write_wrapped(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 			}
 			freep(&str);
 		}
@@ -207,14 +198,12 @@ int write_cc_buffer_as_srt(struct eia608_screen *data, struct encoder_ctx *conte
 	++context->srt_counter;
 	sprintf(timeline, "%u%s", context->srt_counter, context->encoded_crlf);
 	used = encode_line(context, context->buffer, (unsigned char *)timeline);
-	if (write(context->out->fh, context->buffer, used) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(context->out->fh, context->buffer, used);
 
 	sprintf(timeline, "%02u:%02u:%02u,%03u --> %02u:%02u:%02u,%03u%s",
 		h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
 	used = encode_line(context, context->buffer, (unsigned char *)timeline);
-	if (write(context->out->fh, context->buffer, used) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(context->out->fh, context->buffer, used);
 
 	dbg_print(CCX_DMT_DECODER_608, "\n- - - SRT caption ( %d) - - -\n", context->srt_counter);
 	dbg_print(CCX_DMT_DECODER_608, "%s", timeline);
@@ -273,8 +262,7 @@ int write_cc_buffer_as_srt(struct eia608_screen *data, struct encoder_ctx *conte
 					do_dash = 0;
 
 				if (do_dash)
-					if (write(context->out->fh, "- ", 2) == -1)
-						fatal(IO_ERROR, "writing to file");
+					write_wrapped(context->out->fh, "- ", 2);
 				prev_line_start = first;
 				prev_line_end = last;
 				prev_line_center1 = center1;
@@ -286,10 +274,8 @@ int write_cc_buffer_as_srt(struct eia608_screen *data, struct encoder_ctx *conte
 				dbg_print(CCX_DMT_DECODER_608, "\r");
 				dbg_print(CCX_DMT_DECODER_608, "%s\n", context->subline);
 			}
-			if (write(context->out->fh, context->subline, length) == -1)
-				fatal(IO_ERROR, "writing to file");
-			if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
-				fatal(IO_ERROR, "writing to file");
+			write_wrapped(context->out->fh, context->subline, length);
+			write_wrapped(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 			wrote_something = 1;
 			// fprintf (wb->fh,context->encoded_crlf);
 		}
@@ -297,8 +283,7 @@ int write_cc_buffer_as_srt(struct eia608_screen *data, struct encoder_ctx *conte
 	dbg_print(CCX_DMT_DECODER_608, "- - - - - - - - - - - -\r\n");
 
 	// fprintf (wb->fh, context->encoded_crlf);
-	if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 	//printf("$ = %s\n",context->encoded_crlf);
 	return wrote_something;
 }

--- a/src/lib_ccx/ccx_encoders_ssa.c
+++ b/src/lib_ccx/ccx_encoders_ssa.c
@@ -24,8 +24,7 @@ int write_stringz_as_ssa(char *string, struct encoder_ctx *context, LLONG ms_sta
 	dbg_print(CCX_DMT_DECODER_608, "\n- - - ASS/SSA caption - - -\n");
 	dbg_print(CCX_DMT_DECODER_608, "%s", timeline);
 
-	if (write(context->out->fh, context->buffer, used) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(context->out->fh, context->buffer, used);
 	int len = strlen(string);
 	unsigned char *unescaped = (unsigned char *)malloc(len + 1);
 	unsigned char *el = (unsigned char *)malloc(len * 3 + 1); // Be generous
@@ -59,17 +58,14 @@ int write_stringz_as_ssa(char *string, struct encoder_ctx *context, LLONG ms_sta
 			dbg_print(CCX_DMT_DECODER_608, "\r");
 			dbg_print(CCX_DMT_DECODER_608, "%s\n", context->subline);
 		}
-		if (write(context->out->fh, el, u) == -1)
-			fatal(IO_ERROR, "writing to file");
-		if (write(context->out->fh, "\\N", 2) == -1)
-			fatal(IO_ERROR, "writing to file");
+		write_wrapped(context->out->fh, el, u);
+		write_wrapped(context->out->fh, "\\N", 2);
 		begin += strlen((const char *)begin) + 1;
 	}
 
 	dbg_print(CCX_DMT_DECODER_608, "- - - - - - - - - - - -\r\n");
 
-	if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 	free(el);
 	free(unescaped);
 
@@ -117,12 +113,9 @@ int write_cc_bitmap_as_ssa(struct cc_subtitle *sub, struct encoder_ctx *context)
 			sprintf(timeline, "Dialogue: 0,%02u:%02u:%02u.%01u,%02u:%02u:%02u.%02u,Default,,0000,0000,0000,,",
 				h1, m1, s1, ms1 / 10, h2, m2, s2, ms2 / 10);
 			used = encode_line(context, context->buffer, (unsigned char *)timeline);
-			if (write(context->out->fh, context->buffer, used) == -1)
-				fatal(IO_ERROR, "writing to file");
-			if (write(context->out->fh, str, len) == -1)
-				fatal(IO_ERROR, "writing to file");
-			if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
-				fatal(IO_ERROR, "writing to file");
+			write_wrapped(context->out->fh, context->buffer, used);
+			write_wrapped(context->out->fh, str, len);
+			write_wrapped(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 		}
 		freep(&str);
 	}
@@ -195,8 +188,7 @@ int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *conte
 	dbg_print(CCX_DMT_DECODER_608, "\n- - - ASS/SSA caption - - -\n");
 	dbg_print(CCX_DMT_DECODER_608, "%s", timeline);
 
-	if (write(context->out->fh, context->buffer, used) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(context->out->fh, context->buffer, used);
 	int line_count = 0;
 	for (int i = 0; i < 15; i++)
 	{
@@ -252,8 +244,7 @@ int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *conte
 					do_dash = 0;
 
 				if (do_dash)
-					if (write(context->out->fh, "- ", 2) == -1)
-						fatal(IO_ERROR, "writing to file");
+					write_wrapped(context->out->fh, "- ", 2);
 				prev_line_start = first;
 				prev_line_end = last;
 				prev_line_center1 = center1;
@@ -267,11 +258,9 @@ int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *conte
 			}
 			if (line_count)
 			{
-				if (write(context->out->fh, "\\N", 2) == -1)
-					fatal(IO_ERROR, "writing to file");
+				write_wrapped(context->out->fh, "\\N", 2);
 			}
-			if (write(context->out->fh, context->subline, length) == -1)
-				fatal(IO_ERROR, "writing to file");
+			write_wrapped(context->out->fh, context->subline, length);
 			line_count++;
 			wrote_something = 1;
 		}
@@ -279,7 +268,6 @@ int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *conte
 
 	dbg_print(CCX_DMT_DECODER_608, "- - - - - - - - - - - -\r\n");
 
-	if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
-		fatal(IO_ERROR, "writing to file");
+	write_wrapped(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 	return wrote_something;
 }

--- a/src/lib_ccx/ccx_encoders_ssa.c
+++ b/src/lib_ccx/ccx_encoders_ssa.c
@@ -24,7 +24,8 @@ int write_stringz_as_ssa(char *string, struct encoder_ctx *context, LLONG ms_sta
 	dbg_print(CCX_DMT_DECODER_608, "\n- - - ASS/SSA caption - - -\n");
 	dbg_print(CCX_DMT_DECODER_608, "%s", timeline);
 
-	write(context->out->fh, context->buffer, used);
+	if (write(context->out->fh, context->buffer, used) == -1)
+		fatal(IO_ERROR, "writing to file");
 	int len = strlen(string);
 	unsigned char *unescaped = (unsigned char *)malloc(len + 1);
 	unsigned char *el = (unsigned char *)malloc(len * 3 + 1); // Be generous
@@ -58,14 +59,17 @@ int write_stringz_as_ssa(char *string, struct encoder_ctx *context, LLONG ms_sta
 			dbg_print(CCX_DMT_DECODER_608, "\r");
 			dbg_print(CCX_DMT_DECODER_608, "%s\n", context->subline);
 		}
-		write(context->out->fh, el, u);
-		write(context->out->fh, "\\N", 2);
+		if (write(context->out->fh, el, u) == -1)
+			fatal(IO_ERROR, "writing to file");
+		if (write(context->out->fh, "\\N", 2) == -1)
+			fatal(IO_ERROR, "writing to file");
 		begin += strlen((const char *)begin) + 1;
 	}
 
 	dbg_print(CCX_DMT_DECODER_608, "- - - - - - - - - - - -\r\n");
 
-	write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
+	if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
+		fatal(IO_ERROR, "writing to file");
 	free(el);
 	free(unescaped);
 
@@ -113,9 +117,12 @@ int write_cc_bitmap_as_ssa(struct cc_subtitle *sub, struct encoder_ctx *context)
 			sprintf(timeline, "Dialogue: 0,%02u:%02u:%02u.%01u,%02u:%02u:%02u.%02u,Default,,0000,0000,0000,,",
 				h1, m1, s1, ms1 / 10, h2, m2, s2, ms2 / 10);
 			used = encode_line(context, context->buffer, (unsigned char *)timeline);
-			write(context->out->fh, context->buffer, used);
-			write(context->out->fh, str, len);
-			write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
+			if (write(context->out->fh, context->buffer, used) == -1)
+				fatal(IO_ERROR, "writing to file");
+			if (write(context->out->fh, str, len) == -1)
+				fatal(IO_ERROR, "writing to file");
+			if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
+				fatal(IO_ERROR, "writing to file");
 		}
 		freep(&str);
 	}
@@ -188,7 +195,8 @@ int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *conte
 	dbg_print(CCX_DMT_DECODER_608, "\n- - - ASS/SSA caption - - -\n");
 	dbg_print(CCX_DMT_DECODER_608, "%s", timeline);
 
-	write(context->out->fh, context->buffer, used);
+	if (write(context->out->fh, context->buffer, used) == -1)
+		fatal(IO_ERROR, "writing to file");
 	int line_count = 0;
 	for (int i = 0; i < 15; i++)
 	{
@@ -244,7 +252,8 @@ int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *conte
 					do_dash = 0;
 
 				if (do_dash)
-					write(context->out->fh, "- ", 2);
+					if (write(context->out->fh, "- ", 2) == -1)
+						fatal(IO_ERROR, "writing to file");
 				prev_line_start = first;
 				prev_line_end = last;
 				prev_line_center1 = center1;
@@ -258,9 +267,11 @@ int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *conte
 			}
 			if (line_count)
 			{
-				write(context->out->fh, "\\N", 2);
+				if (write(context->out->fh, "\\N", 2) == -1)
+					fatal(IO_ERROR, "writing to file");
 			}
-			write(context->out->fh, context->subline, length);
+			if (write(context->out->fh, context->subline, length) == -1)
+				fatal(IO_ERROR, "writing to file");
 			line_count++;
 			wrote_something = 1;
 		}
@@ -268,6 +279,7 @@ int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *conte
 
 	dbg_print(CCX_DMT_DECODER_608, "- - - - - - - - - - - -\r\n");
 
-	write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
+	if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
+		fatal(IO_ERROR, "writing to file");
 	return wrote_something;
 }

--- a/src/lib_ccx/ccx_encoders_transcript.c
+++ b/src/lib_ccx/ccx_encoders_transcript.c
@@ -96,8 +96,7 @@ int write_cc_bitmap_as_transcript(struct cc_subtitle *sub, struct encoder_ctx *c
 				}
 			}
 
-			if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
-				fatal(IO_ERROR, "writing to file");
+			write_wrapped(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 		}
 	}
 #endif

--- a/src/lib_ccx/ccx_encoders_transcript.c
+++ b/src/lib_ccx/ccx_encoders_transcript.c
@@ -96,7 +96,8 @@ int write_cc_bitmap_as_transcript(struct cc_subtitle *sub, struct encoder_ctx *c
 				}
 			}
 
-			write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
+			if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
+				fatal(IO_ERROR, "writing to file");
 		}
 	}
 #endif

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -222,7 +222,8 @@ void write_webvtt_header(struct encoder_ctx *context)
 				ccx_options.enc_cfg.line_terminator_lf ? "\n\n" : "\r\n\r\n");
 		}
 		used = encode_line(context, context->buffer, (unsigned char *)header_string);
-		write(context->out->fh, context->buffer, used);
+		if (write(context->out->fh, context->buffer, used) == -1)
+			fatal(IO_ERROR, "writing to file");
 	}
 
 	if (ccx_options.webvtt_create_css)
@@ -242,21 +243,27 @@ void write_webvtt_header(struct encoder_ctx *context)
 
 		char *outline_css_file = (char *)malloc((strlen(css_file_name) + strlen(webvtt_outline_css)) * sizeof(char));
 		sprintf(outline_css_file, webvtt_outline_css, css_file_name);
-		write(context->out->fh, outline_css_file, strlen(outline_css_file));
+		if (write(context->out->fh, outline_css_file, strlen(outline_css_file)) == -1)
+			fatal(IO_ERROR, "writing to file");
 	}
 	else if (ccx_options.use_webvtt_styling)
 	{
-		write(context->out->fh, webvtt_inline_css, strlen(webvtt_inline_css));
+		if (write(context->out->fh, webvtt_inline_css, strlen(webvtt_inline_css)) == -1)
+			fatal(IO_ERROR, "writing to file");
 		if (ccx_options.enc_cfg.line_terminator_lf == 1) // If -lf parameter is set.
 		{
-			write(context->out->fh, "\n", 1);
+			if (write(context->out->fh, "\n", 1) == -1)
+				fatal(IO_ERROR, "writing to file");
 		}
 		else
 		{
-			write(context->out->fh, "\r\n", 2);
+			if (write(context->out->fh, "\r\n", 2) == -1)
+				fatal(IO_ERROR, "writing to file");
 		}
-		write(context->out->fh, "##\n", 3);
-		write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
+		if (write(context->out->fh, "##\n", 3) == -1)
+			fatal(IO_ERROR, "writing to file");
+		if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
+			fatal(IO_ERROR, "writing to file");
 	}
 
 	context->wrote_webvtt_header = 1; // Do it even if couldn't write the header, because it won't be possible anyway
@@ -294,10 +301,13 @@ int write_cc_bitmap_as_webvtt(struct cc_subtitle *sub, struct encoder_ctx *conte
 			sprintf(timeline, "%02u:%02u:%02u.%03u --> %02u:%02u:%02u.%03u%s",
 				h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
 			used = encode_line(context, context->buffer, (unsigned char *)timeline);
-			write(context->out->fh, context->buffer, used);
+			if (write(context->out->fh, context->buffer, used) == -1)
+				fatal(IO_ERROR, "writing to file");
 			len = strlen(str);
-			write(context->out->fh, str, len);
-			write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
+			if (write(context->out->fh, str, len) == -1)
+				fatal(IO_ERROR, "writing to file");
+			if (write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length) == -1)
+				fatal(IO_ERROR, "writing to file");
 		}
 		freep(&str);
 	}
@@ -467,24 +477,30 @@ int write_cc_buffer_as_webvtt(struct eia608_screen *data, struct encoder_ctx *co
 					if (open_font != FONT_REGULAR)
 					{
 						if (open_font & FONT_ITALICS)
-							write(context->out->fh, strdup("<i>"), 3);
+							if (write(context->out->fh, strdup("<i>"), 3) == -1)
+								fatal(IO_ERROR, "writing to file");
 						if (open_font & FONT_UNDERLINED)
-							write(context->out->fh, strdup("<u>"), 3);
+							if (write(context->out->fh, strdup("<u>"), 3) == -1)
+								fatal(IO_ERROR, "writing to file");
 					}
 
 					// opening events for colors
 					int open_color = color_events[j] & 0xFF; // Last 16 bytes
 					if (open_color != COL_WHITE)
 					{
-						write(context->out->fh, strdup("<c."), 3);
-						write(context->out->fh, color_text[open_color][0], strlen(color_text[open_color][0]));
-						write(context->out->fh, ">", 1);
+						if (write(context->out->fh, strdup("<c."), 3) == -1)
+							fatal(IO_ERROR, "writing to file");
+						if (write(context->out->fh, color_text[open_color][0], strlen(color_text[open_color][0])) == -1)
+							fatal(IO_ERROR, "writing to file");
+						if (write(context->out->fh, ">", 1) == -1)
+							fatal(IO_ERROR, "writing to file");
 					}
 				}
 
 				// write current text symbol
 				if (context->subline[j] != '\0')
-					write(context->out->fh, &(context->subline[j]), 1);
+					if (write(context->out->fh, &(context->subline[j]), 1) == -1)
+						fatal(IO_ERROR, "writing to file");
 
 				if (ccx_options.use_webvtt_styling)
 				{
@@ -492,7 +508,8 @@ int write_cc_buffer_as_webvtt(struct eia608_screen *data, struct encoder_ctx *co
 					int close_color = color_events[j] >> 16; // First 16 bytes
 					if (close_color != COL_WHITE)
 					{
-						write(context->out->fh, strdup("</c>"), 4);
+						if (write(context->out->fh, strdup("</c>"), 4) == -1)
+							fatal(IO_ERROR, "writing to file");
 					}
 
 					// closing events for fonts
@@ -500,9 +517,11 @@ int write_cc_buffer_as_webvtt(struct eia608_screen *data, struct encoder_ctx *co
 					if (close_font != FONT_REGULAR)
 					{
 						if (close_font & FONT_ITALICS)
-							write(context->out->fh, strdup("</i>"), 4);
+							if (write(context->out->fh, strdup("</i>"), 4) == -1)
+								fatal(IO_ERROR, "writing to file");
 						if (close_font & FONT_UNDERLINED)
-							write(context->out->fh, strdup("</u>"), 4);
+							if (write(context->out->fh, strdup("</u>"), 4) == -1)
+								fatal(IO_ERROR, "writing to file");
 					}
 				}
 			}

--- a/src/lib_ccx/file_functions.c
+++ b/src/lib_ccx/file_functions.c
@@ -461,7 +461,7 @@ size_t buffered_read_opt(struct ccx_demuxer *ctx, unsigned char *buffer, size_t 
 				char c;
 				for (size_t i = 0; i < bytes; i++)
 					if (read(ctx->infd, &c, 1) == -1)
-						fatal(IO_ERROR, "reading from file");
+						fatal(1, "reading from file");
 				copied = bytes;
 			}
 			else

--- a/src/lib_ccx/file_functions.c
+++ b/src/lib_ccx/file_functions.c
@@ -460,7 +460,8 @@ size_t buffered_read_opt(struct ccx_demuxer *ctx, unsigned char *buffer, size_t 
 			{
 				char c;
 				for (size_t i = 0; i < bytes; i++)
-					read(ctx->infd, &c, 1);
+					if (read(ctx->infd, &c, 1) == -1)
+						fatal(IO_ERROR, "reading from file");
 				copied = bytes;
 			}
 			else

--- a/src/lib_ccx/matroska.c
+++ b/src/lib_ccx/matroska.c
@@ -25,14 +25,16 @@ ULLONG get_current_byte(FILE *file)
 UBYTE *read_byte_block(FILE *file, ULLONG n)
 {
 	UBYTE *buffer = malloc((size_t)(sizeof(UBYTE) * n));
-	fread(buffer, 1, (size_t)n, file);
+	if (fread(buffer, 1, (size_t)n, file) != n)
+		fatal(IO_ERROR, "reading from file");
 	return buffer;
 }
 
 char *read_bytes_signed(FILE *file, ULLONG n)
 {
 	char *buffer = malloc((size_t)(sizeof(UBYTE) * (n + 1)));
-	fread(buffer, 1, (size_t)n, file);
+	if (fread(buffer, 1, (size_t)n, file) != n)
+		fatal(IO_ERROR, "reading from file");
 	buffer[n] = 0;
 	return buffer;
 }
@@ -1109,7 +1111,8 @@ void save_sub_track(struct matroska_ctx *mkv_ctx, struct matroska_sub_track *tra
 	free(filename);
 
 	if (track->header != NULL)
-		write(desc, track->header, strlen(track->header));
+		if (write(desc, track->header, strlen(track->header)) == -1)
+			fatal(IO_ERROR, "writing to file");
 
 	for (int i = 0; i < track->sentence_count; i++)
 	{
@@ -1118,7 +1121,8 @@ void save_sub_track(struct matroska_ctx *mkv_ctx, struct matroska_sub_track *tra
 
 		if (track->codec_id == MATROSKA_TRACK_SUBTITLE_CODEC_ID_WEBVTT)
 		{
-			write(desc, "\n\n", 2);
+			if (write(desc, "\n\n", 2) == -1)
+				fatal(IO_ERROR, "writing to file");
 
 			struct block_addition *blockaddition = sentence->blockaddition;
 
@@ -1127,8 +1131,10 @@ void save_sub_track(struct matroska_ctx *mkv_ctx, struct matroska_sub_track *tra
 			{
 				if (blockaddition->comment != NULL)
 				{
-					write(desc, sentence->blockaddition->comment, sentence->blockaddition->comment_size);
-					write(desc, "\n", 1);
+					if (write(desc, sentence->blockaddition->comment, sentence->blockaddition->comment_size) == -1)
+						fatal(IO_ERROR, "writing to file");
+					if (write(desc, "\n", 1) == -1)
+						fatal(IO_ERROR, "writing to file");
 				}
 			}
 
@@ -1137,12 +1143,15 @@ void save_sub_track(struct matroska_ctx *mkv_ctx, struct matroska_sub_track *tra
 			{
 				if (blockaddition->cue_identifier != NULL)
 				{
-					write(desc, blockaddition->cue_identifier, blockaddition->cue_identifier_size);
-					write(desc, "\n", 1);
+					if (write(desc, blockaddition->cue_identifier, blockaddition->cue_identifier_size) == -1)
+						fatal(IO_ERROR, "writing to file");
+					if (write(desc, "\n", 1) == -1)
+						fatal(IO_ERROR, "writing to file");
 				}
 				else if (blockaddition->comment != NULL)
 				{
-					write(desc, "\n", 1);
+					if (write(desc, "\n", 1) == -1)
+						fatal(IO_ERROR, "writing to file");
 				}
 			}
 
@@ -1155,25 +1164,32 @@ void save_sub_track(struct matroska_ctx *mkv_ctx, struct matroska_sub_track *tra
 			char *timestamp_end = malloc(sizeof(char) * 80);
 			timestamp_to_vtttime(time_end, timestamp_end);
 
-			write(desc, timestamp_start, strlen(timestamp_start));
-			write(desc, " --> ", 5);
-			write(desc, timestamp_end, strlen(timestamp_start));
+			if (write(desc, timestamp_start, strlen(timestamp_start)) == -1)
+				fatal(IO_ERROR, "writing to file");
+			if (write(desc, " --> ", 5) == -1)
+				fatal(IO_ERROR, "writing to file");
+			if (write(desc, timestamp_end, strlen(timestamp_start)) == -1)
+				fatal(IO_ERROR, "writing to file");
 
 			// writing cue settings list
 			if (blockaddition != NULL)
 			{
 				if (blockaddition->cue_settings_list != NULL)
 				{
-					write(desc, " ", 1);
-					write(desc, blockaddition->cue_settings_list, blockaddition->cue_settings_list_size);
+					if (write(desc, " ", 1) == -1)
+						fatal(IO_ERROR, "writing to file");
+					if (write(desc, blockaddition->cue_settings_list, blockaddition->cue_settings_list_size) == -1)
+						fatal(IO_ERROR, "writing to file");
 				}
 			}
-			write(desc, "\n", 1);
+			if (write(desc, "\n", 1) == -1)
+				fatal(IO_ERROR, "writing to file");
 
 			int size = 0;
 			while (*(sentence->text + size) == '\n' || *(sentence->text + size) == '\r')
 				size++;
-			write(desc, sentence->text + size, sentence->text_size - size);
+			if (write(desc, sentence->text + size, sentence->text_size - size) == -1)
+				fatal(IO_ERROR, "writing to file");
 
 			free(timestamp_start);
 			free(timestamp_end);
@@ -1190,24 +1206,33 @@ void save_sub_track(struct matroska_ctx *mkv_ctx, struct matroska_sub_track *tra
 			char *timestamp_end = malloc(sizeof(char) * 80);
 			timestamp_to_srttime(time_end, timestamp_end);
 
-			write(desc, number, strlen(number));
-			write(desc, "\n", 1);
-			write(desc, timestamp_start, strlen(timestamp_start));
-			write(desc, " --> ", 5);
-			write(desc, timestamp_end, strlen(timestamp_start));
-			write(desc, "\n", 1);
+			if (write(desc, number, strlen(number)) == -1)
+				fatal(IO_ERROR, "writing to file");
+			if (write(desc, "\n", 1) == -1)
+				fatal(IO_ERROR, "writing to file");
+			if (write(desc, timestamp_start, strlen(timestamp_start)) == -1)
+				fatal(IO_ERROR, "writing to file");
+			if (write(desc, " --> ", 5) == -1)
+				fatal(IO_ERROR, "writing to file");
+			if (write(desc, timestamp_end, strlen(timestamp_start)) == -1)
+				fatal(IO_ERROR, "writing to file");
+			if (write(desc, "\n", 1) == -1)
+				fatal(IO_ERROR, "writing to file");
 			int size = 0;
 			while (*(sentence->text + size) == '\n' || *(sentence->text + size) == '\r')
 				size++;
-			write(desc, sentence->text + size, sentence->text_size - size);
+			if (write(desc, sentence->text + size, sentence->text_size - size) == -1)
+				fatal(IO_ERROR, "writing to file");
 
 			if (sentence->text[sentence->text_size - 1] == '\n')
 			{
-				write(desc, "\n", 1);
+				if (write(desc, "\n", 1) == -1)
+					fatal(IO_ERROR, "writing to file");
 			}
 			else
 			{
-				write(desc, "\n\n", 2);
+				if (write(desc, "\n\n", 2) == -1)
+					fatal(IO_ERROR, "writing to file");
 			}
 
 			free(timestamp_start);
@@ -1221,16 +1246,23 @@ void save_sub_track(struct matroska_ctx *mkv_ctx, struct matroska_sub_track *tra
 				time_end = MIN(time_end, track->sentences[i + 1]->time_start - 1);
 			char *timestamp_end = generate_timestamp_ass_ssa(time_end);
 
-			write(desc, "Dialogue: Marked=0,", strlen("Dialogue: Marked=0,"));
-			write(desc, timestamp_start, strlen(timestamp_start));
-			write(desc, ",", 1);
-			write(desc, timestamp_end, strlen(timestamp_start));
-			write(desc, ",", 1);
+			if (write(desc, "Dialogue: Marked=0,", strlen("Dialogue: Marked=0,")) == -1)
+				fatal(IO_ERROR, "writing to file");
+			if (write(desc, timestamp_start, strlen(timestamp_start)) == -1)
+				fatal(IO_ERROR, "writing to file");
+			if (write(desc, ",", 1) == -1)
+				fatal(IO_ERROR, "writing to file");
+			if (write(desc, timestamp_end, strlen(timestamp_start)) == -1)
+				fatal(IO_ERROR, "writing to file");
+			if (write(desc, ",", 1) == -1)
+				fatal(IO_ERROR, "writing to file");
 			char *text = ass_ssa_sentence_erase_read_order(sentence->text);
 			while ((text[0] == '\\') && (text[1] == 'n' || text[1] == 'N'))
 				text += 2;
-			write(desc, text, strlen(text));
-			write(desc, "\n", 1);
+			if (write(desc, text, strlen(text)) == -1)
+				fatal(IO_ERROR, "writing to file");
+			if (write(desc, "\n", 1) == -1)
+				fatal(IO_ERROR, "writing to file");
 
 			free(timestamp_start);
 			free(timestamp_end);

--- a/src/lib_ccx/matroska.c
+++ b/src/lib_ccx/matroska.c
@@ -26,7 +26,7 @@ UBYTE *read_byte_block(FILE *file, ULLONG n)
 {
 	UBYTE *buffer = malloc((size_t)(sizeof(UBYTE) * n));
 	if (fread(buffer, 1, (size_t)n, file) != n)
-		fatal(IO_ERROR, "reading from file");
+		fatal(1, "reading from file");
 	return buffer;
 }
 
@@ -34,7 +34,7 @@ char *read_bytes_signed(FILE *file, ULLONG n)
 {
 	char *buffer = malloc((size_t)(sizeof(UBYTE) * (n + 1)));
 	if (fread(buffer, 1, (size_t)n, file) != n)
-		fatal(IO_ERROR, "reading from file");
+		fatal(1, "reading from file");
 	buffer[n] = 0;
 	return buffer;
 }
@@ -1111,8 +1111,7 @@ void save_sub_track(struct matroska_ctx *mkv_ctx, struct matroska_sub_track *tra
 	free(filename);
 
 	if (track->header != NULL)
-		if (write(desc, track->header, strlen(track->header)) == -1)
-			fatal(IO_ERROR, "writing to file");
+		write_wrapped(desc, track->header, strlen(track->header));
 
 	for (int i = 0; i < track->sentence_count; i++)
 	{
@@ -1121,8 +1120,7 @@ void save_sub_track(struct matroska_ctx *mkv_ctx, struct matroska_sub_track *tra
 
 		if (track->codec_id == MATROSKA_TRACK_SUBTITLE_CODEC_ID_WEBVTT)
 		{
-			if (write(desc, "\n\n", 2) == -1)
-				fatal(IO_ERROR, "writing to file");
+			write_wrapped(desc, "\n\n", 2);
 
 			struct block_addition *blockaddition = sentence->blockaddition;
 
@@ -1131,10 +1129,8 @@ void save_sub_track(struct matroska_ctx *mkv_ctx, struct matroska_sub_track *tra
 			{
 				if (blockaddition->comment != NULL)
 				{
-					if (write(desc, sentence->blockaddition->comment, sentence->blockaddition->comment_size) == -1)
-						fatal(IO_ERROR, "writing to file");
-					if (write(desc, "\n", 1) == -1)
-						fatal(IO_ERROR, "writing to file");
+					write_wrapped(desc, sentence->blockaddition->comment, sentence->blockaddition->comment_size);
+					write_wrapped(desc, "\n", 1);
 				}
 			}
 
@@ -1143,15 +1139,12 @@ void save_sub_track(struct matroska_ctx *mkv_ctx, struct matroska_sub_track *tra
 			{
 				if (blockaddition->cue_identifier != NULL)
 				{
-					if (write(desc, blockaddition->cue_identifier, blockaddition->cue_identifier_size) == -1)
-						fatal(IO_ERROR, "writing to file");
-					if (write(desc, "\n", 1) == -1)
-						fatal(IO_ERROR, "writing to file");
+					write_wrapped(desc, blockaddition->cue_identifier, blockaddition->cue_identifier_size);
+					write_wrapped(desc, "\n", 1);
 				}
 				else if (blockaddition->comment != NULL)
 				{
-					if (write(desc, "\n", 1) == -1)
-						fatal(IO_ERROR, "writing to file");
+					write_wrapped(desc, "\n", 1);
 				}
 			}
 
@@ -1164,32 +1157,25 @@ void save_sub_track(struct matroska_ctx *mkv_ctx, struct matroska_sub_track *tra
 			char *timestamp_end = malloc(sizeof(char) * 80);
 			timestamp_to_vtttime(time_end, timestamp_end);
 
-			if (write(desc, timestamp_start, strlen(timestamp_start)) == -1)
-				fatal(IO_ERROR, "writing to file");
-			if (write(desc, " --> ", 5) == -1)
-				fatal(IO_ERROR, "writing to file");
-			if (write(desc, timestamp_end, strlen(timestamp_start)) == -1)
-				fatal(IO_ERROR, "writing to file");
+			write_wrapped(desc, timestamp_start, strlen(timestamp_start));
+			write_wrapped(desc, " --> ", 5);
+			write_wrapped(desc, timestamp_end, strlen(timestamp_start));
 
 			// writing cue settings list
 			if (blockaddition != NULL)
 			{
 				if (blockaddition->cue_settings_list != NULL)
 				{
-					if (write(desc, " ", 1) == -1)
-						fatal(IO_ERROR, "writing to file");
-					if (write(desc, blockaddition->cue_settings_list, blockaddition->cue_settings_list_size) == -1)
-						fatal(IO_ERROR, "writing to file");
+					write_wrapped(desc, " ", 1);
+					write_wrapped(desc, blockaddition->cue_settings_list, blockaddition->cue_settings_list_size);
 				}
 			}
-			if (write(desc, "\n", 1) == -1)
-				fatal(IO_ERROR, "writing to file");
+			write_wrapped(desc, "\n", 1);
 
 			int size = 0;
 			while (*(sentence->text + size) == '\n' || *(sentence->text + size) == '\r')
 				size++;
-			if (write(desc, sentence->text + size, sentence->text_size - size) == -1)
-				fatal(IO_ERROR, "writing to file");
+			write_wrapped(desc, sentence->text + size, sentence->text_size - size);
 
 			free(timestamp_start);
 			free(timestamp_end);
@@ -1206,33 +1192,24 @@ void save_sub_track(struct matroska_ctx *mkv_ctx, struct matroska_sub_track *tra
 			char *timestamp_end = malloc(sizeof(char) * 80);
 			timestamp_to_srttime(time_end, timestamp_end);
 
-			if (write(desc, number, strlen(number)) == -1)
-				fatal(IO_ERROR, "writing to file");
-			if (write(desc, "\n", 1) == -1)
-				fatal(IO_ERROR, "writing to file");
-			if (write(desc, timestamp_start, strlen(timestamp_start)) == -1)
-				fatal(IO_ERROR, "writing to file");
-			if (write(desc, " --> ", 5) == -1)
-				fatal(IO_ERROR, "writing to file");
-			if (write(desc, timestamp_end, strlen(timestamp_start)) == -1)
-				fatal(IO_ERROR, "writing to file");
-			if (write(desc, "\n", 1) == -1)
-				fatal(IO_ERROR, "writing to file");
+			write_wrapped(desc, number, strlen(number));
+			write_wrapped(desc, "\n", 1);
+			write_wrapped(desc, timestamp_start, strlen(timestamp_start));
+			write_wrapped(desc, " --> ", 5);
+			write_wrapped(desc, timestamp_end, strlen(timestamp_start));
+			write_wrapped(desc, "\n", 1);
 			int size = 0;
 			while (*(sentence->text + size) == '\n' || *(sentence->text + size) == '\r')
 				size++;
-			if (write(desc, sentence->text + size, sentence->text_size - size) == -1)
-				fatal(IO_ERROR, "writing to file");
+			write_wrapped(desc, sentence->text + size, sentence->text_size - size);
 
 			if (sentence->text[sentence->text_size - 1] == '\n')
 			{
-				if (write(desc, "\n", 1) == -1)
-					fatal(IO_ERROR, "writing to file");
+				write_wrapped(desc, "\n", 1);
 			}
 			else
 			{
-				if (write(desc, "\n\n", 2) == -1)
-					fatal(IO_ERROR, "writing to file");
+				write_wrapped(desc, "\n\n", 2);
 			}
 
 			free(timestamp_start);
@@ -1246,23 +1223,16 @@ void save_sub_track(struct matroska_ctx *mkv_ctx, struct matroska_sub_track *tra
 				time_end = MIN(time_end, track->sentences[i + 1]->time_start - 1);
 			char *timestamp_end = generate_timestamp_ass_ssa(time_end);
 
-			if (write(desc, "Dialogue: Marked=0,", strlen("Dialogue: Marked=0,")) == -1)
-				fatal(IO_ERROR, "writing to file");
-			if (write(desc, timestamp_start, strlen(timestamp_start)) == -1)
-				fatal(IO_ERROR, "writing to file");
-			if (write(desc, ",", 1) == -1)
-				fatal(IO_ERROR, "writing to file");
-			if (write(desc, timestamp_end, strlen(timestamp_start)) == -1)
-				fatal(IO_ERROR, "writing to file");
-			if (write(desc, ",", 1) == -1)
-				fatal(IO_ERROR, "writing to file");
+			write_wrapped(desc, "Dialogue: Marked=0,", strlen("Dialogue: Marked=0,"));
+			write_wrapped(desc, timestamp_start, strlen(timestamp_start));
+			write_wrapped(desc, ",", 1);
+			write_wrapped(desc, timestamp_end, strlen(timestamp_start));
+			write_wrapped(desc, ",", 1);
 			char *text = ass_ssa_sentence_erase_read_order(sentence->text);
 			while ((text[0] == '\\') && (text[1] == 'n' || text[1] == 'N'))
 				text += 2;
-			if (write(desc, text, strlen(text)) == -1)
-				fatal(IO_ERROR, "writing to file");
-			if (write(desc, "\n", 1) == -1)
-				fatal(IO_ERROR, "writing to file");
+			write_wrapped(desc, text, strlen(text));
+			write_wrapped(desc, "\n", 1);
 
 			free(timestamp_start);
 			free(timestamp_end);

--- a/src/lib_ccx/utility.c
+++ b/src/lib_ccx/utility.c
@@ -255,8 +255,14 @@ void print_error(int mode, const char *fmt, ...)
 
 void write_wrapped(int fd, const void *buf, size_t count)
 {
-	if (write(fd, buf, count) == -1)
-		fatal(1, "writing to file");
+	while (count)
+	{
+		ssize_t written = write(fd, buf, count);
+		if (written == -1)
+			fatal(1, "writing to file");
+		buf += written;
+		count -= written;
+	}
 }
 
 /* Write formatted message to stderr and then exit. */

--- a/src/lib_ccx/utility.c
+++ b/src/lib_ccx/utility.c
@@ -253,7 +253,7 @@ void print_error(int mode, const char *fmt, ...)
 	va_end(args);
 }
 
-void write_wrapped(int fd, const void *buf, size_t count)
+void write_wrapped(int fd, const char *buf, size_t count)
 {
 	while (count)
 	{

--- a/src/lib_ccx/utility.c
+++ b/src/lib_ccx/utility.c
@@ -252,6 +252,13 @@ void print_error(int mode, const char *fmt, ...)
 	fprintf(stderr, "\n");
 	va_end(args);
 }
+
+void write_wrapped(int fd, const void *buf, size_t count)
+{
+	if (write(fd, buf, count) == -1)
+		fatal(1, "writing to file");
+}
+
 /* Write formatted message to stderr and then exit. */
 void fatal(int exit_code, const char *fmt, ...)
 {

--- a/src/lib_ccx/utility.h
+++ b/src/lib_ccx/utility.h
@@ -48,6 +48,6 @@ char *strndup(const char *s, size_t n);
 char *strtok_r(char *str, const char *delim, char **saveptr);
 #endif //_WIN32
 
-void write_wrapped(int fd, const void *buf, size_t count);
+void write_wrapped(int fd, const char *buf, size_t count);
 
 #endif //CC_UTILITY_H

--- a/src/lib_ccx/utility.h
+++ b/src/lib_ccx/utility.h
@@ -18,8 +18,6 @@
 
 #define CCX_NOPTS	((int64_t)UINT64_C(0x8000000000000000))
 
-#define IO_ERROR 1
-
 struct ccx_rational
 {
 	int num;
@@ -49,5 +47,7 @@ int asprintf(char **strp, const char *fmt, ...);
 char *strndup(const char *s, size_t n);
 char *strtok_r(char *str, const char *delim, char **saveptr);
 #endif //_WIN32
+
+void write_wrapped(int fd, const void *buf, size_t count);
 
 #endif //CC_UTILITY_H

--- a/src/lib_ccx/utility.h
+++ b/src/lib_ccx/utility.h
@@ -18,6 +18,8 @@
 
 #define CCX_NOPTS	((int64_t)UINT64_C(0x8000000000000000))
 
+#define IO_ERROR 1
+
 struct ccx_rational
 {
 	int num;


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [X] I am an active contributor to CCExtractor.

---

Remove -Wunused-result warnings. The main reason to do this is that contributors aren't flooded with warnings which cause them to ignore them.

output diff:

```diff
244,307d243
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c: In function ‘_dtvcc_write_row’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c:194:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   194 |   write(fd, encoded_buf_start, encoded_buf - encoded_buf_start);
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c:200:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   200 |   write(fd, buf, buf_len);
<       |   ^~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c: In function ‘ccx_dtvcc_write_srt’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c:224:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   224 |  write(encoder->dtvcc_writers[tv->service_number - 1].fd, buf, strlen(buf));
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c:231:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   231 |    write(encoder->dtvcc_writers[tv->service_number - 1].fd,
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<   232 |          encoder->encoded_crlf, encoder->encoded_crlf_length);
<       |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c:235:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   235 |  write(encoder->dtvcc_writers[tv->service_number - 1].fd,
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<   236 |        encoder->encoded_crlf, encoder->encoded_crlf_length);
<       |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c: In function ‘ccx_dtvcc_write_transcript’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c:293:5: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   293 |     write(encoder->dtvcc_writers[tv->service_number - 1].fd, buf, strlen(buf));
<       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c:296:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   296 |    write(encoder->dtvcc_writers[tv->service_number - 1].fd,
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<   297 |          encoder->encoded_crlf, encoder->encoded_crlf_length);
<       |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c: In function ‘_dtvcc_write_sami_header’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c:324:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   324 |  write(encoder->dtvcc_writers[tv->service_number - 1].fd, buf, buf_len);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c: In function ‘_dtvcc_write_sami_footer’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c:331:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   331 |  write(encoder->dtvcc_writers[tv->service_number - 1].fd, buf, strlen(buf));
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c:332:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   332 |  write(encoder->dtvcc_writers[tv->service_number - 1].fd,
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<   333 |        encoder->encoded_crlf, encoder->encoded_crlf_length);
<       |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c: In function ‘ccx_dtvcc_write_sami’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c:354:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   354 |  write(encoder->dtvcc_writers[tv->service_number - 1].fd, buf, strlen(buf));
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c:361:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   361 |    write(encoder->dtvcc_writers[tv->service_number - 1].fd,
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<   362 |          encoder->encoded_br, encoder->encoded_br_length);
<       |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c:363:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   363 |    write(encoder->dtvcc_writers[tv->service_number - 1].fd,
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<   364 |          encoder->encoded_crlf, encoder->encoded_crlf_length);
<       |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c:371:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   371 |  write(encoder->dtvcc_writers[tv->service_number - 1].fd, buf, strlen(buf));
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c: In function ‘ccx_dtvcc_writer_output’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_decoders_708_output.c:491:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   491 |    write(writer->fd, UTF8_BOM, sizeof(UTF8_BOM));
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
325,346d260
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_g608.c: In function ‘write_cc_buffer_as_g608’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_g608.c:19:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    19 |  write(context->out->fh, context->buffer, used);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_g608.c:24:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    24 |  write(context->out->fh, context->buffer, used);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_g608.c:28:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    28 |   write(context->out->fh, context->subline, length);
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_g608.c:31:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    31 |   write(context->out->fh, context->subline, length);
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_g608.c:34:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    34 |   write(context->out->fh, context->subline, length);
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_g608.c:35:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    35 |   write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_g608.c:38:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    38 |  write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
349,356d262
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_mcc.c: In function ‘mcc_encode_cc_data’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_mcc.c:159:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   159 |  write(enc_ctx->out->fh, compressed_data_buffer, strlen(compressed_data_buffer));
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_mcc.c: In function ‘write_string’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_mcc.c:724:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   724 |  write(fh, string, strlen(string));
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
359,396d264
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_sami.c: In function ‘write_cc_bitmap_as_sami’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_sami.c:135:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   135 |   write(context->out->fh, buf, strlen(buf));
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_sami.c:145:6: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   145 |      write(context->out->fh, buf, strlen(buf));
<       |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_sami.c:147:7: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   147 |       write(context->out->fh, context->encoded_br, context->encoded_br_length);
<       |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_sami.c:148:6: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   148 |      write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
<       |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_sami.c:153:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   153 |   write(context->out->fh, buf, strlen(buf));
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_sami.c:159:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   159 |   write(context->out->fh, buf, strlen(buf));
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_sami.c: In function ‘write_cc_buffer_as_sami’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_sami.c:207:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   207 |  write(context->out->fh, context->buffer, used);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_sami.c:218:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   218 |    write(context->out->fh, context->subline, length);
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_sami.c:221:5: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   221 |     write(context->out->fh, context->encoded_br, context->encoded_br_length);
<       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_sami.c:222:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   222 |    write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_sami.c:231:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   231 |  write(context->out->fh, context->buffer, used);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_sami.c:240:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   240 |  write(context->out->fh, context->buffer, used);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
398,425d265
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_scc.c: In function ‘add_padding’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_scc.c:422:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   422 |   write(fd, "_", 1);
<       |   ^~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_scc.c:426:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   426 |   write(fd, "80", 2); // 0x80 == odd_parity(0x00)
<       |   ^~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_scc.c: In function ‘write_character’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_scc.c:443:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   443 |   write(fd, &character, 1);
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_scc.c:448:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   448 |    write(fd, " ", 1);
<       |    ^~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_scc.c: In function ‘write_control_code’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_scc.c:469:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   469 |   write(fd, assembly_code, length);
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_scc.c:474:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   474 |    write(fd, " ", 1);
<       |    ^~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_scc.c: In function ‘add_timestamp’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_scc.c:523:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   523 |  write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_scc.c:525:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   525 |   write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
427,468d266
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c: In function ‘write_stringz_as_smptett’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:56:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    56 |  write(context->out->fh, context->buffer, used);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:83:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    83 |   write(context->out->fh, el, u);
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:86:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    86 |   write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:96:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    96 |  write(context->out->fh, context->buffer, used);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:103:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   103 |  write(context->out->fh, context->buffer, used);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c: In function ‘write_cc_bitmap_as_smptett’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:137:5: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   137 |     write(context->out->fh, buf, strlen(buf));
<       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:139:5: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   139 |     write(context->out->fh, rect[i].ocr_text, len);
<       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:140:5: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   140 |     write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
<       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:142:5: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   142 |     write(context->out->fh, buf, strlen(buf));
<       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c: In function ‘write_cc_buffer_as_smptett’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:234:5: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   234 |     write(context->out->fh, context->buffer, used);
<       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:391:5: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   391 |     write(context->out->fh, final, strlen(final));
<       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:393:5: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   393 |     write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
<       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_smptett.c:402:5: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   402 |     write(context->out->fh, context->buffer, used);
<       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
472,519d269
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c: In function ‘write_stringz_as_srt’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:26:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    26 |  write(context->out->fh, context->buffer, used);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:33:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    33 |  write(context->out->fh, context->buffer, used);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:67:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    67 |   write(context->out->fh, el, u);
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:68:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    68 |   write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:74:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    74 |  write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c: In function ‘write_cc_bitmap_as_srt’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:117:5: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   117 |     write(context->out->fh, context->buffer, used);
<       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:121:5: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   121 |     write(context->out->fh, context->buffer, used);
<       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:123:5: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   123 |     write(context->out->fh, str, len);
<       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:124:5: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   124 |     write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
<       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c: In function ‘write_cc_buffer_as_srt’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:201:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   201 |  write(context->out->fh, context->buffer, used);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:206:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   206 |  write(context->out->fh, context->buffer, used);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:265:6: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   265 |      write(context->out->fh, "- ", 2);
<       |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:277:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   277 |    write(context->out->fh, context->subline, length);
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:278:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   278 |    write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_srt.c:286:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   286 |  write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
521,559d270
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c: In function ‘write_stringz_as_ssa’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:27:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    27 |  write(context->out->fh, context->buffer, used);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:61:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    61 |   write(context->out->fh, el, u);
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:62:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    62 |   write(context->out->fh, "\\N", 2);
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:68:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    68 |  write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c: In function ‘write_cc_bitmap_as_ssa’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:116:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   116 |    write(context->out->fh, context->buffer, used);
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:117:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   117 |    write(context->out->fh, str, len);
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:118:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   118 |    write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c: In function ‘write_cc_buffer_as_ssa’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:191:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   191 |  write(context->out->fh, context->buffer, used);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:247:6: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   247 |      write(context->out->fh, "- ", 2);
<       |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:261:5: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   261 |     write(context->out->fh, "\\N", 2);
<       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:263:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   263 |    write(context->out->fh, context->subline, length);
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_ssa.c:271:2: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   271 |  write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
561,564d271
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_transcript.c: In function ‘write_cc_bitmap_as_transcript’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_transcript.c:99:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<    99 |    write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
566,597d272
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c: In function ‘write_webvtt_header’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:225:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   225 |   write(context->out->fh, context->buffer, used);
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:245:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   245 |   write(context->out->fh, outline_css_file, strlen(outline_css_file));
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:249:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   249 |   write(context->out->fh, webvtt_inline_css, strlen(webvtt_inline_css));
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:252:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   252 |    write(context->out->fh, "\n", 1);
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:256:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   256 |    write(context->out->fh, "\r\n", 2);
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:258:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   258 |   write(context->out->fh, "##\n", 3);
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:259:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   259 |   write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c: In function ‘write_cc_bitmap_as_webvtt’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:297:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   297 |    write(context->out->fh, context->buffer, used);
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:299:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   299 |    write(context->out->fh, str, len);
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:300:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   300 |    write(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
599,630c274,278
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:470:8: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   470 |        write(context->out->fh, strdup("<i>"), 3);
<       |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:472:8: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   472 |        write(context->out->fh, strdup("<u>"), 3);
<       |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:479:7: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   479 |       write(context->out->fh, strdup("<c."), 3);
<       |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:480:7: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   480 |       write(context->out->fh, color_text[open_color][0], strlen(color_text[open_color][0]));
<       |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:481:7: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   481 |       write(context->out->fh, ">", 1);
<       |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:487:6: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   487 |      write(context->out->fh, &(context->subline[j]), 1);
<       |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:495:7: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   495 |       write(context->out->fh, strdup("</c>"), 4);
<       |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:503:8: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   503 |        write(context->out->fh, strdup("</i>"), 4);
<       |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/ccx_encoders_webvtt.c:505:8: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<   505 |        write(context->out->fh, strdup("</u>"), 4);
<       |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
670,673d317
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/file_functions.c: In function ‘buffered_read_opt’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/file_functions.c:463:6: warning: ignoring return value of ‘read’, declared with attribute warn_unused_result [-Wunused-result]
<   463 |      read(ctx->infd, &c, 1);
<       |      ^~~~~~~~~~~~~~~~~~~~~~
682,780d325
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c: In function ‘read_byte_block’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:28:2: warning: ignoring return value of ‘fread’, declared with attribute warn_unused_result [-Wunused-result]
<    28 |  fread(buffer, 1, (size_t)n, file);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c: In function ‘read_bytes_signed’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:35:2: warning: ignoring return value of ‘fread’, declared with attribute warn_unused_result [-Wunused-result]
<    35 |  fread(buffer, 1, (size_t)n, file);
<       |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c: In function ‘save_sub_track’:
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1112:3: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1112 |   write(desc, track->header, strlen(track->header));
<       |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1121:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1121 |    write(desc, "\n\n", 2);
<       |    ^~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1130:6: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1130 |      write(desc, sentence->blockaddition->comment, sentence->blockaddition->comment_size);
<       |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1131:6: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1131 |      write(desc, "\n", 1);
<       |      ^~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1140:6: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1140 |      write(desc, blockaddition->cue_identifier, blockaddition->cue_identifier_size);
<       |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1141:6: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1141 |      write(desc, "\n", 1);
<       |      ^~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1145:6: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1145 |      write(desc, "\n", 1);
<       |      ^~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1158:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1158 |    write(desc, timestamp_start, strlen(timestamp_start));
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1159:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1159 |    write(desc, " --> ", 5);
<       |    ^~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1160:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1160 |    write(desc, timestamp_end, strlen(timestamp_start));
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1167:6: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1167 |      write(desc, " ", 1);
<       |      ^~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1168:6: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1168 |      write(desc, blockaddition->cue_settings_list, blockaddition->cue_settings_list_size);
<       |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1171:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1171 |    write(desc, "\n", 1);
<       |    ^~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1176:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1176 |    write(desc, sentence->text + size, sentence->text_size - size);
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1193:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1193 |    write(desc, number, strlen(number));
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1194:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1194 |    write(desc, "\n", 1);
<       |    ^~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1195:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1195 |    write(desc, timestamp_start, strlen(timestamp_start));
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1196:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1196 |    write(desc, " --> ", 5);
<       |    ^~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1197:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1197 |    write(desc, timestamp_end, strlen(timestamp_start));
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1198:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1198 |    write(desc, "\n", 1);
<       |    ^~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1202:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1202 |    write(desc, sentence->text + size, sentence->text_size - size);
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1206:5: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1206 |     write(desc, "\n", 1);
<       |     ^~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1210:5: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1210 |     write(desc, "\n\n", 2);
<       |     ^~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1224:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1224 |    write(desc, "Dialogue: Marked=0,", strlen("Dialogue: Marked=0,"));
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1225:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1225 |    write(desc, timestamp_start, strlen(timestamp_start));
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1226:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1226 |    write(desc, ",", 1);
<       |    ^~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1227:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1227 |    write(desc, timestamp_end, strlen(timestamp_start));
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1228:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1228 |    write(desc, ",", 1);
<       |    ^~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1232:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1232 |    write(desc, text, strlen(text));
<       |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
< /home/nils/Documents/codein2019/ccextractor/src/lib_ccx/matroska.c:1233:4: warning: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Wunused-result]
<  1233 |    write(desc, "\n", 1);
<       |    ^~~~~~~~~~~~~~~~~~~~
```