### PR TITLE
Updated Github actions and reduced steps required to upload artifacts in Windows. 

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -20,11 +20,11 @@ on:
     - 'package_creators/**'
 jobs:
   build_shell:
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
     steps:
     - name: Install tesseract
       run: sudo apt-get install libtesseract-dev
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: build
       run: ./build
       working-directory: ./linux
@@ -34,14 +34,14 @@ jobs:
       run: mkdir ./linux/artifacts
     - name: Copy release artifact
       run: cp ./linux/ccextractor ./linux/artifacts/
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: CCExtractor Linux build
         path: ./linux/artifacts
   build_autoconf:
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: run autogen
       run: ./autogen.sh
       working-directory: ./linux
@@ -56,7 +56,7 @@ jobs:
   cmake:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: cmake
       run: mkdir build && cd build && cmake ../src
     - name: build
@@ -67,7 +67,7 @@ jobs:
   cmake_ocr_hardsubx:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: dependencies
       run: sudo apt update && sudo apt install libtesseract-dev libavformat-dev libswscale-dev
     - name: cmake

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Check out repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
     - name: build Release
@@ -29,23 +29,18 @@ jobs:
     - name: Display version information
       run: ./ccextractorwin.exe --version
       working-directory: ./windows/Release
-    - name: Prepare artifacts
-      run: mkdir ./windows/artifacts
-    - name: Copy CCExtractor executable for artifact
-      run: cp ./windows/Release/ccextractorwin.exe ./windows/artifacts/
-    - name: Copy GUI for artifact
-      run: cp ./windows/Release/ccextractorgui.exe ./windows/artifacts/; 
-    - name: Copy DLL's needed to artifact
-      run: cp ./windows/Release/*.dll ./windows/artifacts/
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: CCExtractor Windows Non-OCR Release build
-        path: ./windows/artifacts
+        path: |
+      ./windows/Release/ccextractorwin.exe
+      ./windows/Release/ccextractorgui.exe
+      ./windows/Release/*.dll
   build_non_ocr_debug:
     runs-on: windows-latest
     steps:
     - name: Check out repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
     - name: build Debug
@@ -54,23 +49,19 @@ jobs:
     - name: Display version information
       run: ./ccextractorwin.exe --version
       working-directory: ./windows/Debug
-    - name: Prepare artifacts
-      run: mkdir ./windows/artifacts
-    - name: Copy CCExtractor executable and pdb for artifact
-      run: cp ./windows/Debug/ccextractorwin.exe ./windows/artifacts/; cp ./windows/Debug/ccextractorwin.pdb ./windows/artifacts/
-    - name: Copy GUI for artifact
-      run: cp ./windows/Debug/ccextractorgui.exe ./windows/artifacts/; 
-    - name: Copy DLL's needed to artifact
-      run: cp ./windows/Debug/*.dll ./windows/artifacts/
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: CCExtractor Windows Non-OCR Debug build
-        path: ./windows/artifacts
+        path: |
+      ./windows/Debug/ccextractorwin.exe
+      ./windows/Debug/ccextractorwin.pdb
+      ./windows/Debug/ccextractorgui.exe
+      ./windows/Debug/*.dll
   build_ocr_hardsubx_release:
     runs-on: windows-latest
     steps:
     - name: Check out repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
     - name: build Release
@@ -79,23 +70,19 @@ jobs:
     - name: Display version information
       run: ./ccextractorwinfull.exe --version
       working-directory: ./windows/Release-Full
-    - name: Prepare artifacts
-      run: mkdir ./windows/artifacts
-    - name: Copy CCExtractor executable for artifact
-      run: cp ./windows/Release-Full/ccextractorwinfull.exe ./windows/artifacts/
-    - name: Copy GUI for artifact
-      run: cp ./windows/Release/ccextractorgui.exe ./windows/artifacts/; 
-    - name: Copy DLL's needed to artifact
-      run: cp ./windows/Release-Full/*.dll ./windows/artifacts/
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: CCExtractor Windows OCR and HardSubX Release build
-        path: ./windows/artifacts
+        path: |
+      ./windows/Release-Full/ccextractorwinfull.exe
+      ./windows/Release/ccextractorgui.exe
+      ./windows/Release-Full/*.dll
+
   build_ocr_hardsubx_debug:
     runs-on: windows-latest
     steps:
     - name: Check out repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2
     - name: build Debug
@@ -104,15 +91,11 @@ jobs:
     - name: Display version information
       run: ./ccextractorwinfull.exe --version
       working-directory: ./windows/Debug-Full
-    - name: Prepare artifacts
-      run: mkdir ./windows/artifacts
-    - name: Copy CCExtractor executable and pdb for artifact
-      run: cp ./windows/Debug-Full/ccextractorwinfull.exe ./windows/artifacts/; cp ./windows/Debug-Full/ccextractorwinfull.pdb ./windows/artifacts/
-    - name: Copy GUI for artifact
-      run: cp ./windows/Debug/ccextractorgui.exe ./windows/artifacts/; 
-    - name: Copy DLL's needed to artifact
-      run: cp ./windows/Debug-Full/*.dll ./windows/artifacts/
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
         name: CCExtractor Windows OCR and HardSubX Debug build
-        path: ./windows/artifacts
+        path: |
+      ./windows/Debug-Full/ccextractorwinfull.exe
+      ./windows/Debug-Full/ccextractorwinfull.pdb
+      ./windows/Debug/ccextractorgui.exe
+      ./windows/Debug-Full/*.dll


### PR DESCRIPTION
 **[FIX]**

**In raising this pull request, I confirm the following (please check boxes):**

- [+] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [+] I have checked that another pull request for this purpose does not exist.
- [+] I have considered, and confirmed that this submission will be valuable to others.
- [+] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [+] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [+] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Fix #1284 

- Updated GitHub actions from v1 to v2 where ever necessary. 
- Reduced the number of steps required to upload an artifact [Windows].
