### PR TITLE
[FIX] remove '-nots' flag from file-format parsing

### DIFF
--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -1521,7 +1521,6 @@ int parse_parameters(struct ccx_s_options *opt, int argc, char *argv[])
 		if (strcmp(argv[i], "-es") == 0 ||
 		    strcmp(argv[i], "-ts") == 0 ||
 		    strcmp(argv[i], "-ps") == 0 ||
-		    strcmp(argv[i], "-nots") == 0 ||
 		    strcmp(argv[i], "-asf") == 0 ||
 		    strcmp(argv[i], "-wtv") == 0 ||
 		    strcmp(argv[i], "-mp4") == 0 ||


### PR DESCRIPTION
**In raising this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog] (https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).** (not done as not deemed necessary, let me know if otherwise)

**My familiarity with the project is as follows:**

- [ ] I have never used CCExtractor.
- [X] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Removes the `-nots` flag from the section of `parse_parameters()` in `src/lib_ccx/params.c` as is not a valid format, and conflicts with it's other use [here](https://github.com/CCExtractor/ccextractor/blob/master/src/lib_ccx/params.c#L1508)