### PR TITLE
Fix 708 timing issue

### DIFF
--- a/src/lib_ccx/ccx_decoders_708.c
+++ b/src/lib_ccx/ccx_decoders_708.c
@@ -193,6 +193,7 @@ ccx_dtvcc_window_attribs ccx_dtvcc_predefined_window_styles[] =
 void ccx_dtvcc_clear_packet(ccx_dtvcc_ctx *ctx)
 {
 	ctx->current_packet_length = 0;
+	ctx->is_current_packet_header_parsed = 0;
 	memset(ctx->current_packet, 0, CCX_DTVCC_MAX_PACKET_LENGTH * sizeof(unsigned char));
 }
 

--- a/src/lib_ccx/ccx_decoders_708.c
+++ b/src/lib_ccx/ccx_decoders_708.c
@@ -1721,21 +1721,15 @@ void ccx_dtvcc_process_service_block(ccx_dtvcc_ctx *dtvcc,
 	}
 }
 
-void ccx_dtvcc_process_current_packet(ccx_dtvcc_ctx *dtvcc)
+void ccx_dtvcc_process_current_packet(ccx_dtvcc_ctx *dtvcc, int len)
 {
 	int seq = (dtvcc->current_packet[0] & 0xC0) >> 6; // Two most significants bits
-	int len = dtvcc->current_packet[0] & 0x3F;	  // 6 least significants bits
 #ifdef DEBUG_708_PACKETS
 	ccx_common_logging.log_ftn("[CEA-708] dtvcc_process_current_packet: length=%d, seq=%d\n",
 				   dtvcc->current_packet_length, seq);
 #endif
 	if (dtvcc->current_packet_length == 0)
 		return;
-	if (len == 0) // This is well defined in EIA-708; no magic.
-		len = 128;
-	else
-		len = len * 2;
-		// Note that len here is the length including the header
 #ifdef DEBUG_708_PACKETS
 	ccx_common_logging.log_ftn("[CEA-708] dtvcc_process_current_packet: "
 				   "Sequence: %d, packet length: %d\n",

--- a/src/lib_ccx/ccx_decoders_708.h
+++ b/src/lib_ccx/ccx_decoders_708.h
@@ -365,7 +365,7 @@ void ccx_dtvcc_clear_packet(ccx_dtvcc_ctx *ctx);
 void ccx_dtvcc_windows_reset(ccx_dtvcc_service_decoder *decoder);
 void ccx_dtvcc_decoder_flush(ccx_dtvcc_ctx *dtvcc, ccx_dtvcc_service_decoder *decoder);
 
-void ccx_dtvcc_process_current_packet(ccx_dtvcc_ctx *dtvcc);
+void ccx_dtvcc_process_current_packet(ccx_dtvcc_ctx *dtvcc, int len);
 void ccx_dtvcc_process_service_block(ccx_dtvcc_ctx *dtvcc,
 									 ccx_dtvcc_service_decoder *decoder,
 									 unsigned char *data,

--- a/src/lib_ccx/ccx_decoders_708.h
+++ b/src/lib_ccx/ccx_decoders_708.h
@@ -352,6 +352,7 @@ typedef struct ccx_dtvcc_ctx
 
 	unsigned char current_packet[CCX_DTVCC_MAX_PACKET_LENGTH];
 	int current_packet_length;
+	int is_current_packet_header_parsed;
 
 	int last_sequence;
 

--- a/src/lib_ccx/ccx_dtvcc.c
+++ b/src/lib_ccx/ccx_dtvcc.c
@@ -28,25 +28,27 @@ void ccx_dtvcc_process_data(struct lib_cc_decode *ctx,
 		{
 			case 2:
 				ccx_common_logging.debug_ftn(CCX_DMT_708, "[CEA-708] dtvcc_process_data: DTVCC Channel Packet Data\n");
-				if (dtvcc->current_packet_length > 253)
-				{
-					ccx_common_logging.debug_ftn(CCX_DMT_708, "[CEA-708] dtvcc_process_data: "
-										  "Warning: Legal packet size exceeded (1), data not added.\n");
-				}
-				else
-				{
-					dtvcc->current_packet[dtvcc->current_packet_length++] = data[i + 2];
-					dtvcc->current_packet[dtvcc->current_packet_length++] = data[i + 3];
-					int len = dtvcc->current_packet[0] & 0x3F; // 6 least significants bits
-
-					if (len == 0) // This is well defined in EIA-708; no magic.
-						len = 128;
+				if(cc_valid) {
+					if (dtvcc->current_packet_length > 253)
+					{
+						ccx_common_logging.debug_ftn(CCX_DMT_708, "[CEA-708] dtvcc_process_data: "
+											"Warning: Legal packet size exceeded (1), data not added.\n");
+					}
 					else
-						len = len * 2;
-					// Note that len here is the length including the header
+					{
+						dtvcc->current_packet[dtvcc->current_packet_length++] = data[i + 2];
+						dtvcc->current_packet[dtvcc->current_packet_length++] = data[i + 3];
+						int len = dtvcc->current_packet[0] & 0x3F; // 6 least significants bits
 
-					if (dtvcc->current_packet_length >= len)
-						ccx_dtvcc_process_current_packet(dtvcc, len);
+						if (len == 0) // This is well defined in EIA-708; no magic.
+							len = 128;
+						else
+							len = len * 2;
+						// Note that len here is the length including the header
+
+						if (dtvcc->current_packet_length >= len)
+							ccx_dtvcc_process_current_packet(dtvcc, len);
+					}
 				}
 				break;
 			case 3:

--- a/src/lib_ccx/ccx_dtvcc.c
+++ b/src/lib_ccx/ccx_dtvcc.c
@@ -28,25 +28,29 @@ void ccx_dtvcc_process_data(struct lib_cc_decode *ctx,
 		{
 			case 2:
 				ccx_common_logging.debug_ftn(CCX_DMT_708, "[CEA-708] dtvcc_process_data: DTVCC Channel Packet Data\n");
-				if (cc_valid == 0) // This ends the previous packet
-					ccx_dtvcc_process_current_packet(dtvcc);
+				if (dtvcc->current_packet_length > 253)
+				{
+					ccx_common_logging.debug_ftn(CCX_DMT_708, "[CEA-708] dtvcc_process_data: "
+										  "Warning: Legal packet size exceeded (1), data not added.\n");
+				}
 				else
 				{
-					if (dtvcc->current_packet_length > 253)
-					{
-						ccx_common_logging.debug_ftn(CCX_DMT_708, "[CEA-708] dtvcc_process_data: "
-											  "Warning: Legal packet size exceeded (1), data not added.\n");
-					}
+					dtvcc->current_packet[dtvcc->current_packet_length++] = data[i + 2];
+					dtvcc->current_packet[dtvcc->current_packet_length++] = data[i + 3];
+					int len = dtvcc->current_packet[0] & 0x3F; // 6 least significants bits
+
+					if (len == 0) // This is well defined in EIA-708; no magic.
+						len = 128;
 					else
-					{
-						dtvcc->current_packet[dtvcc->current_packet_length++] = data[i + 2];
-						dtvcc->current_packet[dtvcc->current_packet_length++] = data[i + 3];
-					}
+						len = len * 2;
+					// Note that len here is the length including the header
+
+					if (dtvcc->current_packet_length >= len)
+						ccx_dtvcc_process_current_packet(dtvcc, len);
 				}
 				break;
 			case 3:
 				ccx_common_logging.debug_ftn(CCX_DMT_708, "[CEA-708] dtvcc_process_data: DTVCC Channel Packet Start\n");
-				ccx_dtvcc_process_current_packet(dtvcc);
 				if (cc_valid)
 				{
 					if (dtvcc->current_packet_length > CCX_DTVCC_MAX_PACKET_LENGTH - 1)

--- a/src/lib_ccx/ccx_dtvcc.c
+++ b/src/lib_ccx/ccx_dtvcc.c
@@ -28,7 +28,7 @@ void ccx_dtvcc_process_data(struct lib_cc_decode *ctx,
 		{
 			case 2:
 				ccx_common_logging.debug_ftn(CCX_DMT_708, "[CEA-708] dtvcc_process_data: DTVCC Channel Packet Data\n");
-				if (cc_valid)
+				if (cc_valid && dtvcc->is_current_packet_header_parsed)
 				{
 					if (dtvcc->current_packet_length > 253)
 					{
@@ -65,6 +65,7 @@ void ccx_dtvcc_process_data(struct lib_cc_decode *ctx,
 					{
 						dtvcc->current_packet[dtvcc->current_packet_length++] = data[i + 2];
 						dtvcc->current_packet[dtvcc->current_packet_length++] = data[i + 3];
+						dtvcc->is_current_packet_header_parsed = 1;
 					}
 				}
 				break;

--- a/src/lib_ccx/ccx_dtvcc.c
+++ b/src/lib_ccx/ccx_dtvcc.c
@@ -28,11 +28,12 @@ void ccx_dtvcc_process_data(struct lib_cc_decode *ctx,
 		{
 			case 2:
 				ccx_common_logging.debug_ftn(CCX_DMT_708, "[CEA-708] dtvcc_process_data: DTVCC Channel Packet Data\n");
-				if(cc_valid) {
+				if (cc_valid)
+				{
 					if (dtvcc->current_packet_length > 253)
 					{
 						ccx_common_logging.debug_ftn(CCX_DMT_708, "[CEA-708] dtvcc_process_data: "
-											"Warning: Legal packet size exceeded (1), data not added.\n");
+											  "Warning: Legal packet size exceeded (1), data not added.\n");
 					}
 					else
 					{


### PR DESCRIPTION
Process packet as soon as the packet len is equal to the specified len

<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I am an active contributor to CCExtractor.

---
Process current packet as soon as the packet length is equal to the specified length. This leads to the packet being processed in the current FTS, instead of being processed in the next FTS, like before. Fixes #641 

Also ends up fixing #646, as the last packet is now processed instead of waiting for a next packet which never comes

This is causing the issue #677 again. Working on a fix for that
