### PR TITLE
[FIX] Attempt to fix long-running regression in TeleText

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -31,6 +31,7 @@
 - Fix: Segmentation fault with unsupported and multitrack file reports
 - Fix: Write subtitle header to multitrack outputs
 - Fix: Write multitrack files to the output file directory
+- Fix: Regression on Teletext that caused dates to be wrong (RT 78 on the sample platform)
 
 0.88 (2019-05-21)
 -----------------

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -1015,7 +1015,7 @@ int general_loop(struct lib_ccx_ctx *ctx)
 				isdb_set_global_time(dec_ctx, tstamp);
 			}
 			if (data_node->bufferdatatype == CCX_TELETEXT && dec_ctx->private_data) //if we have teletext subs, we set the min_pts here
-				set_tlt_delta(dec_ctx, min_pts);
+				set_tlt_delta(dec_ctx, dec_ctx->timing->current_pts);
 			ret = process_data(enc_ctx, dec_ctx, data_node);
 			if (enc_ctx != NULL)
 			{

--- a/src/lib_ccx/teletext.h
+++ b/src/lib_ccx/teletext.h
@@ -95,7 +95,6 @@ struct TeletextCtx
 
 	uint8_t using_pts;
 	int64_t delta;
-        uint8_t resetT0;
 	uint32_t t0;
 
 	int sentence_cap;//Set to 1 if -sc is passed

--- a/src/lib_ccx/teletext.h
+++ b/src/lib_ccx/teletext.h
@@ -95,6 +95,7 @@ struct TeletextCtx
 
 	uint8_t using_pts;
 	int64_t delta;
+        uint8_t resetT0;
 	uint32_t t0;
 
 	int sentence_cap;//Set to 1 if -sc is passed

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -1265,10 +1265,10 @@ void set_tlt_delta(struct lib_cc_decode *dec_ctx, uint64_t pts)
 			ctx->delta = 0 - (uint64_t)t;
 		}
 		else
-        {
+		{
 			ctx->delta = (uint64_t)(1000 * utc_refvalue - t);
-        }
-        ctx->t0 = t;
+		}
+		ctx->t0 = t;
 
 		ctx->states.pts_initialized = YES;
 		if ((ctx->using_pts == NO) && (ctx->global_timestamp == 0))
@@ -1402,7 +1402,7 @@ int tlt_process_pes_packet(struct lib_cc_decode *dec_ctx, uint8_t *buffer, uint1
 	if (ctx->using_pts == NO)
 	{
 		t = ctx->global_timestamp;
-        // t = get_pts();
+		// t = get_pts();
 	}
 	else
 	{

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -1265,10 +1265,10 @@ void set_tlt_delta(struct lib_cc_decode *dec_ctx, uint64_t pts)
 			ctx->delta = 0 - (uint64_t)t;
 		}
 		else
-		{
+        {
 			ctx->delta = (uint64_t)(1000 * utc_refvalue - t);
-			ctx->resetT0 = YES; // Indicate to reset t0 at next processing opportunity.
-		}
+        }
+        ctx->t0 = t;
 
 		ctx->states.pts_initialized = YES;
 		if ((ctx->using_pts == NO) && (ctx->global_timestamp == 0))
@@ -1402,8 +1402,8 @@ int tlt_process_pes_packet(struct lib_cc_decode *dec_ctx, uint8_t *buffer, uint1
 	if (ctx->using_pts == NO)
 	{
 		t = ctx->global_timestamp;
+        // t = get_pts();
 	}
-	// if (using_pts == NO) t = get_pts();
 	else
 	{
 		// PTS is 33 bits wide, however, timestamp in ms fits into 32 bits nicely (PTS/90)
@@ -1447,11 +1447,6 @@ int tlt_process_pes_packet(struct lib_cc_decode *dec_ctx, uint8_t *buffer, uint1
 			ctx->states.pts_initialized = NO;
 		}
 	}*/
-	if (ctx->resetT0 == YES)
-	{
-		ctx->t0 = t;
-		ctx->resetT0 = NO;
-	}
 
 	if (t < ctx->t0)
 		ctx->delta = ctx->last_timestamp;
@@ -1532,7 +1527,6 @@ void *telxcc_init(void)
 
 	ctx->using_pts = UNDEFINED;
 	ctx->delta = 0;
-	ctx->resetT0 = NO;
 	ctx->t0 = 0;
 
 	ctx->sentence_cap = 0;

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -1261,10 +1261,14 @@ void set_tlt_delta(struct lib_cc_decode *dec_ctx, uint64_t pts)
 	if (ctx->states.pts_initialized == NO)
 	{
 		if (utc_refvalue == UINT64_MAX)
+                {
 			ctx->delta = 0 - (uint64_t)t;
-		else
+		}
+                else
+                {
 			ctx->delta = (uint64_t)(1000 * utc_refvalue - t);
-		ctx->t0 = t;
+                        ctx->resetT0 = YES; // Indicate to reset t0 at next processing opportunity.
+                }
 
 		ctx->states.pts_initialized = YES;
 		if ((ctx->using_pts == NO) && (ctx->global_timestamp == 0))
@@ -1443,6 +1447,12 @@ int tlt_process_pes_packet(struct lib_cc_decode *dec_ctx, uint8_t *buffer, uint1
 			ctx->states.pts_initialized = NO;
 		}
 	}*/
+        if (ctx->resetT0 == YES)
+        {
+                ctx->t0 = t;
+                ctx->resetT0 = NO;
+        }
+
 	if (t < ctx->t0)
 		ctx->delta = ctx->last_timestamp;
 	ctx->last_timestamp = t + ctx->delta;
@@ -1522,6 +1532,7 @@ void *telxcc_init(void)
 
 	ctx->using_pts = UNDEFINED;
 	ctx->delta = 0;
+        ctx->resetT0 = NO;
 	ctx->t0 = 0;
 
 	ctx->sentence_cap = 0;

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -1261,14 +1261,14 @@ void set_tlt_delta(struct lib_cc_decode *dec_ctx, uint64_t pts)
 	if (ctx->states.pts_initialized == NO)
 	{
 		if (utc_refvalue == UINT64_MAX)
-                {
+		{
 			ctx->delta = 0 - (uint64_t)t;
 		}
-                else
-                {
+		else
+		{
 			ctx->delta = (uint64_t)(1000 * utc_refvalue - t);
-                        ctx->resetT0 = YES; // Indicate to reset t0 at next processing opportunity.
-                }
+			ctx->resetT0 = YES; // Indicate to reset t0 at next processing opportunity.
+		}
 
 		ctx->states.pts_initialized = YES;
 		if ((ctx->using_pts == NO) && (ctx->global_timestamp == 0))
@@ -1447,11 +1447,11 @@ int tlt_process_pes_packet(struct lib_cc_decode *dec_ctx, uint8_t *buffer, uint1
 			ctx->states.pts_initialized = NO;
 		}
 	}*/
-        if (ctx->resetT0 == YES)
-        {
-                ctx->t0 = t;
-                ctx->resetT0 = NO;
-        }
+	if (ctx->resetT0 == YES)
+	{
+		ctx->t0 = t;
+		ctx->resetT0 = NO;
+	}
 
 	if (t < ctx->t0)
 		ctx->delta = ctx->last_timestamp;
@@ -1532,7 +1532,7 @@ void *telxcc_init(void)
 
 	ctx->using_pts = UNDEFINED;
 	ctx->delta = 0;
-        ctx->resetT0 = NO;
+	ctx->resetT0 = NO;
 	ctx->t0 = 0;
 
 	ctx->sentence_cap = 0;


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.


Regression test 78 (https://sampleplatform.ccextractor.org/regression/test/78/view)
has been broken since #622 was merged to fix other issues.

It's been traced back to be caused by not setting t0 at the correct time
(setting it using a calculated PTS time rather than taking it from the video frame),
and this commits attempts to fix that.
