### PR TITLE
Extract 708 subs by default

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -2,6 +2,7 @@
 -----------------
 - BOM is no longer enabled by default on windows platforms
 - CEA-708: Rust decoder is now default instead of C decoder
+- CEA-708 subs are now extracted by default
 - Fix: Mac Build processes (#1390)
 - Fix: Fix bug with negative delay parameter (#1365)
 

--- a/src/lib_ccx/ccx_common_option.c
+++ b/src/lib_ccx/ccx_common_option.c
@@ -22,6 +22,8 @@ void init_options(struct ccx_s_options *options)
 	options->settings_608.force_rollup = 0;
 	options->settings_608.screens_to_process = -1;
 	options->settings_608.default_color = COL_TRANSPARENT; // Defaults to transparent/no-color.
+	options->is_608_enabled = 0;
+	options->is_708_enabled = 0;
 
 	options->extract = 1;		   // Extract 1st field only (primary language)
 	options->cc_channel = 1;	   // Channel we want to dump in srt mode
@@ -136,6 +138,7 @@ void init_options(struct ccx_s_options *options)
 	options->enc_cfg.all_services_charset = NULL;
 	options->enc_cfg.with_semaphore = 0;
 	options->enc_cfg.force_dropframe = 0; // Assume No Drop Frame for MCC Encode.
+	options->enc_cfg.extract_only_708 = 0;
 
 	options->settings_dtvcc.enabled = 0;
 	options->settings_dtvcc.active_services_count = 0;

--- a/src/lib_ccx/ccx_common_option.h
+++ b/src/lib_ccx/ccx_common_option.h
@@ -84,6 +84,7 @@ struct encoder_cfg
 	int services_enabled[CCX_DTVCC_MAX_SERVICES];
 	char** services_charsets;
 	char* all_services_charset;
+	int extract_only_708; 								// 1 if only 708 subs extraction is enabled
 };
 
 struct ccx_s_options // Options from user parameters
@@ -102,6 +103,8 @@ struct ccx_s_options // Options from user parameters
 
 	ccx_decoder_608_settings settings_608;                     // Contains the settings for the 608 decoder.
 	ccx_decoder_dtvcc_settings settings_dtvcc;                 // Same for 708 decoder
+	int is_608_enabled;										   // Is 608 enabled by explicitly using flags(-1,-2,-12)
+	int is_708_enabled;										   // Is 708 enabled by explicitly using flags(-svc)
 
 	char millis_separator;
 	int binary_concat;                // Disabled by -ve or --videoedited

--- a/src/lib_ccx/ccx_decoders_608.c
+++ b/src/lib_ccx/ccx_decoders_608.c
@@ -1105,9 +1105,13 @@ int process608(const unsigned char *data, int length, void *private_data, struct
 	struct ccx_decoder_608_context *context;
 	int i;
 
-	if (dec_ctx->current_field == 1)
+	if (dec_ctx->current_field == 1 && (dec_ctx->extract == 1 || dec_ctx->extract == 12))
 	{
 		context = dec_ctx->context_cc608_field_1;
+	}
+	else if (dec_ctx->current_field == 2 && (dec_ctx->extract == 2 || dec_ctx->extract == 12))
+	{
+		context = dec_ctx->context_cc608_field_2;
 	}
 	else if (dec_ctx->current_field == 2 && dec_ctx->extract == 1)
 	{
@@ -1115,7 +1119,7 @@ int process608(const unsigned char *data, int length, void *private_data, struct
 	}
 	else
 	{
-		context = dec_ctx->context_cc608_field_2;
+		return -1;
 	}
 	if (context)
 	{

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -796,7 +796,7 @@ static int init_output_ctx(struct encoder_ctx *ctx, struct encoder_cfg *cfg)
 	ctx->ucla = cfg->ucla;
 	ctx->force_dropframe = cfg->force_dropframe;
 
-	if (ctx->generates_file && cfg->cc_to_stdout == CCX_FALSE && cfg->send_to_srv == CCX_FALSE)
+	if (ctx->generates_file && cfg->cc_to_stdout == CCX_FALSE && cfg->send_to_srv == CCX_FALSE && cfg->extract_only_708 == CCX_FALSE)
 	{
 		if (cfg->output_filename != NULL)
 		{

--- a/src/lib_ccx/mp4.c
+++ b/src/lib_ccx/mp4.c
@@ -696,18 +696,18 @@ int processmp4(struct lib_ccx_ctx *ctx, struct ccx_s_mp4Cfg *cfg, char *file)
 											   &dec_sub, &mp4_ret, subtype,
 											   data, sample->dataLength);
 								break;
-                            case MEDIA_TYPE(GF_ISOM_MEDIA_TEXT, GF_ISOM_SUBTYPE_TEXT): // text:text 
-                            {
-                                static int unsupported_reported = 0;
-                                if (!unsupported_reported)
-                                {
-                                    mprint ("\ntext:text not yet supported, see\n");
-                                    mprint ("https://developer.apple.com/library/mac/documentation/quicktime/qtff/QTFFChap3/qtff3.html\n");
-                                    mprint ("If you want to work on a PR.\n");
-                                    unsupported_reported = 1;
-                                }
-                                break;
-                            }
+							case MEDIA_TYPE(GF_ISOM_MEDIA_TEXT, GF_ISOM_SUBTYPE_TEXT): // text:text
+							{
+								static int unsupported_reported = 0;
+								if (!unsupported_reported)
+								{
+									mprint("\ntext:text not yet supported, see\n");
+									mprint("https://developer.apple.com/library/mac/documentation/quicktime/qtff/QTFFChap3/qtff3.html\n");
+									mprint("If you want to work on a PR.\n");
+									unsupported_reported = 1;
+								}
+								break;
+							}
 
 							default:
 								// See https://gpac.wp.imt.fr/2014/09/04/subtitling-with-gpac/ for more possible types

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -1840,6 +1840,7 @@ int parse_parameters(struct ccx_s_options *opt, int argc, char *argv[])
 		}
 		if (strcmp(argv[i], "-12") == 0)
 		{
+			opt->is_608_enabled = 1;
 			opt->extract = 12;
 			continue;
 		}
@@ -2090,11 +2091,13 @@ int parse_parameters(struct ccx_s_options *opt, int argc, char *argv[])
 		}
 		if (strcmp(argv[i], "-1") == 0)
 		{
+			opt->is_608_enabled = 1;
 			opt->extract = 1;
 			continue;
 		}
 		if (strcmp(argv[i], "-2") == 0)
 		{
+			opt->is_608_enabled = 1;
 			opt->extract = 2;
 			continue;
 		}
@@ -2340,6 +2343,7 @@ int parse_parameters(struct ccx_s_options *opt, int argc, char *argv[])
 		{
 			if (i < argc - 1)
 			{
+				opt->is_708_enabled = 1;
 				i++;
 				parse_708_services(opt, argv[i]);
 				continue;
@@ -2972,6 +2976,24 @@ int parse_parameters(struct ccx_s_options *opt, int argc, char *argv[])
 	{
 		opt->enc_cfg.output_filename = NULL;
 	}
+
+	if (!opt->is_608_enabled && !opt->is_708_enabled)
+	{
+		// If nothing is selected then extract both 608 and 708 subs
+
+		// 608 field 1 is enabled by default
+		// Enable 708 subs extraction
+		parse_708_services(opt, "all");
+	}
+	else if (!opt->is_608_enabled && opt->is_708_enabled)
+	{
+		// Extract only 708 subs
+
+		// 608 field 1 is enabled by default, disable it
+		opt->extract = 0;
+		opt->enc_cfg.extract_only_708 = 1;
+	}
+
 #ifdef WITH_LIBCURL
 	opt->enc_cfg.curlposturl = opt->curlposturl;
 #endif


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

Extract CEA-708 subs by default, without the need to pass any parameters.
Current status:- 
- 708(-svc) and field 1(-1) are enabled by default
- if no params are provided:- extract whatever is available, if both(708 and 608) are available then extract both
- If only -1/-2/-12 is provided:- extract only 608 subs
- if only -svc is provided:- extract only 708 subs
- if both -1/-2/-12 and -svc are provided:- extract both 608 and 708
