### PR TITLE
[FIX] Fix issue #1453: Respect `-stdout` if multiple CC tracks are found in a Matroska input file

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,6 +1,6 @@
 0.95 (to be released)
 -----------------
-- Fix: respect `-stdout` even if multiple CC tracks are present in a Matroksa input file (#1453)
+- Fix: respect `-stdout` even if multiple CC tracks are present in a Matroska input file (#1453)
 - Fix: crash in Rust decoder on ATSC1.0 TS Files (#1407)
 - Removed the --with-gui flag for linux/configure and mac/configure (use the Flutter GUI instead)
 - Fix: segmentation fault in using hardsubx

--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 0.95 (to be released)
 -----------------
+- Fix: respect `-stdout` even if multiple CC tracks are present in a Matroksa input file (#1453)
 - Fix: crash in Rust decoder on ATSC1.0 TS Files (#1407)
 - Removed the --with-gui flag for linux/configure and mac/configure (use the Flutter GUI instead)
 - Fix: segmentation fault in using hardsubx

--- a/src/lib_ccx/matroska.c
+++ b/src/lib_ccx/matroska.c
@@ -1099,15 +1099,24 @@ char *ass_ssa_sentence_erase_read_order(char *text)
 
 void save_sub_track(struct matroska_ctx *mkv_ctx, struct matroska_sub_track *track)
 {
-	char *filename = generate_filename_from_track(mkv_ctx, track);
-	mprint("\nOutput file: %s", filename);
+	char *filename;
 	int desc;
+
+	if (mkv_ctx->ctx->cc_to_stdout == CCX_TRUE)
+	{
+		desc = 1; // file descriptor of stdout
+	}
+	else
+	{
+		filename = generate_filename_from_track(mkv_ctx, track);
+		mprint("\nOutput file: %s", filename);
 #ifdef WIN32
-	desc = open(filename, O_WRONLY | O_CREAT | O_TRUNC | O_APPEND, S_IREAD | S_IWRITE);
+		desc = open(filename, O_WRONLY | O_CREAT | O_TRUNC | O_APPEND, S_IREAD | S_IWRITE);
 #else
-	desc = open(filename, O_WRONLY | O_CREAT | O_TRUNC | O_APPEND, S_IWUSR | S_IRUSR);
+		desc = open(filename, O_WRONLY | O_CREAT | O_TRUNC | O_APPEND, S_IWUSR | S_IRUSR);
 #endif
-	free(filename);
+		free(filename);
+	}
 
 	if (track->header != NULL)
 		write_wrapped(desc, track->header, strlen(track->header));


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

When passed the `-stdout` flag, CCExtractor should write the subtitles to standard output, instead of an output file.

However, as noted in Issue #1453, CCExtractor doesn't respect the `-stdout` flag when multiple CC tracks are present in a Matroska input file (usually .mkv).

The commit/s in this pull request ensure/s that output is written to standard output if `-stdout` is present even if the input file is a Matroska container with multiple CC tracks.

Signed-off-by: Abhishek Kumar <abhi.kr.2100@gmail.com>