### PR TITLE
[FIX] segmentation fault on encoding McPoodle's raw to WebVTT

### DIFF
--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -937,6 +937,7 @@ struct encoder_ctx *init_encoder(struct encoder_cfg *opt)
 	int ret;
 	int i;
 	struct encoder_ctx *ctx = malloc(sizeof(struct encoder_ctx));
+	ctx->timing = malloc(sizeof(struct ccx_common_timing_ctx));
 	if (!ctx)
 		return NULL;
 


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please checkboxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---
Fixes #1294

**Changes**
The problem occurs in the initialization of the **encoder context**. The `malloc` function acts differently for `UK_ITVBE.ts` (here, `ctx->timing` is not null) and `cc_sample_dos2unix.bin` (here, `ctx->timing` is set to `null`)
https://github.com/CCExtractor/ccextractor/blob/cf84757e02889ffa0231624fdf941eafded59906/src/lib_ccx/ccx_encoders_common.c#L935-L939

I added a fix by allocating memory for `ctx->timing.`
