### PR TITLE
[FIX] Removed extra lines of code which added extra p tags

### DIFF
--- a/src/lib_ccx/ccx_encoders_smptett.c
+++ b/src/lib_ccx/ccx_encoders_smptett.c
@@ -101,7 +101,7 @@ void write_stringz_as_smptett(char *string, struct encoder_ctx *context, LLONG m
 	}
 	used = encode_line(context, context->buffer, (unsigned char *)str);
 	write_wrapped(context->out->fh, context->buffer, used);
-	sprintf((char *)str, "</p>\n");
+
 	free(el);
 	free(unescaped);
 }

--- a/src/lib_ccx/ccx_encoders_smptett.c
+++ b/src/lib_ccx/ccx_encoders_smptett.c
@@ -94,13 +94,6 @@ void write_stringz_as_smptett(char *string, struct encoder_ctx *context, LLONG m
 	}
 	used = encode_line(context, context->buffer, (unsigned char *)str);
 	write_wrapped(context->out->fh, context->buffer, used);
-	sprintf((char *)str, "<p begin=\"%02u:%02u:%02u.%03u\">\n\n", h2, m2, s2, ms2);
-	if (context->encoding != CCX_ENC_UNICODE)
-	{
-		dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
-	}
-	used = encode_line(context, context->buffer, (unsigned char *)str);
-	write_wrapped(context->out->fh, context->buffer, used);
 
 	free(el);
 	free(unescaped);


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

So I couldn't find any sort of specification requiring empty p tags to be inserted into the ttml file. Thus I have removed the code that was adding these completely.