### PR TITLE
add option to extract closed captions and burnt in subs in the same pass

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -2,6 +2,9 @@
 -----------------
 - Fix: crash in Rust decoder on ATSC1.0 TS Files (#1407)
 - Fix: segmentation fault in using hardsubx
+- New: Add function (and command) that extracts closed caption subtitles as well as burnt-in subtitles from a file in a single pass. (As proposed in issue 726)
+- Refactored: the `general_loop` function has some code moved to a new function
+
 
 0.94 (2021-12-14)
 -----------------

--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -66,15 +66,6 @@ int api_start(struct ccx_s_options api_options)
 			fatal(EXIT_NOT_CLASSIFIED, "Unable to create Library Context %d\n", errno);
 	}
 
-#ifdef ENABLE_HARDSUBX
-	if (api_options.hardsubx)
-	{
-		// Perform burned in subtitle extraction
-		hardsubx(&api_options);
-		return 0;
-	}
-#endif
-
 #ifdef WITH_LIBCURL
 	curl_global_init(CURL_GLOBAL_ALL);
 
@@ -202,6 +193,14 @@ int api_start(struct ccx_s_options api_options)
 				if (api_options.ignore_pts_jumps)
 					ccx_common_timing_settings.disable_sync_check = 1;
 				mprint("\rAnalyzing data in general mode\n");
+#ifdef ENABLE_HARDSUBX
+				if (api_options.hardsubx)
+				{
+					// Perform burned in subtitle extraction
+					hardsubx(&api_options, ctx);
+					return 0;
+				}
+#endif
 				tmp = general_loop(ctx);
 				if (!ret)
 					ret = tmp;

--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -142,7 +142,7 @@ int api_start(struct ccx_s_options api_options)
 		mprint("[share] launching translate service\n");
 		ccx_share_launch_translator(api_options.translate_langs, api_options.translate_key);
 	}
-#endif //ENABLE_SHARING
+#endif // ENABLE_SHARING
 	ret = 0;
 	while (switch_to_next_file(ctx, 0))
 	{
@@ -150,7 +150,7 @@ int api_start(struct ccx_s_options api_options)
 #ifdef ENABLE_SHARING
 		if (api_options.sharing_enabled)
 			ccx_share_start(ctx->basefilename);
-#endif //ENABLE_SHARING
+#endif // ENABLE_SHARING
 
 		stream_mode = ctx->demux_ctx->get_stream_mode(ctx->demux_ctx);
 		// Disable sync check for raw formats - they have the right timeline.
@@ -315,7 +315,7 @@ int api_start(struct ccx_s_options api_options)
 				ccx_share_stream_done(ctx->basefilename);
 				ccx_share_stop();
 			}
-#endif //ENABLE_SHARING
+#endif // ENABLE_SHARING
 
 			if (dec_ctx->total_pulldownframes)
 				mprint("incl. pulldown frames:  %s  (%u frames at %.2ffps)\n",

--- a/src/lib_ccx/ccx_common_option.c
+++ b/src/lib_ccx/ccx_common_option.c
@@ -85,6 +85,7 @@ void init_options(struct ccx_s_options *options)
 	options->hardsubx_conf_thresh = 0.0;
 	options->hardsubx_hue = 0.0;
 	options->hardsubx_lum_thresh = 95.0;
+	options->hardsubx_and_common = 0;
 
 	options->transcript_settings = ccx_encoders_default_transcript_settings;
 	options->millis_separator = ',';

--- a/src/lib_ccx/ccx_common_option.h
+++ b/src/lib_ccx/ccx_common_option.h
@@ -144,6 +144,7 @@ struct ccx_s_options // Options from user parameters
 	int ucla;                         // 1 if UCLA used, 0 if not
 	int tickertext;                   // 1 if ticker text style burned in subs, 0 if not
 	int hardsubx;                     // 1 if burned-in subtitles to be extracted
+	int hardsubx_and_common;		  // 1 if both burned-in and not burned in need to be extracted
 	char *dvblang;                    // The name of the language stream for DVB
 	const char *ocrlang;              // The name of the .traineddata file to be loaded with tesseract
 	int ocr_oem;                      // The Tesseract OEM mode, could be 0 (default), 1 or 2

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -183,7 +183,7 @@ int ps_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 				datalen = packetlength - 4 - nextheader[6];
 				// dbg_print(CCX_DMT_VERBOSE, "datalen :%d packetlen :%" PRIu16 " pes header ext :%d\n", datalen, packetlength, nextheader[6]);
 
-				//Subtitle substream ID 0x20 - 0x39 (32 possible)
+				// Subtitle substream ID 0x20 - 0x39 (32 possible)
 				if (nextheader[7] >= 0x20 && nextheader[7] < 0x40)
 				{
 					dbg_print(CCX_DMT_VERBOSE, "Subtitle found Stream id:%02x\n", nextheader[7]);
@@ -830,6 +830,162 @@ void segment_output_file(struct lib_ccx_ctx *ctx, struct lib_cc_decode *dec_ctx)
 		}
 	}
 }
+int process_non_multiprogram_general_loop(struct lib_ccx_ctx *ctx,
+					  struct demuxer_data **datalist,
+					  struct demuxer_data **data_node,
+					  struct lib_cc_decode **dec_ctx,
+					  struct encoder_ctx **enc_ctx,
+					  uint64_t *min_pts,
+					  int ret,
+					  int *caps)
+{
+
+	struct cap_info *cinfo = NULL;
+	// struct encoder_ctx *enc_ctx = NULL;
+	//  Find most promising stream: teletex, DVB, ISDB
+	int pid = get_best_stream(ctx->demux_ctx);
+	if (pid < 0)
+	{
+		*data_node = get_best_data(*datalist);
+	}
+	else
+	{
+		ignore_other_stream(ctx->demux_ctx, pid);
+		*data_node = get_data_stream(*datalist, pid);
+	}
+
+	if (ccx_options.analyze_video_stream)
+	{
+		int video_pid = get_video_stream(ctx->demux_ctx);
+		if (video_pid != pid && video_pid != -1)
+		{
+			struct cap_info *cinfo_video = get_cinfo(ctx->demux_ctx, pid);
+			struct lib_cc_decode *dec_ctx_video = update_decoder_list_cinfo(ctx, cinfo_video);
+			*enc_ctx = update_encoder_list_cinfo(ctx, cinfo_video);
+			struct cc_subtitle *dec_sub_video = &dec_ctx_video->dec_sub;
+			struct demuxer_data *data_node_video = get_data_stream(*datalist, video_pid);
+
+			if (data_node_video)
+			{
+				if (data_node_video->pts != CCX_NOPTS)
+				{
+					struct ccx_rational tb = {1, MPEG_CLOCK_FREQ};
+					LLONG pts;
+					if (data_node_video->tb.num != 1 || data_node_video->tb.den != MPEG_CLOCK_FREQ)
+					{
+						pts = change_timebase(data_node_video->pts, data_node_video->tb, tb);
+					}
+					else
+					{
+						pts = data_node_video->pts;
+					}
+
+					set_current_pts(dec_ctx_video->timing, pts);
+					set_fts(dec_ctx_video->timing);
+				}
+				size_t got = process_m2v(*enc_ctx, dec_ctx_video, data_node_video->buffer, data_node_video->len, dec_sub_video);
+				if (got > 0)
+				{
+					memmove(data_node_video->buffer, data_node_video->buffer + got, (size_t)(data_node_video->len - got));
+					data_node_video->len -= got;
+				}
+			}
+		}
+	}
+
+	cinfo = get_cinfo(ctx->demux_ctx, pid);
+	*enc_ctx = update_encoder_list_cinfo(ctx, cinfo);
+	*dec_ctx = update_decoder_list_cinfo(ctx, cinfo);
+	(*dec_ctx)->dtvcc->encoder = (void *)(*enc_ctx);
+
+	if ((*dec_ctx)->timing->min_pts == 0x01FFFFFFFFLL) // if we didn't set the min_pts of the program
+	{
+		int p_index = 0; // program index
+		for (int i = 0; i < ctx->demux_ctx->nb_program; i++)
+		{
+			if ((*dec_ctx)->program_number == ctx->demux_ctx->pinfo[i].program_number)
+			{
+				p_index = i;
+				break;
+			}
+		}
+
+		if ((*dec_ctx)->codec == CCX_CODEC_TELETEXT) // even if there's no sub data, we still need to set the min_pts
+		{
+			if (ctx->demux_ctx->pinfo[p_index].got_important_streams_min_pts[PRIVATE_STREAM_1] != UINT64_MAX) // Teletext is synced with subtitle packet PTS
+			{
+				*min_pts = ctx->demux_ctx->pinfo[p_index].got_important_streams_min_pts[PRIVATE_STREAM_1];
+				set_current_pts((*dec_ctx)->timing, *min_pts);
+				set_fts((*dec_ctx)->timing);
+			}
+		}
+		if ((*dec_ctx)->codec == CCX_CODEC_DVB) // DVB will always have to be in sync with audio (no matter the min_pts of the other streams)
+		{
+			if (ctx->demux_ctx->pinfo[p_index].got_important_streams_min_pts[AUDIO] != UINT64_MAX) // it means we got the first pts for audio
+			{
+				*min_pts = ctx->demux_ctx->pinfo[p_index].got_important_streams_min_pts[AUDIO];
+				set_current_pts((*dec_ctx)->timing, *min_pts);
+				set_fts((*dec_ctx)->timing);
+			}
+		}
+	}
+
+	if (*enc_ctx)
+		(*enc_ctx)->timing = (*dec_ctx)->timing;
+
+	if (*data_node) // no sub data, no need to process non-existing data
+	{
+		if ((*data_node)->pts != CCX_NOPTS)
+		{
+			struct ccx_rational tb = {1, MPEG_CLOCK_FREQ};
+			LLONG pts;
+			if ((*data_node)->tb.num != 1 || (*data_node)->tb.den != MPEG_CLOCK_FREQ)
+			{
+				pts = change_timebase((*data_node)->pts, (*data_node)->tb, tb);
+			}
+			else
+				pts = (*data_node)->pts;
+			set_current_pts((*dec_ctx)->timing, pts);
+			set_fts((*dec_ctx)->timing);
+		}
+
+		if ((*data_node)->bufferdatatype == CCX_ISDB_SUBTITLE)
+		{
+			uint64_t tstamp;
+			if (ctx->demux_ctx->global_timestamp_inited)
+			{
+				tstamp = (ctx->demux_ctx->global_timestamp + ctx->demux_ctx->offset_global_timestamp) - ctx->demux_ctx->min_global_timestamp;
+			}
+			else
+			{
+				// Fix if global timestamp not inited
+				tstamp = get_fts((*dec_ctx)->timing, (*dec_ctx)->current_field);
+			}
+			isdb_set_global_time(*dec_ctx, tstamp);
+		}
+		if ((*data_node)->bufferdatatype == CCX_TELETEXT && (*dec_ctx)->private_data) // if we have teletext subs, we set the min_pts here
+			set_tlt_delta(*dec_ctx, (*dec_ctx)->timing->current_pts);
+		ret = process_data(*enc_ctx, *dec_ctx, *data_node);
+		if (*enc_ctx != NULL)
+		{
+			if ((*enc_ctx)->srt_counter || (*enc_ctx)->cea_708_counter || (*dec_ctx)->saw_caption_block || ret == 1)
+				*caps = 1;
+		}
+
+		// Process the last subtitle for DVB
+		if (!(!terminate_asap && !end_of_file && is_decoder_processed_enough(ctx) == CCX_FALSE))
+		{
+			if ((*data_node)->bufferdatatype == CCX_DVB_SUBTITLE && (*dec_ctx)->dec_sub.prev->end_time == 0)
+			{
+				(*dec_ctx)->dec_sub.prev->end_time = ((*dec_ctx)->timing->current_pts - (*dec_ctx)->timing->min_pts) / (MPEG_CLOCK_FREQ / 1000);
+				if ((*enc_ctx) != NULL)
+					encode_sub((*enc_ctx)->prev, (*dec_ctx)->dec_sub.prev);
+				(*dec_ctx)->dec_sub.prev->got_output = 0;
+			}
+		}
+	}
+	return ret;
+}
 
 int general_loop(struct lib_ccx_ctx *ctx)
 {
@@ -887,6 +1043,7 @@ int general_loop(struct lib_ccx_ctx *ctx)
 	}
 
 	end_of_file = 0;
+
 	while (!terminate_asap && !end_of_file && is_decoder_processed_enough(ctx) == CCX_FALSE)
 	{
 		// GET MORE DATA IN BUFFER
@@ -901,147 +1058,19 @@ int general_loop(struct lib_ccx_ctx *ctx)
 		position_sanity_check(ctx->demux_ctx);
 		if (!ctx->multiprogram)
 		{
-			struct cap_info *cinfo = NULL;
 			struct encoder_ctx *enc_ctx = NULL;
-			// Find most promising stream: teletext, DVB, ISDB, ATSC, in that order
-			int pid = get_best_stream(ctx->demux_ctx);
-			if (pid < 0)
-			{
-				data_node = get_best_data(datalist);
-			}
-			else
-			{
-				ignore_other_stream(ctx->demux_ctx, pid);
-				data_node = get_data_stream(datalist, pid);
-			}
-			if (ccx_options.analyze_video_stream)
-			{
-				int video_pid = get_video_stream(ctx->demux_ctx);
-				if (video_pid != pid && video_pid != -1)
-				{
-					struct cap_info *cinfo_video = get_cinfo(ctx->demux_ctx, pid); // Must be pid, not video_pid or DVB crashes (possibly buffer consumption?) - TODO
-					struct lib_cc_decode *dec_ctx_video = update_decoder_list_cinfo(ctx, cinfo_video);
-					enc_ctx = update_encoder_list_cinfo(ctx, cinfo_video);
-					struct cc_subtitle *dec_sub_video = &dec_ctx_video->dec_sub;
-					struct demuxer_data *data_node_video = get_data_stream(datalist, video_pid);
-					if (data_node_video)
-					{
-						if (data_node_video->pts != CCX_NOPTS)
-						{
-							struct ccx_rational tb = {1, MPEG_CLOCK_FREQ};
-							LLONG pts;
-							if (data_node_video->tb.num != 1 || data_node_video->tb.den != MPEG_CLOCK_FREQ)
-							{
-								pts = change_timebase(data_node_video->pts, data_node_video->tb, tb);
-							}
-							else
-								pts = data_node_video->pts;
-							set_current_pts(dec_ctx_video->timing, pts);
-							set_fts(dec_ctx_video->timing);
-						}
-						size_t got = process_m2v(enc_ctx, dec_ctx_video, data_node_video->buffer, data_node_video->len, dec_sub_video);
-						if (got > 0)
-						{
-							memmove(data_node_video->buffer, data_node_video->buffer + got, (size_t)(data_node_video->len - got));
-							data_node_video->len -= got;
-						}
-					}
-				}
-			}
-
-			cinfo = get_cinfo(ctx->demux_ctx, pid);
-			enc_ctx = update_encoder_list_cinfo(ctx, cinfo);
-			dec_ctx = update_decoder_list_cinfo(ctx, cinfo);
-			dec_ctx->dtvcc->encoder = (void *)enc_ctx; //WARN: otherwise cea-708 will not work
-
-			if (dec_ctx->timing->min_pts == 0x01FFFFFFFFLL) //if we didn't set the min_pts of the program
-			{
-				int p_index = 0; //program index
-				for (int i = 0; i < ctx->demux_ctx->nb_program; i++)
-				{
-					if (dec_ctx->program_number == ctx->demux_ctx->pinfo[i].program_number)
-					{
-						p_index = i;
-						break;
-					}
-				}
-
-				if (dec_ctx->codec == CCX_CODEC_TELETEXT) //even if there's no sub data, we still need to set the min_pts
-				{
-					if (ctx->demux_ctx->pinfo[p_index].got_important_streams_min_pts[PRIVATE_STREAM_1] != UINT64_MAX) //Teletext is synced with subtitle packet PTS
-					{
-						min_pts = ctx->demux_ctx->pinfo[p_index].got_important_streams_min_pts[PRIVATE_STREAM_1];
-						set_current_pts(dec_ctx->timing, min_pts);
-						set_fts(dec_ctx->timing);
-					}
-				}
-				if (dec_ctx->codec == CCX_CODEC_DVB) //DVB will always have to be in sync with audio (no matter the min_pts of the other streams)
-				{
-					if (ctx->demux_ctx->pinfo[p_index].got_important_streams_min_pts[AUDIO] != UINT64_MAX) //it means we got the first pts for audio
-					{
-						min_pts = ctx->demux_ctx->pinfo[p_index].got_important_streams_min_pts[AUDIO];
-						set_current_pts(dec_ctx->timing, min_pts);
-						set_fts(dec_ctx->timing);
-					}
-				}
-			}
-
-			if (enc_ctx)
-				enc_ctx->timing = dec_ctx->timing;
-
-			if (!data_node) //no sub data, no need to process non-existing data
-				continue;
-
-			if (data_node->pts != CCX_NOPTS)
-			{
-				struct ccx_rational tb = {1, MPEG_CLOCK_FREQ};
-				LLONG pts;
-				if (data_node->tb.num != 1 || data_node->tb.den != MPEG_CLOCK_FREQ)
-				{
-					pts = change_timebase(data_node->pts, data_node->tb, tb);
-				}
-				else
-					pts = data_node->pts;
-				set_current_pts(dec_ctx->timing, pts);
-				set_fts(dec_ctx->timing);
-			}
-
-			if (data_node->bufferdatatype == CCX_ISDB_SUBTITLE)
-			{
-				uint64_t tstamp;
-				if (ctx->demux_ctx->global_timestamp_inited)
-				{
-					tstamp = (ctx->demux_ctx->global_timestamp + ctx->demux_ctx->offset_global_timestamp) - ctx->demux_ctx->min_global_timestamp;
-				}
-				else
-				{
-					// Fix if global timestamp not inited
-					tstamp = get_fts(dec_ctx->timing, dec_ctx->current_field);
-				}
-				isdb_set_global_time(dec_ctx, tstamp);
-			}
-			if (data_node->bufferdatatype == CCX_TELETEXT && dec_ctx->private_data) //if we have teletext subs, we set the min_pts here
-				set_tlt_delta(dec_ctx, dec_ctx->timing->current_pts);
-			ret = process_data(enc_ctx, dec_ctx, data_node);
-			if (enc_ctx != NULL)
-			{
-				if (enc_ctx->srt_counter || enc_ctx->cea_708_counter || dec_ctx->saw_caption_block || ret == 1)
-					caps = 1;
-			}
-
-			// Process the last subtitle for DVB
-			if (!(!terminate_asap && !end_of_file && is_decoder_processed_enough(ctx) == CCX_FALSE))
-			{
-				if (data_node->bufferdatatype == CCX_DVB_SUBTITLE && dec_ctx->dec_sub.prev->end_time == 0)
-				{
-					dec_ctx->dec_sub.prev->end_time = (dec_ctx->timing->current_pts - dec_ctx->timing->min_pts) / (MPEG_CLOCK_FREQ / 1000);
-					if (enc_ctx != NULL)
-						encode_sub(enc_ctx->prev, dec_ctx->dec_sub.prev);
-					dec_ctx->dec_sub.prev->got_output = 0;
-				}
-			}
+			int ret = process_non_multiprogram_general_loop(ctx,
+									&datalist,
+									&data_node,
+									&dec_ctx,
+									&enc_ctx,
+									&min_pts,
+									ret,
+									&caps);
 			if (ret == CCX_EINVAL)
+			{
 				break;
+			}
 		}
 		else
 		{
@@ -1157,7 +1186,7 @@ int general_loop(struct lib_ccx_ctx *ctx)
 			}
 		}
 
-		//void segment_output_file(struct lib_ccx_ctx *ctx, struct lib_cc_decode *dec_ctx);
+		// void segment_output_file(struct lib_ccx_ctx *ctx, struct lib_cc_decode *dec_ctx);
 		segment_output_file(ctx, dec_ctx);
 
 		if (ccx_options.send_to_srv)

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -39,7 +39,7 @@ int ps_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 		if (!*ppdata)
 			return -1;
 		data = *ppdata;
-		//TODO Set to dummy, find and set actual value
+		// TODO Set to dummy, find and set actual value
 		data->program_number = 1;
 		data->stream_pid = 1;
 		data->codec = CCX_CODEC_ATSC_CC;
@@ -151,14 +151,14 @@ int ps_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 				result = 1;
 				continue;
 			}
-			//PES Header
-			//Private Stream 1 (non MPEG audio , subpictures)
+			// PES Header
+			// Private Stream 1 (non MPEG audio , subpictures)
 			else if (nextheader[3] == 0xBD)
 			{
 				uint16_t packetlength = (nextheader[4] << 8) | nextheader[5];
 				int ret, datalen;
-				//TODO: read PES Header extension , skipped for now
-				// read_video_pes_header() might do
+				// TODO: read PES Header extension , skipped for now
+				//  read_video_pes_header() might do
 				buffered_skip(ctx->demux_ctx, 2);
 				ctx->demux_ctx->past += 2;
 				ret = buffered_read(ctx->demux_ctx, nextheader + 6, 1); // PES header data length (extension)
@@ -171,7 +171,7 @@ int ps_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 				buffered_skip(ctx->demux_ctx, (int)nextheader[6]);
 				ctx->demux_ctx->past += (int)nextheader[6];
 
-				//Substream ID
+				// Substream ID
 				ret = buffered_read(ctx->demux_ctx, nextheader + 7, 1);
 				ctx->demux_ctx->past += 1;
 				if (ret != 1)
@@ -198,7 +198,7 @@ int ps_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 					{
 						payload_read += (int)result;
 					}
-					//FIXME: Temporary bypass
+					// FIXME: Temporary bypass
 					data->bufferdatatype = CCX_DVD_SUBTITLE;
 
 					data->len = result;
@@ -209,7 +209,7 @@ int ps_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 				else
 				{
 					data->bufferdatatype = CCX_PES;
-					//Non Subtitle packet
+					// Non Subtitle packet
 					buffered_skip(ctx->demux_ctx, datalen);
 					ctx->demux_ctx->past += datalen;
 					// fake a result value as something was skipped
@@ -272,7 +272,7 @@ int ps_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 				vpesnum++;
 				dbg_print(CCX_DMT_VERBOSE, "PES video packet #%u\n", vpesnum);
 
-				//peslen is unsigned since loop would have already broken if it was negative
+				// peslen is unsigned since loop would have already broken if it was negative
 				int want = (int)((BUFSIZE - data->len) > peslen ? peslen : (BUFSIZE - data->len));
 
 				if (want != peslen)
@@ -332,7 +332,7 @@ int general_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **data)
 		if (!*data)
 			return -1;
 		ptr = *data;
-		//Dummy program numbers
+		// Dummy program numbers
 		ptr->program_number = 1;
 		ptr->stream_pid = 0x100;
 		ptr->codec = CCX_CODEC_ATSC_CC;
@@ -550,7 +550,7 @@ int raw_loop(struct lib_ccx_ctx *ctx)
 			dec_sub->got_output = 0;
 		}
 
-		//int ccblocks = cb_field1;
+		// int ccblocks = cb_field1;
 		add_current_pts(dec_ctx->timing, cb_field1 * 1001 / 30 * (MPEG_CLOCK_FREQ / 1000));
 		set_fts(dec_ctx->timing); // Now set the FTS related variables including fts_max
 
@@ -664,7 +664,7 @@ int process_data(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, str
 	}
 	else if (data_node->bufferdatatype == CCX_TELETEXT)
 	{
-		//telxcc_update_gt(dec_ctx->private_data, ctx->demux_ctx->global_timestamp);
+		// telxcc_update_gt(dec_ctx->private_data, ctx->demux_ctx->global_timestamp);
 		if (enc_ctx)
 		{
 			ret = tlt_process_pes_packet(dec_ctx, data_node->buffer, data_node->len, dec_sub, enc_ctx->sentence_cap);
@@ -821,8 +821,8 @@ void segment_output_file(struct lib_ccx_ctx *ctx, struct lib_cc_decode *dec_ctx)
 			ctx->segment_counter++;
 			if (enc_ctx)
 			{
-				//list_del(&enc_ctx->list);
-				//dinit_encoder(&enc_ctx, t);
+				// list_del(&enc_ctx->list);
+				// dinit_encoder(&enc_ctx, t);
 				const char *extension = get_file_extension(ccx_options.enc_cfg.write_format);
 				sprintf(ccx_options.enc_cfg.output_filename, "%s_%06d%s", ctx->basefilename, ctx->segment_counter + 1, extension);
 				reset_output_ctx(enc_ctx, &ccx_options.enc_cfg);
@@ -1093,11 +1093,11 @@ int general_loop(struct lib_ccx_ctx *ctx)
 
 				enc_ctx = update_encoder_list_cinfo(ctx, cinfo);
 				dec_ctx = update_decoder_list_cinfo(ctx, cinfo);
-				dec_ctx->dtvcc->encoder = (void *)enc_ctx; //WARN: otherwise cea-708 will not work
+				dec_ctx->dtvcc->encoder = (void *)enc_ctx; // WARN: otherwise cea-708 will not work
 
-				if (dec_ctx->timing->min_pts == 0x01FFFFFFFFLL) //if we didn't set the min_pts of the program
+				if (dec_ctx->timing->min_pts == 0x01FFFFFFFFLL) // if we didn't set the min_pts of the program
 				{
-					int p_index = 0; //program index
+					int p_index = 0; // program index
 					for (int i = 0; i < ctx->demux_ctx->nb_program; i++)
 					{
 						if (dec_ctx->program_number == ctx->demux_ctx->pinfo[i].program_number)
@@ -1107,18 +1107,18 @@ int general_loop(struct lib_ccx_ctx *ctx)
 						}
 					}
 
-					if (dec_ctx->codec == CCX_CODEC_TELETEXT) //even if there's no sub data, we still need to set the min_pts
+					if (dec_ctx->codec == CCX_CODEC_TELETEXT) // even if there's no sub data, we still need to set the min_pts
 					{
-						if (ctx->demux_ctx->pinfo[p_index].got_important_streams_min_pts[PRIVATE_STREAM_1] != UINT64_MAX) //Teletext is synced with subtitle packet PTS
+						if (ctx->demux_ctx->pinfo[p_index].got_important_streams_min_pts[PRIVATE_STREAM_1] != UINT64_MAX) // Teletext is synced with subtitle packet PTS
 						{
-							min_pts = ctx->demux_ctx->pinfo[p_index].got_important_streams_min_pts[PRIVATE_STREAM_1]; //it means we got the first pts for private stream 1
+							min_pts = ctx->demux_ctx->pinfo[p_index].got_important_streams_min_pts[PRIVATE_STREAM_1]; // it means we got the first pts for private stream 1
 							set_current_pts(dec_ctx->timing, min_pts);
 							set_fts(dec_ctx->timing);
 						}
 					}
-					if (dec_ctx->codec == CCX_CODEC_DVB) //DVB will always have to be in sync with audio (no matter the min_pts of the other streams)
+					if (dec_ctx->codec == CCX_CODEC_DVB) // DVB will always have to be in sync with audio (no matter the min_pts of the other streams)
 					{
-						if (ctx->demux_ctx->pinfo[p_index].got_important_streams_min_pts[AUDIO] != UINT64_MAX) //it means we got the first pts for audio
+						if (ctx->demux_ctx->pinfo[p_index].got_important_streams_min_pts[AUDIO] != UINT64_MAX) // it means we got the first pts for audio
 						{
 							min_pts = ctx->demux_ctx->pinfo[p_index].got_important_streams_min_pts[AUDIO];
 							set_current_pts(dec_ctx->timing, min_pts);
@@ -1268,7 +1268,7 @@ int rcwt_loop(struct lib_ccx_ctx *ctx)
 	}
 
 	dec_ctx = update_decoder_list(ctx);
-	dec_ctx->dtvcc->encoder = (void *)enc_ctx; //WARN: otherwise cea-708 will not work
+	dec_ctx->dtvcc->encoder = (void *)enc_ctx; // WARN: otherwise cea-708 will not work
 	if (parsebuf[6] == 0 && parsebuf[7] == 2)
 	{
 		dec_ctx->codec = CCX_CODEC_TELETEXT;

--- a/src/lib_ccx/hardsubx.c
+++ b/src/lib_ccx/hardsubx.c
@@ -10,7 +10,7 @@
 #include <libavutil/imgutils.h>
 #include <libswscale/swscale.h>
 
-int hardsubx_process_data(struct lib_hardsubx_ctx *ctx)
+int hardsubx_process_data(struct lib_hardsubx_ctx *ctx, struct lib_ccx_ctx *ctx_normal)
 {
 	// Get the required media attributes and initialize structures
 	av_register_all();
@@ -101,6 +101,10 @@ int hardsubx_process_data(struct lib_hardsubx_ctx *ctx)
 
 	if (ctx->tickertext)
 		hardsubx_process_frames_tickertext(ctx, enc_ctx);
+	else if (ctx->hardsubx_and_common)
+	{
+		process_hardsubx_linear_frames_and_normal_subs(ctx, enc_ctx, ctx_normal);
+	}
 	else
 		hardsubx_process_frames_linear(ctx, enc_ctx);
 
@@ -290,6 +294,7 @@ struct lib_hardsubx_ctx *_init_hardsubx(struct ccx_s_options *options)
 	ctx->conf_thresh = options->hardsubx_conf_thresh;
 	ctx->hue = options->hardsubx_hue;
 	ctx->lum_thresh = options->hardsubx_lum_thresh;
+	ctx->hardsubx_and_common = options->hardsubx_and_common;
 
 	//Initialize subtitle structure memory
 	ctx->dec_sub = (struct cc_subtitle *)malloc(sizeof(struct cc_subtitle));
@@ -312,7 +317,7 @@ void _dinit_hardsubx(struct lib_hardsubx_ctx **ctx)
 	freep(ctx);
 }
 
-void hardsubx(struct ccx_s_options *options)
+void hardsubx(struct ccx_s_options *options, struct lib_ccx_ctx *ctx_normal)
 {
 	// This is similar to the 'main' function in ccextractor.c, but for hard subs
 	mprint("HardsubX (Hard Subtitle Extractor) - Burned-in subtitle extraction subsystem\n");
@@ -329,7 +334,7 @@ void hardsubx(struct ccx_s_options *options)
 	// Data processing loop
 	time_t start, end;
 	time(&start);
-	hardsubx_process_data(ctx);
+	hardsubx_process_data(ctx, ctx_normal);
 
 	// Show statistics (time taken, frames processed, mode etc)
 	time(&end);

--- a/src/lib_ccx/hardsubx.c
+++ b/src/lib_ccx/hardsubx.c
@@ -4,7 +4,7 @@
 #include "ocr.h"
 #include "utility.h"
 
-//TODO: Correct FFMpeg integration
+// TODO: Correct FFMpeg integration
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libavutil/imgutils.h>
@@ -108,7 +108,7 @@ int hardsubx_process_data(struct lib_hardsubx_ctx *ctx, struct lib_ccx_ctx *ctx_
 	else
 		hardsubx_process_frames_linear(ctx, enc_ctx);
 
-	dinit_encoder(&enc_ctx, 0); //TODO: Replace 0 with end timestamp
+	dinit_encoder(&enc_ctx, 0); // TODO: Replace 0 with end timestamp
 
 	// Free the allocated memory for frame processing
 	av_free(ctx->rgb_buffer);
@@ -273,8 +273,8 @@ struct lib_hardsubx_ctx *_init_hardsubx(struct ccx_s_options *options)
 		fatal(EXIT_NOT_ENOUGH_MEMORY, "Not enough memory to initialize Tesseract");
 	}
 
-	//Initialize attributes common to lib_ccx context
-	ctx->basefilename = get_basename(options->output_filename); //TODO: Check validity, add stdin, network
+	// Initialize attributes common to lib_ccx context
+	ctx->basefilename = get_basename(options->output_filename); // TODO: Check validity, add stdin, network
 	ctx->current_file = -1;
 	ctx->inputfile = options->inputfile;
 	ctx->num_input_files = options->num_input_files;
@@ -283,7 +283,7 @@ struct lib_hardsubx_ctx *_init_hardsubx(struct ccx_s_options *options)
 	ctx->subs_delay = options->subs_delay;
 	ctx->cc_to_stdout = options->cc_to_stdout;
 
-	//Initialize subtitle text parameters
+	// Initialize subtitle text parameters
 	ctx->tickertext = options->tickertext;
 	ctx->cur_conf = 0.0;
 	ctx->prev_conf = 0.0;
@@ -296,7 +296,7 @@ struct lib_hardsubx_ctx *_init_hardsubx(struct ccx_s_options *options)
 	ctx->lum_thresh = options->hardsubx_lum_thresh;
 	ctx->hardsubx_and_common = options->hardsubx_and_common;
 
-	//Initialize subtitle structure memory
+	// Initialize subtitle structure memory
 	ctx->dec_sub = (struct cc_subtitle *)malloc(sizeof(struct cc_subtitle));
 	memset(ctx->dec_sub, 0, sizeof(struct cc_subtitle));
 
@@ -312,7 +312,7 @@ void _dinit_hardsubx(struct lib_hardsubx_ctx **ctx)
 	TessBaseAPIEnd(lctx->tess_handle);
 	TessBaseAPIDelete(lctx->tess_handle);
 
-	//Free subtitle
+	// Free subtitle
 	freep(lctx->dec_sub);
 	freep(ctx);
 }

--- a/src/lib_ccx/hardsubx.h
+++ b/src/lib_ccx/hardsubx.h
@@ -5,7 +5,7 @@
 #include "utility.h"
 
 #ifdef ENABLE_HARDSUBX
-//TODO: Correct FFMpeg integration
+// TODO: Correct FFMpeg integration
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libswscale/swscale.h>
@@ -69,7 +69,7 @@ struct lib_hardsubx_ctx
 
 	// Subtitle text parameters
 	int tickertext;
-	int hardsubx_and_common; //if cc and hardsubx both
+	int hardsubx_and_common; // if cc and hardsubx both
 	struct cc_subtitle *dec_sub;
 	int ocr_mode;
 	int subcolor;
@@ -80,27 +80,27 @@ struct lib_hardsubx_ctx
 	float lum_thresh;
 };
 
-struct lib_hardsubx_ctx* _init_hardsubx(struct ccx_s_options *options);
+struct lib_hardsubx_ctx *_init_hardsubx(struct ccx_s_options *options);
 void _hardsubx_params_dump(struct ccx_s_options *options, struct lib_hardsubx_ctx *ctx);
-void hardsubx(struct ccx_s_options *options, struct lib_ccx_ctx* ctx_normal);
+void hardsubx(struct ccx_s_options *options, struct lib_ccx_ctx *ctx_normal);
 void _dinit_hardsubx(struct lib_hardsubx_ctx **ctx);
-int hardsubx_process_data(struct lib_hardsubx_ctx *ctx, struct lib_ccx_ctx* ctx_normal);
+int hardsubx_process_data(struct lib_hardsubx_ctx *ctx, struct lib_ccx_ctx *ctx_normal);
 
-//hardsubx_decoder.c
+// hardsubx_decoder.c
 void hardsubx_process_frames_linear(struct lib_hardsubx_ctx *ctx, struct encoder_ctx *enc_ctx);
 int hardsubx_process_frames_tickertext(struct lib_hardsubx_ctx *ctx, struct encoder_ctx *enc_ctx);
 void hardsubx_process_frames_binary(struct lib_hardsubx_ctx *ctx);
-char* _process_frame_white_basic(struct lib_hardsubx_ctx *ctx, AVFrame *frame, int width, int height, int index);
+char *_process_frame_white_basic(struct lib_hardsubx_ctx *ctx, AVFrame *frame, int width, int height, int index);
 char *_process_frame_color_basic(struct lib_hardsubx_ctx *ctx, AVFrame *frame, int width, int height, int index);
 void _display_frame(struct lib_hardsubx_ctx *ctx, AVFrame *frame, int width, int height, int timestamp);
-char* _process_frame_tickertext(struct lib_hardsubx_ctx *ctx, AVFrame *frame, int width, int height, int index);
+char *_process_frame_tickertext(struct lib_hardsubx_ctx *ctx, AVFrame *frame, int width, int height, int index);
 void process_hardsubx_linear_frames_and_normal_subs(struct lib_hardsubx_ctx *hard_ctx, struct encoder_ctx *enc_ctx, struct lib_ccx_ctx *ctx);
 
-//hardsubx_imgops.c
-void rgb_to_hsv(float R, float G, float B,float *H, float *S, float *V);
-void rgb_to_lab(float R, float G, float B,float *L, float *a, float *b);
+// hardsubx_imgops.c
+void rgb_to_hsv(float R, float G, float B, float *H, float *S, float *V);
+void rgb_to_lab(float R, float G, float B, float *L, float *a, float *b);
 
-//hardsubx_classifier.c
+// hardsubx_classifier.c
 char *get_ocr_text_simple(struct lib_hardsubx_ctx *ctx, PIX *image);
 char *get_ocr_text_wordwise(struct lib_hardsubx_ctx *ctx, PIX *image);
 char *get_ocr_text_letterwise(struct lib_hardsubx_ctx *ctx, PIX *image);
@@ -108,8 +108,8 @@ char *get_ocr_text_simple_threshold(struct lib_hardsubx_ctx *ctx, PIX *image, fl
 char *get_ocr_text_wordwise_threshold(struct lib_hardsubx_ctx *ctx, PIX *image, float threshold);
 char *get_ocr_text_letterwise_threshold(struct lib_hardsubx_ctx *ctx, PIX *image, float threshold);
 
-//hardsubx_utility.c
-int edit_distance(char * word1, char * word2, int len1, int len2);
+// hardsubx_utility.c
+int edit_distance(char *word1, char *word2, int len1, int len2);
 int64_t convert_pts_to_ms(int64_t pts, AVRational time_base);
 int64_t convert_pts_to_ns(int64_t pts, AVRational time_base);
 int64_t convert_pts_to_s(int64_t pts, AVRational time_base);

--- a/src/lib_ccx/hardsubx.h
+++ b/src/lib_ccx/hardsubx.h
@@ -69,6 +69,7 @@ struct lib_hardsubx_ctx
 
 	// Subtitle text parameters
 	int tickertext;
+	int hardsubx_and_common; //if cc and hardsubx both
 	struct cc_subtitle *dec_sub;
 	int ocr_mode;
 	int subcolor;
@@ -81,9 +82,9 @@ struct lib_hardsubx_ctx
 
 struct lib_hardsubx_ctx* _init_hardsubx(struct ccx_s_options *options);
 void _hardsubx_params_dump(struct ccx_s_options *options, struct lib_hardsubx_ctx *ctx);
-void hardsubx(struct ccx_s_options *options);
+void hardsubx(struct ccx_s_options *options, struct lib_ccx_ctx* ctx_normal);
 void _dinit_hardsubx(struct lib_hardsubx_ctx **ctx);
-int hardsubx_process_data(struct lib_hardsubx_ctx *ctx);
+int hardsubx_process_data(struct lib_hardsubx_ctx *ctx, struct lib_ccx_ctx* ctx_normal);
 
 //hardsubx_decoder.c
 void hardsubx_process_frames_linear(struct lib_hardsubx_ctx *ctx, struct encoder_ctx *enc_ctx);
@@ -93,6 +94,7 @@ char* _process_frame_white_basic(struct lib_hardsubx_ctx *ctx, AVFrame *frame, i
 char *_process_frame_color_basic(struct lib_hardsubx_ctx *ctx, AVFrame *frame, int width, int height, int index);
 void _display_frame(struct lib_hardsubx_ctx *ctx, AVFrame *frame, int width, int height, int timestamp);
 char* _process_frame_tickertext(struct lib_hardsubx_ctx *ctx, AVFrame *frame, int width, int height, int index);
+void process_hardsubx_linear_frames_and_normal_subs(struct lib_hardsubx_ctx *hard_ctx, struct encoder_ctx *enc_ctx, struct lib_ccx_ctx *ctx);
 
 //hardsubx_imgops.c
 void rgb_to_hsv(float R, float G, float B,float *H, float *S, float *V);

--- a/src/lib_ccx/hardsubx_decoder.c
+++ b/src/lib_ccx/hardsubx_decoder.c
@@ -2,7 +2,7 @@
 #include "utility.h"
 
 #ifdef ENABLE_HARDSUBX
-//TODO: Correct FFMpeg integration
+// TODO: Correct FFMpeg integration
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libavutil/imgutils.h>
@@ -13,7 +13,7 @@
 
 char *_process_frame_white_basic(struct lib_hardsubx_ctx *ctx, AVFrame *frame, int width, int height, int index)
 {
-	//printf("frame : %04d\n", index);
+	// printf("frame : %04d\n", index);
 	PIX *im;
 	PIX *gray_im;
 	PIX *sobel_edge_im;
@@ -46,7 +46,7 @@ char *_process_frame_white_basic(struct lib_hardsubx_ctx *ctx, AVFrame *frame, i
 		}
 	}
 
-	//Handle the edge image
+	// Handle the edge image
 	gray_im = pixConvertRGBToGray(im, 0.0, 0.0, 0.0);
 	sobel_edge_im = pixSobelEdgeFilter(gray_im, L_VERTICAL_EDGES);
 	dilate_gray_im = pixDilateGray(sobel_edge_im, 21, 11);
@@ -164,7 +164,7 @@ char *_process_frame_color_basic(struct lib_hardsubx_ctx *ctx, AVFrame *frame, i
 			pixGetPixel(pixd, j, i, &p2);
 			// pixGetPixel(hue_im,j,i,&p3);
 			pixGetPixel(edge_im_2, j, i, &p4);
-			if (p1 == 0 && p2 == 0 && p4 > 0) //if(p4>0&&p1==0)//if(p2==0&&p1==0&&p3>0)
+			if (p1 == 0 && p2 == 0 && p4 > 0) // if(p4>0&&p1==0)//if(p2==0&&p1==0&&p3>0)
 			{
 				pixSetRGBPixel(feat_im, j, i, 255, 255, 255);
 			}
@@ -270,7 +270,7 @@ void _display_frame(struct lib_hardsubx_ctx *ctx, AVFrame *frame, int width, int
 			pixGetPixel(pixd, j, i, &p2);
 			// pixGetPixel(hue_im,j,i,&p3);
 			pixGetPixel(edge_im_2, j, i, &p4);
-			if (p1 == 0 && p2 == 0 && p4 > 0) //if(p4>0&&p1==0)//if(p2==0&&p1==0&&p3>0)
+			if (p1 == 0 && p2 == 0 && p4 > 0) // if(p4>0&&p1==0)//if(p2==0&&p1==0&&p3>0)
 			{
 				pixSetRGBPixel(feat_im, j, i, 255, 255, 255);
 			}
@@ -328,7 +328,7 @@ char *_process_frame_tickertext(struct lib_hardsubx_ctx *ctx, AVFrame *frame, in
 		}
 	}
 
-	//Handle the edge image
+	// Handle the edge image
 	gray_im = pixConvertRGBToGray(im, 0.0, 0.0, 0.0);
 	sobel_edge_im = pixSobelEdgeFilter(gray_im, L_VERTICAL_EDGES);
 	dilate_gray_im = pixDilateGray(sobel_edge_im, 21, 11);
@@ -381,7 +381,7 @@ int hardsubx_process_frames_tickertext(struct lib_hardsubx_ctx *ctx, struct enco
 		if (ctx->packet.stream_index == ctx->video_stream_id)
 		{
 			frame_number++;
-			//Decode the video stream packet
+			// Decode the video stream packet
 			avcodec_decode_video2(ctx->codec_ctx, ctx->frame, &got_frame, &ctx->packet);
 			if (got_frame && frame_number % 1000 == 0)
 			{
@@ -433,7 +433,7 @@ void hardsubx_process_frames_linear(struct lib_hardsubx_ctx *ctx, struct encoder
 		{
 			frame_number++;
 
-			//Decode the video stream packet
+			// Decode the video stream packet
 			avcodec_decode_video2(ctx->codec_ctx, ctx->frame, &got_frame, &ctx->packet);
 
 			if (got_frame && frame_number % 25 == 0)

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -313,4 +313,13 @@ struct lib_cc_decode *update_decoder_list(struct lib_ccx_ctx *ctx);
 struct encoder_ctx *update_encoder_list_cinfo(struct lib_ccx_ctx *ctx, struct cap_info* cinfo);
 struct encoder_ctx * update_encoder_list(struct lib_ccx_ctx *ctx);
 struct encoder_ctx *get_encoder_by_pn(struct lib_ccx_ctx *ctx, int pn);
+int process_non_multiprogram_general_loop(struct lib_ccx_ctx* ctx, 
+											struct demuxer_data **datalist,
+											struct demuxer_data **data_node,
+											struct lib_cc_decode **dec_ctx,
+											struct encoder_ctx **enc_ctx,
+											uint64_t *min_pts,
+											int ret,
+											int *caps);
+void segment_output_file(struct lib_ccx_ctx *ctx, struct lib_cc_decode *dec_ctx);
 #endif

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -128,7 +128,7 @@ int parsedelay(struct ccx_s_options *opt, char *par)
 
 int append_file_to_queue(struct ccx_s_options *opt, char *filename)
 {
-	if (filename[0] == '\0') //skip files with empty file name (ex : ./ccextractor "")
+	if (filename[0] == '\0') // skip files with empty file name (ex : ./ccextractor "")
 		return 0;
 	char *c = (char *)malloc(strlen(filename) + 1);
 	if (c == NULL)
@@ -841,7 +841,7 @@ void print_usage(void)
 	mprint("                       to find data in all packets by scanning.\n");
 #ifdef ENABLE_SHARING
 	mprint("       -sharing-debug: Print extracted CC sharing service messages\n");
-#endif //ENABLE_SHARING
+#endif // ENABLE_SHARING
 	mprint("\n");
 
 	mprint("Teletext related options:\n");
@@ -903,7 +903,7 @@ void print_usage(void)
 	mprint("                       in csv format (e.g. -translate ru,fr,it\n");
 	mprint("      -translate-auth: Set Translation Service authorization data to make translation possible\n");
 	mprint("                       In case of Google Translate API - API Key\n");
-#endif //ENABLE_SHARING
+#endif // ENABLE_SHARING
 
 	mprint("Notes on the CEA-708 decoder: While it is starting to be useful, it's\n");
 	mprint("a work in progress. A number of things don't work yet in the decoder\n");
@@ -1042,7 +1042,7 @@ void version(char *location)
 	char *leptversion = getLeptonicaVersion();
 	mprint("	Leptonica Version: %s\n", leptversion);
 	lept_free(leptversion);
-#endif //ENABLE_OCR
+#endif // ENABLE_OCR
 	mprint("	libGPAC Version: %s\n", GPAC_VERSION);
 	mprint("	zlib: %s\n", ZLIB_VERSION);
 	mprint("	utf8proc Version: %s\n", (const char *)utf8proc_version());
@@ -1195,7 +1195,7 @@ void mkvlang_params_check(char *lang)
 		}
 	}
 
-	//Steps to check for the last lang of multiple mkvlangs provided by the user.
+	// Steps to check for the last lang of multiple mkvlangs provided by the user.
 	present = strlen(lang) - 1;
 
 	for (int char_index = strlen(lang) - 1; char_index >= 0; char_index--)
@@ -1277,7 +1277,7 @@ int parse_parameters(struct ccx_s_options *opt, int argc, char *argv[])
 		{
 			if (strcmp(argv[i], "-hcc") == 0)
 			{
-				//if extraction of both burned in and non burned in subs
+				// if extraction of both burned in and non burned in subs
 				opt->hardsubx_and_common = 1;
 				continue;
 			}
@@ -2273,7 +2273,7 @@ int parse_parameters(struct ccx_s_options *opt, int argc, char *argv[])
 			opt->debug_mask |= CCX_DMT_SHARE;
 			continue;
 		}
-#endif //ENABLE_SHARING
+#endif // ENABLE_SHARING
 		if (strcmp(argv[i], "-fullbin") == 0)
 		{
 			opt->fullbin = 1;
@@ -2769,7 +2769,7 @@ int parse_parameters(struct ccx_s_options *opt, int argc, char *argv[])
 				fatal(EXIT_MALFORMED_PARAMETER, "-curlposturl has no argument.\n");
 			}
 		}
-#endif //WITH_LIBCURL
+#endif // WITH_LIBCURL
 
 #ifdef ENABLE_SHARING
 		if (strcmp(argv[i], "-enable-sharing") == 0)
@@ -2818,7 +2818,7 @@ int parse_parameters(struct ccx_s_options *opt, int argc, char *argv[])
 				fatal(EXIT_MALFORMED_PARAMETER, "-translate-auth has no argument.\n");
 			}
 		}
-#endif //ENABLE_SHARING
+#endif // ENABLE_SHARING
 
 		fatal(EXIT_INCOMPATIBLE_PARAMETERS, "Error: Parameter %s not understood.\n", argv[i]);
 	}
@@ -2947,7 +2947,7 @@ int parse_parameters(struct ccx_s_options *opt, int argc, char *argv[])
 		print_error(opt->gui_mode_reports, "-curlposturl requires that the format is curl\n");
 		return EXIT_INCOMPATIBLE_PARAMETERS;
 	}
-#endif //WITH_LIBCURL
+#endif // WITH_LIBCURL
 	/* Initialize some Encoder Configuration */
 	opt->enc_cfg.extract = opt->extract;
 	if (opt->num_input_files > 0)

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -983,6 +983,8 @@ void print_usage(void)
 	mprint("                     Recommended values are in the range 80 to 100.\n");
 	mprint("                     The default value is 95\n");
 	mprint("\n");
+	mprint("		-hcc	   : This option will be used if the file should have both\n");
+	mprint("					 closed captions and burned in subtitles\n");
 	mprint("            An example command for burned-in subtitle extraction is as follows:\n");
 	mprint("               ccextractor video.mp4 -hardsubx -subcolor white -detect_italics \n");
 	mprint("                   -whiteness_thresh 90 -conf_thresh 60\n");
@@ -1273,6 +1275,12 @@ int parse_parameters(struct ccx_s_options *opt, int argc, char *argv[])
 		}
 		if (opt->hardsubx == 1)
 		{
+			if (strcmp(argv[i], "-hcc") == 0)
+			{
+				//if extraction of both burned in and non burned in subs
+				opt->hardsubx_and_common = 1;
+				continue;
+			}
 			if (strcmp(argv[i], "-ocr_mode") == 0)
 			{
 				if (i < argc - 1)


### PR DESCRIPTION


<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**
(Not applicable because still WIP)

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [X] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

This PR is in context to issue #726 

The current status is that the generated subtitle file has content from closed-caption extraction and burnt-in extraction, however they are not in the correct order. 

The approach I have in mind right now is to use the timestamp of previously encoded subtitles of one of the modes (burnt-in or closed caption) and make a decision on which packet to process (the image or the closed caption) 

Please advise on whether this approach looks okay. 

Note: I have added appropriate command line options for this already

Any advice is appreciated 

CC: @cfsmp3 
