### PR TITLE
Fix min and max fts when PTS resets

### DIFF
--- a/src/lib_ccx/ccx_common_timing.h
+++ b/src/lib_ccx/ccx_common_timing.h
@@ -50,6 +50,7 @@ struct ccx_common_timing_ctx
 	int sync_pts2fts_set; // 0 = No, 1 = Yes
 	LLONG sync_pts2fts_fts;
 	LLONG sync_pts2fts_pts;
+	int pts_reset; 		  // 0 = No, 1 = Yes. PTS resets when current_pts is lower than prev
 };
 // Count 608 (per field) and 708 blocks since last set_fts() call
 extern int cb_field1, cb_field2, cb_708;


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---
VOB files can contain multiple chapters in a single file. This causes PTS to reset to 0 when a new chapter starts. This leads to FTS also getting reset. But min and max fts aren't reset. So fixed that
Fixes https://github.com/CCExtractor/ccextractor/issues/1277
