### PR TITLE
[FIX] Fix crash in Rust decoder on ATSC1.0 TS Files (#1407)

### DIFF
--- a/src/rust/src/decoder/service_decoder.rs
+++ b/src/rust/src/decoder/service_decoder.rs
@@ -272,7 +272,6 @@ impl dtvcc_service_decoder {
         timing: &mut ccx_common_timing_ctx,
     ) -> i32 {
         let code = block[0];
-        let next_code = block[1];
         let C1Command {
             command,
             length,
@@ -296,12 +295,12 @@ impl dtvcc_service_decoder {
             | C1CodeSet::CW7 => {
                 self.handle_set_current_window(code - DTVCC_COMMANDS_C1_CODES_DTVCC_C1_CW0 as u8)
             }
-            C1CodeSet::CLW => self.handle_clear_windows(next_code, encoder, timing),
-            C1CodeSet::HDW => self.handle_hide_windows(next_code, encoder, timing),
-            C1CodeSet::TGW => self.handle_toggle_windows(next_code, encoder, timing),
-            C1CodeSet::DLW => self.handle_delete_windows(next_code, encoder, timing),
-            C1CodeSet::DSW => self.handle_display_windows(next_code, timing),
-            C1CodeSet::DLY => self.handle_delay(next_code),
+            C1CodeSet::CLW => self.handle_clear_windows(block[1], encoder, timing),
+            C1CodeSet::HDW => self.handle_hide_windows(block[1], encoder, timing),
+            C1CodeSet::TGW => self.handle_toggle_windows(block[1], encoder, timing),
+            C1CodeSet::DLW => self.handle_delete_windows(block[1], encoder, timing),
+            C1CodeSet::DSW => self.handle_display_windows(block[1], timing),
+            C1CodeSet::DLY => self.handle_delay(block[1]),
             C1CodeSet::DLC => self.handle_delay_cancel(),
             C1CodeSet::RST => self.handle_reset(),
             C1CodeSet::SPA => self.handle_set_pen_attributes(&block[1..]),


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Fixes #1407 
