### PR TITLE
[FIX] WebVTT X-TIMESTAMP-MAP header placement (#1463)

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -5,6 +5,7 @@
 - Fix: segmentation fault in using hardsubx
 - New: Add function (and command) that extracts closed caption subtitles as well as burnt-in subtitles from a file in a single pass. (As proposed in issue 726)
 - Refactored: the `general_loop` function has some code moved to a new function
+- Fix: WebVTT X-TIMESTAMP-MAP placement (#1463)
 
 
 0.94 (2021-12-14)

--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -6,7 +6,7 @@
 - New: Add function (and command) that extracts closed caption subtitles as well as burnt-in subtitles from a file in a single pass. (As proposed in issue 726)
 - Refactored: the `general_loop` function has some code moved to a new function
 - Fix: WebVTT X-TIMESTAMP-MAP placement (#1463)
-
+- Fix: Fixed --no-timestamp-map flag
 
 0.94 (2021-12-14)
 -----------------

--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -6,7 +6,7 @@
 - New: Add function (and command) that extracts closed caption subtitles as well as burnt-in subtitles from a file in a single pass. (As proposed in issue 726)
 - Refactored: the `general_loop` function has some code moved to a new function
 - Fix: WebVTT X-TIMESTAMP-MAP placement (#1463)
-- Fix: Fixed --no-timestamp-map flag
+- Disable X-TIMESTAMP-MAP by default (changed option --no-timestamp-map to --timestamp-map)
 
 0.94 (2021-12-14)
 -----------------

--- a/src/lib_ccx/ccx_common_option.c
+++ b/src/lib_ccx/ccx_common_option.c
@@ -41,7 +41,7 @@ void init_options(struct ccx_s_options *options)
 	options->live_stream = 0;     // 0 -> A regular file
 	options->messages_target = 1; // 1=stdout
 	options->print_file_reports = 0;
-	options->no_timestamp_map = 0; // Enable timestamps by default
+	options->timestamp_map = 0; // Disable X-TIMESTAMP-MAP header by default
 
 	/* Levenshtein's parameters, for string comparison */
 	options->dolevdist = 1;		  // By default attempt to correct typos

--- a/src/lib_ccx/ccx_common_option.h
+++ b/src/lib_ccx/ccx_common_option.h
@@ -117,7 +117,7 @@ struct ccx_s_options // Options from user parameters
                                          >0 -> Live stream with a timeout of this value in seconds */
 	char *filter_profanity_file;         // Extra profanity word file
 	int messages_target;              // 0 = nowhere (quiet), 1=stdout, 2=stderr
-	int no_timestamp_map;             // 1 for no timestamps for WebVTT, 0 for the timestamp header
+	int timestamp_map;                // If 1, add WebVTT X-TIMESTAMP-MAP header
 	/* Levenshtein's parameters, for string comparison */
 	int dolevdist;					  // 0 => don't attempt to correct typos with this algorithm
 	int levdistmincnt, levdistmaxpct; // Means 2 fails or less is "the same", 10% or less is also "the same"

--- a/src/lib_ccx/ccx_common_option.h
+++ b/src/lib_ccx/ccx_common_option.h
@@ -37,7 +37,6 @@ struct encoder_cfg
 	int force_flush;                     // Force flush on content write
 	int append_mode;                     // Append mode for output files
 	int ucla;                            // 1 if -UCLA used, 0 if not
-	int no_timestamp_map;				 // 1 if timestamps disabled for WebVTT
 
 	enum ccx_encoding_type encoding;
 	enum ccx_output_date_format date_format;

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -962,7 +962,6 @@ struct encoder_ctx *init_encoder(struct encoder_cfg *opt)
 	ctx->srt_counter = 0;
 	ctx->cea_708_counter = 0;
 	ctx->wrote_webvtt_header = 0;
-	ctx->no_timestamp_map = opt->no_timestamp_map;
 	ctx->wrote_ccd_channel_header = false;
 
 	ctx->program_number = opt->program_number;

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -92,7 +92,7 @@ static const char *smptett_header = "<?xml version=\"1.0\" encoding=\"UTF-8\" st
 				    "  <body>\n"
 				    "    <div>\n";
 
-static const char *webvtt_header[] = {"WEBVTT", "\r\n", "\r\n", NULL};
+static const char *webvtt_header[] = {"WEBVTT", "\r\n", NULL};
 
 static const char *simple_xml_header = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<captions>\r\n";
 

--- a/src/lib_ccx/ccx_encoders_common.h
+++ b/src/lib_ccx/ccx_encoders_common.h
@@ -89,8 +89,6 @@ struct encoder_ctx
 	int force_flush;
 	/* Keep track of whether -UCLA used */
 	int ucla;
-	/* Disable timestamps for WebVTT */
-	int no_timestamp_map;
 
 	struct ccx_common_timing_ctx *timing; /* Some encoders need access to PTS, such as WebVTT */
 

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -214,8 +214,8 @@ void write_webvtt_header(struct encoder_ctx *context)
 		unsigned h1, m1, s1, ms1;
 		millis_to_time(context->timing->sync_pts2fts_fts, &h1, &m1, &s1, &ms1);
 
-		// If the user has not disabled X-TIMESTAMP-MAP
-		if (!ccx_options.no_timestamp_map)
+		// If the user has enabled X-TIMESTAMP-MAP
+		if (ccx_options.timestamp_map)
 		{
 			sprintf(header_string, "X-TIMESTAMP-MAP=MPEGTS:%ld,LOCAL:%02u:%02u:%02u.%03u%s",
 				context->timing->sync_pts2fts_pts, h1, m1, s1, ms1,

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -221,6 +221,10 @@ void write_webvtt_header(struct encoder_ctx *context)
 				context->timing->sync_pts2fts_pts, h1, m1, s1, ms1,
 				ccx_options.enc_cfg.line_terminator_lf ? "\n\n" : "\r\n\r\n");
 		}
+		else
+		{
+			sprintf(header_string, ccx_options.enc_cfg.line_terminator_lf ? "\n" : "\r\n");
+		}
 		used = encode_line(context, context->buffer, (unsigned char *)header_string);
 		write_wrapped(context->out->fh, context->buffer, used);
 	}

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -215,7 +215,7 @@ void write_webvtt_header(struct encoder_ctx *context)
 		millis_to_time(context->timing->sync_pts2fts_fts, &h1, &m1, &s1, &ms1);
 
 		// If the user has not disabled X-TIMESTAMP-MAP
-		if (!context->no_timestamp_map)
+		if (!ccx_options.no_timestamp_map)
 		{
 			sprintf(header_string, "X-TIMESTAMP-MAP=MPEGTS:%ld,LOCAL:%02u:%02u:%02u.%03u%s",
 				context->timing->sync_pts2fts_pts, h1, m1, s1, ms1,

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -207,7 +207,7 @@ void write_webvtt_header(struct encoder_ctx *context)
 	if (context->wrote_webvtt_header) // Already done
 		return;
 
-	if (context->timing != NULL && context->timing->sync_pts2fts_set)
+	if (ccx_options.timestamp_map && context->timing != NULL && context->timing->sync_pts2fts_set)
 	{
 		char header_string[200];
 		int used;
@@ -215,18 +215,24 @@ void write_webvtt_header(struct encoder_ctx *context)
 		millis_to_time(context->timing->sync_pts2fts_fts, &h1, &m1, &s1, &ms1);
 
 		// If the user has enabled X-TIMESTAMP-MAP
-		if (ccx_options.timestamp_map)
+		sprintf(header_string, "X-TIMESTAMP-MAP=MPEGTS:%ld,LOCAL:%02u:%02u:%02u.%03u%s",
+			context->timing->sync_pts2fts_pts, h1, m1, s1, ms1,
+			ccx_options.enc_cfg.line_terminator_lf ? "\n\n" : "\r\n\r\n");
+
+		used = encode_line(context, context->buffer, (unsigned char *)header_string);
+		write_wrapped(context->out->fh, context->buffer, used);
+	}
+	else
+	{
+		// Must have another newline if X-TIMESTAMP-MAP is not used
+		if (ccx_options.enc_cfg.line_terminator_lf == 1) // If -lf parameter is set.
 		{
-			sprintf(header_string, "X-TIMESTAMP-MAP=MPEGTS:%ld,LOCAL:%02u:%02u:%02u.%03u%s",
-				context->timing->sync_pts2fts_pts, h1, m1, s1, ms1,
-				ccx_options.enc_cfg.line_terminator_lf ? "\n\n" : "\r\n\r\n");
+			write_wrapped(context->out->fh, "\n", 1);
 		}
 		else
 		{
-			sprintf(header_string, ccx_options.enc_cfg.line_terminator_lf ? "\n" : "\r\n");
+			write_wrapped(context->out->fh, "\r\n", 2);
 		}
-		used = encode_line(context, context->buffer, (unsigned char *)header_string);
-		write_wrapped(context->out->fh, context->buffer, used);
 	}
 
 	if (ccx_options.webvtt_create_css)

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -568,7 +568,7 @@ void print_usage(void)
 	mprint("                       less or equal than the max allowed..\n");
 	mprint("-anvid --analyzevideo  Analyze the video stream even if it's not used for\n");
 	mprint("                       subtitles. This allows to provide video information.\n");
-	mprint("  --no-timestamp-map   Use this flag to disable the X-TIMESTAMP-MAP header for WebVTT\n");
+	mprint("  --timestamp-map      Enable the X-TIMESTAMP-MAP header for WebVTT (HLS)\n");
 	mprint("Levenshtein distance:\n\n");
 	mprint("  When processing teletext files CCExtractor tries to correct typos by\n");
 	mprint("  comparing consecutive lines. If line N+1 is almost identical to line N except\n");
@@ -1528,9 +1528,9 @@ int parse_parameters(struct ccx_s_options *opt, int argc, char *argv[])
 			continue;
 		}
 
-		if (strcmp(argv[i], "--no-timestamp-map") == 0 || strcmp(argv[i], "-ntm") == 0)
+		if (strcmp(argv[i], "--timestamp-map") == 0 || strcmp(argv[i], "-tm") == 0)
 		{
-			opt->no_timestamp_map = 1;
+			opt->timestamp_map = 1;
 			continue;
 		}
 


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

This fixes issue #1463. If enabled, the X-TIMESTAMP-MAP header is placed on the second line. There are always two newlines between the headers and body.

This also fixes the --no-timestamp-map option, which wasn't disabling the header.

I added on the commit to disable X-TIMESTAMP-MAP header by default since it is not valid WebVTT. It doesn't make sense to generate invalid WebVTT by default, especially when the input is not MPEG-TS. This is a breaking change (--no-timestamp-map becomes --timestamp-map).