### PR TITLE
[IMPROVEMENT] Add bazel build to Github Actions.

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -77,3 +77,13 @@ jobs:
       working-directory: build
     - name: Display version information
       run: ./build/ccextractor --version
+  bazel:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: bazel build
+      working-directory: ./
+      run: bazel build //src:ccextractor --verbose_failures
+    - name: Display version information
+      working-directory: ./bazel-bin
+      run: ./src/ccextractor --version


### PR DESCRIPTION

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

As discussed @cfsmp3 , I've added bazel build to Github actions for linux. So whenever a new pr comes from now it'll be tested for bazel build and only if all of the builds which now includes bazel pass, only then a test will be ran for a pr via sample-platform (yet to be done in this year's GSoC). 
CC @canihavesomecoffee 
