### PR TITLE
[FIX] Fix issue #1421

### DIFF
--- a/src/lib_ccx/stream_functions.c
+++ b/src/lib_ccx/stream_functions.c
@@ -482,6 +482,10 @@ int isValidMP4Box(unsigned char *buffer, size_t position, size_t *nextBoxLocatio
 		    buffer[position + 6] == ccx_stream_mp4_boxes[idx].boxType[2] && buffer[position + 7] == ccx_stream_mp4_boxes[idx].boxType[3])
 		{
 			mprint("Detected MP4 box with name: %s\n", ccx_stream_mp4_boxes[idx].boxType);
+			// If the box type is "moov", check if it contains a valid movie header 
+			if (idx == 2 && !( buffer[position + 8] == 'm' && buffer[position + 9] == 'v' && buffer[position + 10] == 'h' && buffer[position + 11] == 'd' )) {
+				continue;
+			} 
 			// Box name matches. Do crude validation of possible box size, and if valid, add points for "valid" box
 			size_t boxSize = buffer[position] << 24;
 			boxSize |= buffer[position + 1] << 16;

--- a/src/lib_ccx/stream_functions.c
+++ b/src/lib_ccx/stream_functions.c
@@ -483,7 +483,7 @@ int isValidMP4Box(unsigned char *buffer, size_t position, size_t *nextBoxLocatio
 		{
 			mprint("Detected MP4 box with name: %s\n", ccx_stream_mp4_boxes[idx].boxType);
 			// If the box type is "moov", check if it contains a valid movie header 
-			if (idx == 2 && !( buffer[position + 8] == 'm' && buffer[position + 9] == 'v' && buffer[position + 10] == 'h' && buffer[position + 11] == 'd' )) {
+			if (idx == 2 && !( buffer[position + 12] == 'm' && buffer[position + 13] == 'v' && buffer[position + 14] == 'h' && buffer[position + 15] == 'd' )) {
 				continue;
 			} 
 			// Box name matches. Do crude validation of possible box size, and if valid, add points for "valid" box


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [x] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

This pull request fixes Issue #1421, by checking if a box of type `moov` also has a valid movie header (mvhd). This might cause problems with files which do not have the header at the start of the box. I could not confirm if such files exist, but all the files I tested with do have the `mvhd` header at the start of the `moov` box. This might require some further testing, as it might cause problems with such MP4 containers which could contain another atom before the `mvhd` header.