### PR TITLE
[FIX] Multitrack, WebVTT, and Segfault issues

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -27,6 +27,7 @@
   for this.
 - Fix: Segmentation fault on Windows
 - Update: Updated libGPAC to 1.0.1
+- Fix: Segmentation fault with unsupported and multitrack file reports
 
 0.88 (2019-05-21)
 -----------------

--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -28,6 +28,7 @@
 - Fix: Segmentation fault on Windows
 - Update: Updated libGPAC to 1.0.1
 - Fix: Segmentation fault with unsupported and multitrack file reports
+- Fix: Write subtitle header to multitrack outputs
 
 0.88 (2019-05-21)
 -----------------

--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -29,6 +29,7 @@
 - Update: Updated libGPAC to 1.0.1
 - Fix: Segmentation fault with unsupported and multitrack file reports
 - Fix: Write subtitle header to multitrack outputs
+- Fix: Write multitrack files to the output file directory
 
 0.88 (2019-05-21)
 -----------------

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -92,7 +92,7 @@ static const char *smptett_header = "<?xml version=\"1.0\" encoding=\"UTF-8\" st
 				    "  <body>\n"
 				    "    <div>\n";
 
-static const char *webvtt_header[] = {"WEBVTT", "\r\n", NULL};
+static const char *webvtt_header[] = {"WEBVTT", "\r\n", "\r\n", NULL};
 
 static const char *simple_xml_header = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<captions>\r\n";
 

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -1466,6 +1466,8 @@ void switch_output_file(struct lib_ccx_ctx *ctx, struct encoder_ctx *enc_ctx, in
 	enc_ctx->out->filename = create_outfilename(get_basename(enc_ctx->first_input_file), suffix, ext);
 	enc_ctx->out->fh = open(enc_ctx->out->filename, O_RDWR | O_CREAT | O_TRUNC | O_BINARY, S_IREAD | S_IWRITE);
 
+	write_subtitle_file_header(enc_ctx, enc_ctx->out);
+
 	// Reset counters as we switch output file.
 	enc_ctx->cea_708_counter = 0;
 	enc_ctx->srt_counter = 0;

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -1449,6 +1449,12 @@ unsigned int get_font_encoded(struct encoder_ctx *ctx, unsigned char *buffer, in
 
 void switch_output_file(struct lib_ccx_ctx *ctx, struct encoder_ctx *enc_ctx, int track_id)
 {
+	// Do nothing when in "report" mode
+	if (enc_ctx == NULL || enc_ctx->out == NULL)
+	{
+		return;
+	}
+
 	if (enc_ctx->out->filename != NULL)
 	{ // Close and release the previous handle
 		free(enc_ctx->out->filename);

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -1463,8 +1463,13 @@ void switch_output_file(struct lib_ccx_ctx *ctx, struct encoder_ctx *enc_ctx, in
 	const char *ext = get_file_extension(ctx->write_format);
 	char suffix[32];
 	sprintf(suffix, "_%d", track_id);
-	enc_ctx->out->filename = create_outfilename(get_basename(enc_ctx->first_input_file), suffix, ext);
-	enc_ctx->out->fh = open(enc_ctx->out->filename, O_RDWR | O_CREAT | O_TRUNC | O_BINARY, S_IREAD | S_IWRITE);
+	char *basename = get_basename(enc_ctx->out->original_filename);
+	if (basename != NULL)
+	{
+		enc_ctx->out->filename = create_outfilename(basename, suffix, ext);
+		enc_ctx->out->fh = open(enc_ctx->out->filename, O_RDWR | O_CREAT | O_TRUNC | O_BINARY, S_IREAD | S_IWRITE);
+		free(basename);
+	}
 
 	write_subtitle_file_header(enc_ctx, enc_ctx->out);
 

--- a/src/lib_ccx/ccx_encoders_structs.h
+++ b/src/lib_ccx/ccx_encoders_structs.h
@@ -18,6 +18,7 @@ struct ccx_s_write
 	int fh;
 	int temporarily_closed; // 1 means the file was created OK before but we released the handle
 	char *filename;
+	char *original_filename;
 	void* spupng_data;
 	int with_semaphore;     // 1 means create a .sem file when the file is open and delete it when it's closed
 	char *semaphore_filename;

--- a/src/lib_ccx/output.c
+++ b/src/lib_ccx/output.c
@@ -12,6 +12,7 @@ void dinit_write(struct ccx_s_write *wb)
 	if (wb->fh > 0)
 		close(wb->fh);
 	freep(&wb->filename);
+	freep(&wb->original_filename);
 	if (wb->with_semaphore && wb->semaphore_filename)
 		unlink(wb->semaphore_filename);
 	freep(&wb->semaphore_filename);
@@ -50,6 +51,7 @@ int init_write(struct ccx_s_write *wb, char *filename, int with_semaphore)
 	wb->fh = -1;
 	wb->temporarily_closed = 0;
 	wb->filename = filename;
+	wb->original_filename = strdup(filename);
 
 	wb->with_semaphore = with_semaphore;
 	wb->append_mode = ccx_options.enc_cfg.append_mode;

--- a/src/lib_ccx/params_dump.c
+++ b/src/lib_ccx/params_dump.c
@@ -269,6 +269,11 @@ void print_file_report(struct lib_ccx_ctx *ctx)
 				return;
 			}
 
+			if (ctx->current_file >= ctx->num_input_files)
+			{
+				return;
+			}
+
 			printf("%s\n", ctx->inputfile[ctx->current_file]);
 			break;
 		case CCX_DS_STDIN:


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

* The WEBVTT format issue was introduced in #1092 (after v0.88), so I didn't include it in the changelog. See [WebVTT file structure](https://www.w3.org/TR/webvtt1/#file-structure) for newline requirements.
* Added the WEBVTT header to multitrack output files (mp4).
* Generate multitrack filenames based on the output file instead of the input file. This fixes the situation where the -o argument is used and the first track is saved to the specified output location and the other tracks are saved next to the input file. I added `char *original_filename` to `struct ccx_s_write`, to avoid chained suffixes with three or more tracks (e.g. "test_2_3.vtt").
