### PR TITLE
Remove -cf

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -22,6 +22,8 @@
 - Fix: Allow all oem modes with tesseract v4 (#1264)
 - Doc: Updated ccextractor.cnf.sample.
 - Remove: Python API (since no one cares about it and it's unmaintained)
+- Remove: -cf , just use FFmpeg if you want a ES from a TS or PS, CCExtractor is a bad tool
+  for this.
 
 0.88 (2019-05-21)
 -----------------

--- a/src/lib_ccx/ccx_common_option.c
+++ b/src/lib_ccx/ccx_common_option.c
@@ -116,7 +116,6 @@ void init_options(struct ccx_s_options *options)
 
 	options->demux_cfg.auto_stream = CCX_SM_AUTODETECT;
 	options->demux_cfg.m2ts = 0;
-	options->demux_cfg.out_elementarystream_filename = NULL;
 	options->demux_cfg.ts_autoprogram = 0; // Try to find a stream with captions automatically (no -pn needed)
 	options->demux_cfg.ts_cappids[0] = 0;  // PID for stream that holds caption information
 	options->demux_cfg.nb_ts_cappid = 0;

--- a/src/lib_ccx/ccx_common_option.h
+++ b/src/lib_ccx/ccx_common_option.h
@@ -10,7 +10,6 @@ struct demuxer_cfg
 {
 	int m2ts; // Regular TS or M2TS
 	enum ccx_stream_mode_enum auto_stream;
-	char *out_elementarystream_filename;
 
 	/* subtitle codec type */
 	enum ccx_code_type codec;

--- a/src/lib_ccx/ccx_demuxer.c
+++ b/src/lib_ccx/ccx_demuxer.c
@@ -262,12 +262,6 @@ static void ccx_demuxer_print_cfg(struct ccx_demuxer *ctx)
 			break;
 	}
 }
-int ccx_demuxer_write_es(struct ccx_demuxer *ctx, unsigned char *buf, size_t len)
-{
-	if (ctx->fh_out_elementarystream != NULL)
-		fwrite(buf, 1, len, ctx->fh_out_elementarystream);
-	return CCX_OK;
-}
 
 void ccx_demuxer_delete(struct ccx_demuxer **ctx)
 {
@@ -290,8 +284,6 @@ void ccx_demuxer_delete(struct ccx_demuxer **ctx)
 		if (lctx->PIDs_programs[i])
 			freep(lctx->PIDs_programs + i);
 	}
-	if (lctx->fh_out_elementarystream != NULL)
-		fclose(lctx->fh_out_elementarystream);
 
 	freep(&lctx->filebuffer);
 	freep(ctx);
@@ -363,24 +355,14 @@ struct ccx_demuxer *init_demuxer(void *parent, struct demuxer_cfg *cfg)
 	ctx->get_filesize = ccx_demuxer_get_file_size;
 	ctx->get_stream_mode = ccx_demuxer_get_stream_mode;
 	ctx->print_cfg = ccx_demuxer_print_cfg;
-	ctx->write_es = ccx_demuxer_write_es;
 	ctx->hauppauge_warning_shown = 0;
 	ctx->parent = parent;
 	ctx->last_pat_payload = NULL;
 	ctx->last_pat_length = 0;
 
-	ctx->fh_out_elementarystream = NULL;
 	ctx->warning_program_not_found_shown = CCX_FALSE;
 	ctx->strangeheader = 0;
 	memset(&ctx->freport, 0, sizeof(ctx->freport));
-	if (cfg->out_elementarystream_filename != NULL)
-	{
-		if ((ctx->fh_out_elementarystream = fopen(cfg->out_elementarystream_filename, "wb")) == NULL)
-		{
-			print_error(CCX_COMMON_EXIT_FILE_CREATION_FAILED, "Unable to open clean file: %s \nDetails : %s .\n", cfg->out_elementarystream_filename, strerror(errno)); //printing specific error - Permission Denied/ Wrong Path etc..
-			return NULL;
-		}
-	}
 
 	for (i = 0; i < MAX_PSI_PID; i++)
 		ctx->PID_buffers[i] = NULL;

--- a/src/lib_ccx/ccx_demuxer.h
+++ b/src/lib_ccx/ccx_demuxer.h
@@ -106,7 +106,6 @@ struct ccx_demuxer
 	struct cap_info cinfo_tree;
 
 	/* File handles */
-	FILE *fh_out_elementarystream;
 	int infd;   // descriptor number to input.
 	LLONG past; /* Position in file, if in sync same as ftell()  */
 
@@ -166,7 +165,6 @@ struct ccx_demuxer
 	int (*is_open)(struct ccx_demuxer *ctx);
 	int (*get_stream_mode)(struct ccx_demuxer *ctx);
 	LLONG (*get_filesize) (struct ccx_demuxer *ctx);
-	int (*write_es)(struct ccx_demuxer *ctx, unsigned char* buf, size_t len);
 };
 
 struct demuxer_data

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -351,8 +351,6 @@ void print_usage(void)
 	mprint("    -o outputfilename: Use -o parameters to define output filename if you don't\n");
 	mprint("                       like the default ones (same as infile plus _1 or _2 when\n");
 	mprint("                       needed and file extension, e.g. .srt).\n");
-	mprint("         -cf filename: Write 'clean' data to a file. Cleans means the ES\n");
-	mprint("                       without TS or PES headers.\n");
 	mprint("              -stdout: Write output to stdout (console) instead of file. If\n");
 	mprint("                       stdout is used, then -o can't be used. Also\n");
 	mprint("                       -stdout will redirect all messages to stderr (error).\n");
@@ -2325,19 +2323,6 @@ int parse_parameters(struct ccx_s_options *opt, int argc, char *argv[])
 			else
 			{
 				fatal(EXIT_MALFORMED_PARAMETER, "-o has no argument.\n");
-			}
-		}
-		if (strcmp(argv[i], "-cf") == 0)
-		{
-			if (i < argc - 1)
-			{
-				i++;
-				opt->demux_cfg.out_elementarystream_filename = argv[i];
-				continue;
-			}
-			else
-			{
-				fatal(EXIT_MALFORMED_PARAMETER, "-cf has no argument.\n");
 			}
 		}
 		if (strcmp(argv[i], "-svc") == 0 || strcmp(argv[i], "--service") == 0)


### PR DESCRIPTION
Remove -cf which is just a rather bad attempt to convert a TS or PS to a ES (by just writing non-headers).

I added it maybe in CCExtractor 0.02 to help me with debugging. I don't need anyone else has ever used it and I know better now :-)
