### PR TITLE
Add debug option

### DIFF
--- a/docs/COMPILATION.MD
+++ b/docs/COMPILATION.MD
@@ -34,12 +34,17 @@ yum install -y glew-devel glfw-devel cmake gcc libcurl-devel tesseract-devel lep
 
 ### Using the build script
 
-
+By default build script does not include debugging information hence, you cannot debug the executable produced (i.e. `./ccextractor`) on a debugger. To include debugging information, pass `-debug` as an argument.
 ```bash
 #Navigate to linux directory and call the build script
 
 cd ccextractor/linux
+
+# compile without debug info
 ./build
+
+# compile with debug info
+./build -debug
 
 # test your build
 ./ccextractor

--- a/linux/build
+++ b/linux/build
@@ -1,5 +1,23 @@
 #!/usr/bin/env bash
 BLD_FLAGS="$BLD_FLAGS -std=gnu99 -Wno-write-strings -Wno-pointer-sign -DGPAC_CONFIG_LINUX -D_FILE_OFFSET_BITS=64 -DVERSION_FILE_PRESENT -DENABLE_OCR -DFT2_BUILD_LIBRARY -DGPAC_DISABLE_VTT -DGPAC_DISABLE_OD_DUMP"
+# check if user wants to compile with debug flags
+CL_ARGS=("$@")
+DEBUG_ARG=false
+for arg in $CL_ARGS
+    do
+        if [ $arg = "-debug" ]
+        then
+            BLD_FLAGS="$BLD_FLAGS -g"
+            DEBUG_ARG=true
+            echo "Added debug flag..."
+        fi
+done
+if [ $# -ne 0 ] && [ $DEBUG_ARG = false ]; #invalid argument check
+then
+    echo "Error: Invalid argument";
+    exit 6
+fi
+
 bit_os=$(getconf LONG_BIT)
 if [ "$bit_os"=="64" ]
 then

--- a/linux/build
+++ b/linux/build
@@ -12,7 +12,7 @@ for arg in $CL_ARGS
             echo "Added debug flag..."
         fi
 done
-if [ $# -ne 0 ] && [ $DEBUG_ARG = false ]; #invalid argument check
+if [ $# -ne 0 ] && [ $DEBUG_ARG = false ] #invalid argument check
 then
     echo "Error: Invalid argument";
     exit 6


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---
Currently, [`linux/build`](https://github.com/CCExtractor/ccextractor/blob/master/linux/build) script does not include debug information when compiling ccx. 

**Changes**
- added option to enable debug flags on [`linux/build`](https://github.com/CCExtractor/ccextractor/blob/master/linux/build).
- add the necessary information to [`COMPILATION.MD`](https://github.com/CCExtractor/ccextractor/blob/master/docs/COMPILATION.MD).

@canihavesomecoffee I added information about debugging `ccx` (as discussed on slack). Can you take a look?