### PR TITLE
Ignore extra padding data in the current_packet

### DIFF
--- a/src/lib_ccx/ccx_decoders_708.c
+++ b/src/lib_ccx/ccx_decoders_708.c
@@ -1743,8 +1743,8 @@ void ccx_dtvcc_process_current_packet(ccx_dtvcc_ctx *dtvcc)
 #endif
 	if (dtvcc->current_packet_length != len)
 	{
-		// Extra padding data, can be ignored
-		dtvcc->current_packet_length = len;
+		// Most likely things are going to be bad for us
+		len = dtvcc->current_packet_length; // At least don't read beyond the buffer
 	}
 	if (dtvcc->last_sequence != CCX_DTVCC_NO_LAST_SEQUENCE &&
 	    (dtvcc->last_sequence + 1) % 4 != seq)

--- a/src/lib_ccx/ccx_decoders_708.c
+++ b/src/lib_ccx/ccx_decoders_708.c
@@ -1741,10 +1741,10 @@ void ccx_dtvcc_process_current_packet(ccx_dtvcc_ctx *dtvcc)
 				   "Sequence: %d, packet length: %d\n",
 				   seq, len);
 #endif
-	if (dtvcc->current_packet_length != len) // Is this possible?
+	if (dtvcc->current_packet_length != len)
 	{
-		_dtvcc_decoders_reset(dtvcc);
-		return;
+		// Extra padding data, can be ignored
+		dtvcc->current_packet_length = len;
 	}
 	if (dtvcc->last_sequence != CCX_DTVCC_NO_LAST_SEQUENCE &&
 	    (dtvcc->last_sequence + 1) % 4 != seq)


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [x] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---
Fixes issue #677 
Instead of resetting the decoder, when current_length doesn't equal the len in header, change current_length to len(ignore the extra data as padding)
