### PR TITLE
[DOCUMENTATION] mentioned debug info on compilation docs

### DIFF
--- a/docs/COMPILATION.MD
+++ b/docs/COMPILATION.MD
@@ -33,13 +33,18 @@ yum install -y glew-devel glfw-devel cmake gcc libcurl-devel tesseract-devel lep
 2. Compiling
 
 ### Using the build script
-
+By default build script does not include debugging information hence, you cannot debug the executable produced (i.e. `./ccextractor`) on a debugger. To include debugging information, use the `builddebug` script.
 
 ```bash
 #Navigate to linux directory and call the build script
 
 cd ccextractor/linux
+
+# compile without debug flags
 ./build
+
+# compile with debug info
+./builddebug
 
 # test your build
 ./ccextractor


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---
As per the discussion on #1299

**Changes**
- added info about `linux/builddebug` to the compilation doc.
