### PR TITLE
modify gui output for easier parsing

### DIFF
--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -1369,18 +1369,17 @@ void write_cc_buffer_to_gui(struct eia608_screen *data, struct encoder_ctx *cont
 	{
 		if (data->row_used[i])
 		{
-			fprintf(stderr, "###SUBTITLE#");
 			if (!time_reported)
 			{
 				millis_to_time(data->start_time, &h1, &m1, &s1, &ms1);
 				millis_to_time(data->end_time - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
 				// Note, only MM:SS here as we need to save space in the preview window
-				fprintf(stderr, "%02u:%02u#%02u:%02u#",
+				fprintf(stderr, "###TIME#%02u:%02u-%02u:%02u\n",
 					h1 * 60 + m1, s1, h2 * 60 + m2, s2);
 				time_reported = 1;
 			}
 			else
-				fprintf(stderr, "##");
+				fprintf(stderr, "###SUBTITLE###");
 
 			// We don't capitalize here because whatever function that was used
 			// before to write to file already took care of it.

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -1374,7 +1374,7 @@ void write_cc_buffer_to_gui(struct eia608_screen *data, struct encoder_ctx *cont
 				millis_to_time(data->start_time, &h1, &m1, &s1, &ms1);
 				millis_to_time(data->end_time - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
 				// Note, only MM:SS here as we need to save space in the preview window
-				fprintf(stderr, "###TIME#%02u:%02u-%02u:%02u\n",
+				fprintf(stderr, "###TIME#%02u:%02u-%02u:%02u\n###SUBTITLE###",
 					h1 * 60 + m1, s1, h2 * 60 + m2, s2);
 				time_reported = 1;
 			}

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -1374,7 +1374,7 @@ void write_cc_buffer_to_gui(struct eia608_screen *data, struct encoder_ctx *cont
 				millis_to_time(data->start_time, &h1, &m1, &s1, &ms1);
 				millis_to_time(data->end_time - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
 				// Note, only MM:SS here as we need to save space in the preview window
-				fprintf(stderr, "###TIME#%02u:%02u-%02u:%02u\n###SUBTITLE###",
+				fprintf(stderr, "###TIME###%02u:%02u-%02u:%02u\n###SUBTITLE###",
 					h1 * 60 + m1, s1, h2 * 60 + m2, s2);
 				time_reported = 1;
 			}

--- a/src/lib_ccx/matroska.c
+++ b/src/lib_ccx/matroska.c
@@ -523,7 +523,7 @@ void parse_segment_cluster_block_group(struct matroska_ctx *mkv_ctx, ULLONG clus
 			{
 				if (pos == 0)
 				{
-					fprintf(stderr, "###TIME#%02u:%02u-%02u:%02u\n###SUBTITLE###",
+					fprintf(stderr, "###TIME###%02u:%02u-%02u:%02u\n###SUBTITLE###",
 						h1 * 60 + m1, s1, h2 * 60 + m2, s2);
 				}
 				else

--- a/src/lib_ccx/matroska.c
+++ b/src/lib_ccx/matroska.c
@@ -521,15 +521,14 @@ void parse_segment_cluster_block_group(struct matroska_ctx *mkv_ctx, ULLONG clus
 			int pos = 0;
 			while (true)
 			{
-				fprintf(stderr, "###SUBTITLE#");
 				if (pos == 0)
 				{
-					fprintf(stderr, "%02u:%02u#%02u:%02u#",
+					fprintf(stderr, "###TIME#%02u:%02u-%02u:%02u\n###SUBTITLE###",
 						h1 * 60 + m1, s1, h2 * 60 + m2, s2);
 				}
 				else
 				{
-					fprintf(stderr, "##");
+					fprintf(stderr, "###SUBTITLE###");
 				}
 				int end_pos = pos;
 				while (end_pos < length && text[end_pos] != '\n')

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -688,7 +688,6 @@ page_is_empty:
 
 		if (tlt_config.gui_mode_reports)
 		{
-			fprintf(stderr, "###SUBTITLE#");
 			if (!time_reported)
 			{
 				char timecode_show_mmss[6], timecode_hide_mmss[6];
@@ -697,11 +696,11 @@ page_is_empty:
 				timecode_show_mmss[5] = 0;
 				timecode_hide_mmss[5] = 0;
 				// Note, only MM:SS here as we need to save space in the preview window
-				fprintf(stderr, "%s#%s#", timecode_show_mmss, timecode_hide_mmss);
+				fprintf(stderr, "###TIME#%s-%s\n###SUBTITLES###", timecode_show_mmss, timecode_hide_mmss);
 				time_reported = 1;
 			}
 			else
-				fprintf(stderr, "##");
+				fprintf(stderr, "###SUBTITLE###");
 		}
 
 		for (uint8_t col = 0; col <= col_stop; col++)

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -696,7 +696,7 @@ page_is_empty:
 				timecode_show_mmss[5] = 0;
 				timecode_hide_mmss[5] = 0;
 				// Note, only MM:SS here as we need to save space in the preview window
-				fprintf(stderr, "###TIME#%s-%s\n###SUBTITLES###", timecode_show_mmss, timecode_hide_mmss);
+				fprintf(stderr, "###TIME###%s-%s\n###SUBTITLES###", timecode_show_mmss, timecode_hide_mmss);
 				time_reported = 1;
 			}
 			else


### PR DESCRIPTION
Changes output of gui reports to decouple subtitle and time from 
```
###SUBTITLE###>> NARRATOR: The reports
###SUBTITLE#23:34#23:35#>> NARRATOR: The reports
###SUBTITLE###concurred.
###SUBTITLE#23:35#23:37#concurred.
###SUBTITLE###>> BP has not adequately
###SUBTITLE#23:37#23:39#>> BP has not adequately

```
to
```
###TIME#23:34-23:35
###SUBTITLE###>> NARRATOR: The reports
###SUBTITLE###concurred.
###TIME#23:35-23:37
###SUBTITLE###concurred.
###SUBTITLE###>> BP has not adequately
###TIME#23:37-23:39


```