### PR TITLE
removing unused mut warnings

### DIFF
--- a/src/rust/build.rs
+++ b/src/rust/build.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    let mut allowlist_functions = vec![
+    let allowlist_functions = vec![
         ".*(?i)_?dtvcc_.*",
         "get_visible_.*",
         "get_fts",
@@ -18,7 +18,7 @@ fn main() {
         "mprint",
     ]);
 
-    let mut allowlist_types = vec![
+    let allowlist_types = vec![
         ".*(?i)_?dtvcc_.*",
         "encoder_ctx",
         "lib_cc_decode",


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

{pull request content here}
