### PR TITLE
Fix timing zero-ing out, when Direct Rollup is selected

### DIFF
--- a/src/lib_ccx/ccx_decoders_608.c
+++ b/src/lib_ccx/ccx_decoders_608.c
@@ -321,6 +321,13 @@ int write_cc_buffer(ccx_decoder_608_context *context, struct cc_subtitle *sub)
 		memcpy(((struct eia608_screen *)sub->data) + sub->nb_data, data, sizeof(*data));
 		sub->nb_data++;
 		wrote_something = 1;
+
+		// Buffer until next packet to get correct timing
+		if (start_time == end_time && sub->got_output == 1)
+		{
+			sub->got_output = 0;
+		}
+
 		if (start_time < end_time)
 		{
 			int i = 0;
@@ -335,7 +342,15 @@ int write_cc_buffer(ccx_decoder_608_context *context, struct cc_subtitle *sub)
 			}
 			for (i = 0; i < nb_data; i++)
 			{
-				data->start_time = start_time + (((end_time - start_time) / nb_data) * i);
+				// Don't update start time if Direct Rollup is selected
+				if (context->settings->direct_rollup)
+				{
+					data->start_time = start_time;
+				}
+				else
+				{
+					data->start_time = start_time + (((end_time - start_time) / nb_data) * i);
+				}
 				data->end_time = start_time + (((end_time - start_time) / nb_data) * (i + 1));
 				data++;
 			}


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---
Fix timing zero-ing out, when Direct Rollup is selected
Fixes #1327 
