### PR TITLE
Fix column length

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -33,6 +33,9 @@
 - Fix: Write multitrack files to the output file directory
 - Fix: Correct frame number calculation in SCC (#1340)
 - Fix: Regression on Teletext that caused dates to be wrong (RT 78 on the sample platform)
+- Fix: CEA-708: Better timing, fixes for missing subtitles
+- Fix: timing for direct rollup
+- Fix: timing for VOB files with multiple chapters
 
 0.88 (2019-05-21)
 -----------------

--- a/src/lib_ccx/ccx_decoders_708_output.c
+++ b/src/lib_ccx/ccx_decoders_708_output.c
@@ -133,16 +133,7 @@ void _dtvcc_write_row(ccx_dtvcc_writer_ctx *writer, ccx_dtvcc_service_decoder *d
 	ccx_dtvcc_pen_attribs pen_attribs = ccx_dtvcc_default_pen_attribs;
 	_dtvcc_get_write_interval(tv, row_index, &first, &last);
 
-	if (decoder->current_window == -1)
-		ccx_common_logging.log_ftn("[CEA-708] _dtvcc_write_row: Window has to be defined first\n");
-
-	int length;
-	if (decoder->current_window == -1) // Bug - in this case we have broken timing. See issue in GitHub
-		length = last + 1;
-	else
-		length = decoder->windows[decoder->current_window].col_count;
-
-	for (int i = 0; i < length; i++)
+	for (int i = 0; i < last + 1; i++)
 	{
 
 		if (use_colors)
@@ -154,7 +145,7 @@ void _dtvcc_write_row(ccx_dtvcc_writer_ctx *writer, ccx_dtvcc_service_decoder *d
 
 		pen_color = tv->pen_colors[row_index][i];
 		pen_attribs = tv->pen_attribs[row_index][i];
-		if (i < first || i > last)
+		if (i < first)
 		{
 			size_t size = write_utf16_char(' ', buf + buf_len);
 			buf_len += size;


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---
Don't take column length from curr_window, as row could from any window
