### PR TITLE
Fix clippy warning and Use rust 1.56.0 for CI 

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -98,7 +98,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.56.0
           override: true
       - name: build
         run: cargo build 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -42,7 +42,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.56.0
           override: true
           components: rustfmt, clippy
       - name: rustfmt

--- a/src/rust/src/decoder/mod.rs
+++ b/src/rust/src/decoder/mod.rs
@@ -47,7 +47,7 @@ impl<'a> Dtvcc<'a> {
         Self {
             is_active: is_true(ctx.is_active),
             active_services_count: ctx.active_services_count as u8,
-            services_active: ctx.services_active.iter().copied().collect(),
+            services_active: ctx.services_active.to_vec(),
             report_enabled: is_true(ctx.report_enabled),
             report,
             decoders: ctx.decoders.iter_mut().collect(),


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

