### PR TITLE
[FIX] segmentation fault when using hardsubx

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,7 +1,7 @@
 0.95 (to be released)
 -----------------
 - Fix: crash in Rust decoder on ATSC1.0 TS Files (#1407)
-
+- Fix: segmentation fault in using hardsubx
 
 0.94 (2021-12-14)
 -----------------

--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -48,14 +48,6 @@ int api_start(struct ccx_s_options api_options)
 #if defined(ENABLE_OCR) && defined(_WIN32)
 	setMsgSeverity(LEPT_MSG_SEVERITY);
 #endif
-#ifdef ENABLE_HARDSUBX
-	if (api_options.hardsubx)
-	{
-		// Perform burned in subtitle extraction
-		hardsubx(&api_options);
-		return 0;
-	}
-#endif
 
 	// Initialize CCExtractor libraries
 	ctx = init_libraries(&api_options);
@@ -73,6 +65,15 @@ int api_start(struct ccx_s_options api_options)
 		else
 			fatal(EXIT_NOT_CLASSIFIED, "Unable to create Library Context %d\n", errno);
 	}
+
+#ifdef ENABLE_HARDSUBX
+	if (api_options.hardsubx)
+	{
+		// Perform burned in subtitle extraction
+		hardsubx(&api_options);
+		return 0;
+	}
+#endif
 
 #ifdef WITH_LIBCURL
 	curl_global_init(CURL_GLOBAL_ALL);


### PR DESCRIPTION

<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [X] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [X] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Using `hardsubx` on samples would lead to a segmentation fault.
The seg fault arose because the `init_libraries` method was called after the `hardsubx` call. 

This pull request moves it to the appropriate place.
