### PR TITLE
fix: ffmpeg 5 and tesseract 5 compatibility

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -9,6 +9,7 @@
 - Fix: WebVTT X-TIMESTAMP-MAP placement (#1463)
 - Disable X-TIMESTAMP-MAP by default (changed option --no-timestamp-map to --timestamp-map)
 - Fix: missing `#` in color attribute of font tag
+- Fix: ffmpeg 5.0, tesseract 5.0 compatibility and remove deprecated methods
 
 0.94 (2021-12-14)
 -----------------

--- a/src/lib_ccx/ffmpeg_intgr.c
+++ b/src/lib_ccx/ffmpeg_intgr.c
@@ -133,7 +133,6 @@ int ff_get_ccframe(void *arg, unsigned char *data, int maxlen)
 	struct ffmpeg_ctx *ctx = arg;
 	int len = 0;
 	int ret = 0;
-	int got_frame;
 	AVPacket packet;
 
 	ret = av_read_frame(ctx->ifmt, &packet);
@@ -151,12 +150,13 @@ int ff_get_ccframe(void *arg, unsigned char *data, int maxlen)
 		return AVERROR(EAGAIN);
 	}
 
-	ret = avcodec_decode_video2(ctx->dec_ctx, ctx->frame, &got_frame, &packet);
+	avcodec_send_packet(ctx->codec_ctx, &ctx->packet);
+	ret = avcodec_receive_frame(ctx->dec_ctx, ctx->frame);
 	if (ret < 0)
 	{
 		av_log(NULL, AV_LOG_ERROR, "unable to decode packet\n");
 	}
-	else if (!got_frame)
+	else if (ret != 0)
 	{
 		return AVERROR(EAGAIN);
 	}

--- a/src/lib_ccx/ffmpeg_intgr.c
+++ b/src/lib_ccx/ffmpeg_intgr.c
@@ -66,7 +66,6 @@ void *init_ffmpeg(const char *path)
 	struct ffmpeg_ctx *ctx;
 	AVCodec *dec = NULL;
 	avcodec_register_all();
-	av_register_all();
 
 	if (ccx_options.debug_mask & CCX_DMT_VERBOSE)
 		av_log_set_level(AV_LOG_INFO);

--- a/src/lib_ccx/hardsubx.c
+++ b/src/lib_ccx/hardsubx.c
@@ -222,7 +222,7 @@ struct lib_hardsubx_ctx *_init_hardsubx(struct ccx_s_options *options)
 	char *pars_values = strdup("/dev/null");
 	char *tessdata_path = NULL;
 
-	char *lang = options->ocrlang;
+	char *lang = (char *)options->ocrlang;
 	if (!lang)
 		lang = "eng"; // English is default language
 
@@ -246,7 +246,7 @@ struct lib_hardsubx_ctx *_init_hardsubx(struct ccx_s_options *options)
 
 	int ret = -1;
 
-	if (!strncmp("4.", TessVersion(), 2))
+	if (!strncmp("4.", TessVersion(), 2) || !strncmp("5.", TessVersion(), 2))
 	{
 		char tess_path[1024];
 		if (ccx_options.ocr_oem < 0)

--- a/src/lib_ccx/hardsubx.c
+++ b/src/lib_ccx/hardsubx.c
@@ -32,7 +32,7 @@ int hardsubx_process_data(struct lib_hardsubx_ctx *ctx, struct lib_ccx_ctx *ctx_
 	ctx->video_stream_id = -1;
 	for (int i = 0; i < ctx->format_ctx->nb_streams; i++)
 	{
-		if (ctx->format_ctx->streams[i]->codec->codec_type == AVMEDIA_TYPE_VIDEO)
+		if (ctx->format_ctx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
 		{
 			ctx->video_stream_id = i;
 			break;
@@ -43,7 +43,7 @@ int hardsubx_process_data(struct lib_hardsubx_ctx *ctx, struct lib_ccx_ctx *ctx_
 		fatal(EXIT_READ_ERROR, "Video Stream not found!\n");
 	}
 
-	ctx->codec_ctx = ctx->format_ctx->streams[ctx->video_stream_id]->codec;
+	ctx->codec_ctx = ctx->format_ctx->streams[ctx->video_stream_id]->codecpar;
 	ctx->codec = avcodec_find_decoder(ctx->codec_ctx->codec_id);
 	if (ctx->codec == NULL)
 	{

--- a/src/lib_ccx/hardsubx.c
+++ b/src/lib_ccx/hardsubx.c
@@ -12,9 +12,6 @@
 
 int hardsubx_process_data(struct lib_hardsubx_ctx *ctx, struct lib_ccx_ctx *ctx_normal)
 {
-	// Get the required media attributes and initialize structures
-	av_register_all();
-
 	if (avformat_open_input(&ctx->format_ctx, ctx->inputfile[0], NULL, NULL) != 0)
 	{
 		fatal(EXIT_READ_ERROR, "Error reading input file!\n");

--- a/src/lib_ccx/hardsubx.c
+++ b/src/lib_ccx/hardsubx.c
@@ -40,8 +40,20 @@ int hardsubx_process_data(struct lib_hardsubx_ctx *ctx, struct lib_ccx_ctx *ctx_
 		fatal(EXIT_READ_ERROR, "Video Stream not found!\n");
 	}
 
-	ctx->codec_ctx = ctx->format_ctx->streams[ctx->video_stream_id]->codecpar;
-	ctx->codec = avcodec_find_decoder(ctx->codec_ctx->codec_id);
+	ctx->codec_ctx = avcodec_alloc_context3(NULL);
+	if (!ctx->codec_ctx)
+	{
+		fatal(EXIT_NOT_ENOUGH_MEMORY, "Could not allocate codec context!\n");
+	}
+
+	// Assign codec parameters to codec context
+	if (avcodec_parameters_to_context(ctx->codec_ctx, ctx->format_ctx->streams[ctx->video_stream_id]->codecpar) < 0)
+	{
+		fatal(EXIT_READ_ERROR, "Could not initialize codec context!\n");
+	}
+
+	// Find decoder for the codec context
+	ctx->codec = (AVCodec *)avcodec_find_decoder(ctx->codec_ctx->codec_id);
 	if (ctx->codec == NULL)
 	{
 		fatal(EXIT_READ_ERROR, "Input codec is not supported!\n");

--- a/src/lib_ccx/hardsubx_decoder.c
+++ b/src/lib_ccx/hardsubx_decoder.c
@@ -76,26 +76,26 @@ char *_process_frame_white_basic(struct lib_hardsubx_ctx *ctx, AVFrame *frame, i
 	// TESSERACT OCR FOR THE FRAME HERE
 	switch (ctx->ocr_mode)
 	{
-	case HARDSUBX_OCRMODE_WORD:
-		if (ctx->conf_thresh > 0)
-			subtitle_text = get_ocr_text_wordwise_threshold(ctx, feat_im, ctx->conf_thresh);
-		else
-			subtitle_text = get_ocr_text_wordwise(ctx, feat_im);
-		break;
-	case HARDSUBX_OCRMODE_LETTER:
-		if (ctx->conf_thresh > 0)
-			subtitle_text = get_ocr_text_letterwise_threshold(ctx, feat_im, ctx->conf_thresh);
-		else
-			subtitle_text = get_ocr_text_letterwise(ctx, feat_im);
-		break;
-	case HARDSUBX_OCRMODE_FRAME:
-		if (ctx->conf_thresh > 0)
-			subtitle_text = get_ocr_text_simple_threshold(ctx, feat_im, ctx->conf_thresh);
-		else
-			subtitle_text = get_ocr_text_simple(ctx, feat_im);
-		break;
-	default:
-		fatal(EXIT_MALFORMED_PARAMETER, "Invalid OCR Mode");
+		case HARDSUBX_OCRMODE_WORD:
+			if (ctx->conf_thresh > 0)
+				subtitle_text = get_ocr_text_wordwise_threshold(ctx, feat_im, ctx->conf_thresh);
+			else
+				subtitle_text = get_ocr_text_wordwise(ctx, feat_im);
+			break;
+		case HARDSUBX_OCRMODE_LETTER:
+			if (ctx->conf_thresh > 0)
+				subtitle_text = get_ocr_text_letterwise_threshold(ctx, feat_im, ctx->conf_thresh);
+			else
+				subtitle_text = get_ocr_text_letterwise(ctx, feat_im);
+			break;
+		case HARDSUBX_OCRMODE_FRAME:
+			if (ctx->conf_thresh > 0)
+				subtitle_text = get_ocr_text_simple_threshold(ctx, feat_im, ctx->conf_thresh);
+			else
+				subtitle_text = get_ocr_text_simple(ctx, feat_im);
+			break;
+		default:
+			fatal(EXIT_MALFORMED_PARAMETER, "Invalid OCR Mode");
 	}
 
 	pixDestroy(&im);
@@ -180,26 +180,26 @@ char *_process_frame_color_basic(struct lib_hardsubx_ctx *ctx, AVFrame *frame, i
 	// TESSERACT OCR FOR THE FRAME HERE
 	switch (ctx->ocr_mode)
 	{
-	case HARDSUBX_OCRMODE_WORD:
-		if (ctx->conf_thresh > 0)
-			subtitle_text = get_ocr_text_wordwise_threshold(ctx, feat_im, ctx->conf_thresh);
-		else
-			subtitle_text = get_ocr_text_wordwise(ctx, feat_im);
-		break;
-	case HARDSUBX_OCRMODE_LETTER:
-		if (ctx->conf_thresh > 0)
-			subtitle_text = get_ocr_text_letterwise_threshold(ctx, feat_im, ctx->conf_thresh);
-		else
-			subtitle_text = get_ocr_text_letterwise(ctx, feat_im);
-		break;
-	case HARDSUBX_OCRMODE_FRAME:
-		if (ctx->conf_thresh > 0)
-			subtitle_text = get_ocr_text_simple_threshold(ctx, feat_im, ctx->conf_thresh);
-		else
-			subtitle_text = get_ocr_text_simple(ctx, feat_im);
-		break;
-	default:
-		fatal(EXIT_MALFORMED_PARAMETER, "Invalid OCR Mode");
+		case HARDSUBX_OCRMODE_WORD:
+			if (ctx->conf_thresh > 0)
+				subtitle_text = get_ocr_text_wordwise_threshold(ctx, feat_im, ctx->conf_thresh);
+			else
+				subtitle_text = get_ocr_text_wordwise(ctx, feat_im);
+			break;
+		case HARDSUBX_OCRMODE_LETTER:
+			if (ctx->conf_thresh > 0)
+				subtitle_text = get_ocr_text_letterwise_threshold(ctx, feat_im, ctx->conf_thresh);
+			else
+				subtitle_text = get_ocr_text_letterwise(ctx, feat_im);
+			break;
+		case HARDSUBX_OCRMODE_FRAME:
+			if (ctx->conf_thresh > 0)
+				subtitle_text = get_ocr_text_simple_threshold(ctx, feat_im, ctx->conf_thresh);
+			else
+				subtitle_text = get_ocr_text_simple(ctx, feat_im);
+			break;
+		default:
+			fatal(EXIT_MALFORMED_PARAMETER, "Invalid OCR Mode");
 	}
 
 	pixDestroy(&im);
@@ -390,13 +390,13 @@ int hardsubx_process_frames_tickertext(struct lib_hardsubx_ctx *ctx, struct enco
 			{
 				// sws_scale is used to convert the pixel format to RGB24 from all other cases
 				sws_scale(
-					ctx->sws_ctx,
-					(uint8_t const *const *)ctx->frame->data,
-					ctx->frame->linesize,
-					0,
-					ctx->codec_ctx->height,
-					ctx->rgb_frame->data,
-					ctx->rgb_frame->linesize);
+				    ctx->sws_ctx,
+				    (uint8_t const *const *)ctx->frame->data,
+				    ctx->frame->linesize,
+				    0,
+				    ctx->codec_ctx->height,
+				    ctx->rgb_frame->data,
+				    ctx->rgb_frame->linesize);
 
 				ticker_text = _process_frame_tickertext(ctx, ctx->rgb_frame, ctx->codec_ctx->width, ctx->codec_ctx->height, frame_number);
 				printf("frame_number: %d\n", frame_number);
@@ -426,7 +426,7 @@ void hardsubx_process_frames_linear(struct lib_hardsubx_ctx *ctx, struct encoder
 	int frame_number = 0;
 	int64_t prev_begin_time = 0, prev_end_time = 0; // Begin and end time of previous seen subtitle
 	int64_t prev_packet_pts = 0;
-	char *subtitle_text = NULL;		 // Subtitle text of current frame
+	char *subtitle_text = NULL;	 // Subtitle text of current frame
 	char *prev_subtitle_text = NULL; // Previously seen subtitle text
 
 	while (av_read_frame(ctx->format_ctx, &ctx->packet) >= 0)
@@ -445,13 +445,13 @@ void hardsubx_process_frames_linear(struct lib_hardsubx_ctx *ctx, struct encoder
 
 				// sws_scale is used to convert the pixel format to RGB24 from all other cases
 				sws_scale(
-					ctx->sws_ctx,
-					(uint8_t const *const *)ctx->frame->data,
-					ctx->frame->linesize,
-					0,
-					ctx->codec_ctx->height,
-					ctx->rgb_frame->data,
-					ctx->rgb_frame->linesize);
+				    ctx->sws_ctx,
+				    (uint8_t const *const *)ctx->frame->data,
+				    ctx->frame->linesize,
+				    0,
+				    ctx->codec_ctx->height,
+				    ctx->rgb_frame->data,
+				    ctx->rgb_frame->linesize);
 
 				// Send the frame to other functions for processing
 				if (ctx->subcolor == HARDSUBX_COLOR_WHITE)
@@ -565,7 +565,7 @@ void process_hardsubx_linear_frames_and_normal_subs(struct lib_hardsubx_ctx *har
 	int frame_number = 0;
 	int64_t prev_begin_time_hard = 0, prev_end_time_hard = 0; // Begin and end time of previous seen burnt-in subtitle
 	int64_t prev_packet_pts_hard = 0;
-	char *subtitle_text_hard = NULL;	  // Subtitle text of current frame (burnt_in)
+	char *subtitle_text_hard = NULL;      // Subtitle text of current frame (burnt_in)
 	char *prev_subtitle_text_hard = NULL; // Previously seen burnt-in subtitle text
 
 	stream_mode = ctx->demux_ctx->get_stream_mode(ctx->demux_ctx);
@@ -575,40 +575,40 @@ void process_hardsubx_linear_frames_and_normal_subs(struct lib_hardsubx_ctx *har
 
 	switch (stream_mode)
 	{
-	case CCX_SM_ELEMENTARY_OR_NOT_FOUND:
-		get_more_data = &general_get_more_data;
-		break;
-	case CCX_SM_TRANSPORT:
-		get_more_data = &ts_get_more_data;
-		break;
-	case CCX_SM_PROGRAM:
-		get_more_data = &ps_get_more_data;
-		break;
-	case CCX_SM_ASF:
-		get_more_data = &asf_get_more_data;
-		break;
-	case CCX_SM_WTV:
-		get_more_data = &wtv_get_more_data;
-		break;
-		// case CCX_SM_GXF:
-		// 	get_more_data = &ccx_gxf_get_more_data;
-		// 	break;
+		case CCX_SM_ELEMENTARY_OR_NOT_FOUND:
+			get_more_data = &general_get_more_data;
+			break;
+		case CCX_SM_TRANSPORT:
+			get_more_data = &ts_get_more_data;
+			break;
+		case CCX_SM_PROGRAM:
+			get_more_data = &ps_get_more_data;
+			break;
+		case CCX_SM_ASF:
+			get_more_data = &asf_get_more_data;
+			break;
+		case CCX_SM_WTV:
+			get_more_data = &wtv_get_more_data;
+			break;
+			// case CCX_SM_GXF:
+			// 	get_more_data = &ccx_gxf_get_more_data;
+			// 	break;
 #ifdef ENABLE_FFMPEG
-	case CCX_SM_FFMPEG:
-		get_more_data = &ffmpeg_get_more_data;
-		break;
+		case CCX_SM_FFMPEG:
+			get_more_data = &ffmpeg_get_more_data;
+			break;
 #endif
-	// case CCX_SM_MXF:
-	// 	get_more_data = ccx_mxf_getmoredata;
-	// 	// The MXFContext might have already been initialized if the
-	// 	// stream type was autodetected
-	// 	if (ctx->demux_ctx->private_data == NULL)
-	// 	{
-	// 		ctx->demux_ctx->private_data = ccx_gxf_init(ctx->demux_ctx);
-	// 	}
-	// 	break;
-	default:
-		fatal(CCX_COMMON_EXIT_BUG_BUG, "In general_loop: Impossible value for stream_mode");
+		// case CCX_SM_MXF:
+		// 	get_more_data = ccx_mxf_getmoredata;
+		// 	// The MXFContext might have already been initialized if the
+		// 	// stream type was autodetected
+		// 	if (ctx->demux_ctx->private_data == NULL)
+		// 	{
+		// 		ctx->demux_ctx->private_data = ccx_gxf_init(ctx->demux_ctx);
+		// 	}
+		// 	break;
+		default:
+			fatal(CCX_COMMON_EXIT_BUG_BUG, "In general_loop: Impossible value for stream_mode");
 	}
 	end_of_file = 0;
 	int status = 0;
@@ -642,13 +642,13 @@ void process_hardsubx_linear_frames_and_normal_subs(struct lib_hardsubx_ctx *har
 					if (dec_ctx == NULL || hard_ctx->dec_sub->start_time >= (dec_ctx->dec_sub).start_time || status < 0)
 					{
 						int ret = process_non_multiprogram_general_loop(ctx,
-																		&datalist,
-																		&data_node,
-																		&dec_ctx,
-																		&enc_ctx,
-																		&min_pts,
-																		ret,
-																		&caps);
+												&datalist,
+												&data_node,
+												&dec_ctx,
+												&enc_ctx,
+												&min_pts,
+												ret,
+												&caps);
 					}
 				}
 				if (ctx->live_stream)
@@ -705,40 +705,40 @@ void process_hardsubx_linear_frames_and_normal_subs(struct lib_hardsubx_ctx *har
 
 				avcodec_send_packet(hard_ctx->codec_ctx, &hard_ctx->packet);
 				if (avcodec_receive_frame(hard_ctx->codec_ctx,
-										  hard_ctx->frame) == 0 &&
-					frame_number % 25 == 0)
+							  hard_ctx->frame) == 0 &&
+				    frame_number % 25 == 0)
 				{
 					float diff = (float)convert_pts_to_ms(hard_ctx->packet.pts - prev_packet_pts_hard,
-														  hard_ctx->format_ctx->streams[hard_ctx->video_stream_id]->time_base);
+									      hard_ctx->format_ctx->streams[hard_ctx->video_stream_id]->time_base);
 
 					if (fabsf(diff) >= 1000 * hard_ctx->min_sub_duration)
 					{
 
 						// sws_scale is used to convert the pixel format to RGB24 from all other cases
 						sws_scale(
-							hard_ctx->sws_ctx,
-							(uint8_t const *const *)hard_ctx->frame->data,
-							hard_ctx->frame->linesize,
-							0,
-							hard_ctx->codec_ctx->height,
-							hard_ctx->rgb_frame->data,
-							hard_ctx->rgb_frame->linesize);
+						    hard_ctx->sws_ctx,
+						    (uint8_t const *const *)hard_ctx->frame->data,
+						    hard_ctx->frame->linesize,
+						    0,
+						    hard_ctx->codec_ctx->height,
+						    hard_ctx->rgb_frame->data,
+						    hard_ctx->rgb_frame->linesize);
 
 						if (hard_ctx->subcolor == HARDSUBX_COLOR_WHITE)
 						{
 							subtitle_text_hard = _process_frame_white_basic(hard_ctx,
-																			hard_ctx->rgb_frame,
-																			hard_ctx->codec_ctx->width,
-																			hard_ctx->codec_ctx->height,
-																			frame_number);
+													hard_ctx->rgb_frame,
+													hard_ctx->codec_ctx->width,
+													hard_ctx->codec_ctx->height,
+													frame_number);
 						}
 						else
 						{
 							subtitle_text_hard = _process_frame_color_basic(hard_ctx,
-																			hard_ctx->rgb_frame,
-																			hard_ctx->codec_ctx->width,
-																			hard_ctx->codec_ctx->height,
-																			frame_number);
+													hard_ctx->rgb_frame,
+													hard_ctx->codec_ctx->width,
+													hard_ctx->codec_ctx->height,
+													frame_number);
 						}
 
 						_display_frame(hard_ctx, hard_ctx->rgb_frame, hard_ctx->codec_ctx->width, hard_ctx->codec_ctx->height, frame_number);
@@ -843,13 +843,13 @@ void hardsubx_process_frames_binary(struct lib_hardsubx_ctx *ctx)
 						// printf("GOT FRAME: %d\n",ctx->packet.pts);
 						// sws_scale is used to convert the pixel format to RGB24 from all other cases
 						sws_scale(
-							ctx->sws_ctx,
-							(uint8_t const *const *)ctx->frame->data,
-							ctx->frame->linesize,
-							0,
-							ctx->codec_ctx->height,
-							ctx->rgb_frame->data,
-							ctx->rgb_frame->linesize);
+						    ctx->sws_ctx,
+						    (uint8_t const *const *)ctx->frame->data,
+						    ctx->frame->linesize,
+						    0,
+						    ctx->codec_ctx->height,
+						    ctx->rgb_frame->data,
+						    ctx->rgb_frame->linesize);
 						// Send the frame to other functions for processing
 						_display_frame(ctx, ctx->rgb_frame, ctx->codec_ctx->width, ctx->codec_ctx->height, seconds_time);
 						break;

--- a/src/lib_ccx/hardsubx_decoder.c
+++ b/src/lib_ccx/hardsubx_decoder.c
@@ -76,26 +76,26 @@ char *_process_frame_white_basic(struct lib_hardsubx_ctx *ctx, AVFrame *frame, i
 	// TESSERACT OCR FOR THE FRAME HERE
 	switch (ctx->ocr_mode)
 	{
-		case HARDSUBX_OCRMODE_WORD:
-			if (ctx->conf_thresh > 0)
-				subtitle_text = get_ocr_text_wordwise_threshold(ctx, feat_im, ctx->conf_thresh);
-			else
-				subtitle_text = get_ocr_text_wordwise(ctx, feat_im);
-			break;
-		case HARDSUBX_OCRMODE_LETTER:
-			if (ctx->conf_thresh > 0)
-				subtitle_text = get_ocr_text_letterwise_threshold(ctx, feat_im, ctx->conf_thresh);
-			else
-				subtitle_text = get_ocr_text_letterwise(ctx, feat_im);
-			break;
-		case HARDSUBX_OCRMODE_FRAME:
-			if (ctx->conf_thresh > 0)
-				subtitle_text = get_ocr_text_simple_threshold(ctx, feat_im, ctx->conf_thresh);
-			else
-				subtitle_text = get_ocr_text_simple(ctx, feat_im);
-			break;
-		default:
-			fatal(EXIT_MALFORMED_PARAMETER, "Invalid OCR Mode");
+	case HARDSUBX_OCRMODE_WORD:
+		if (ctx->conf_thresh > 0)
+			subtitle_text = get_ocr_text_wordwise_threshold(ctx, feat_im, ctx->conf_thresh);
+		else
+			subtitle_text = get_ocr_text_wordwise(ctx, feat_im);
+		break;
+	case HARDSUBX_OCRMODE_LETTER:
+		if (ctx->conf_thresh > 0)
+			subtitle_text = get_ocr_text_letterwise_threshold(ctx, feat_im, ctx->conf_thresh);
+		else
+			subtitle_text = get_ocr_text_letterwise(ctx, feat_im);
+		break;
+	case HARDSUBX_OCRMODE_FRAME:
+		if (ctx->conf_thresh > 0)
+			subtitle_text = get_ocr_text_simple_threshold(ctx, feat_im, ctx->conf_thresh);
+		else
+			subtitle_text = get_ocr_text_simple(ctx, feat_im);
+		break;
+	default:
+		fatal(EXIT_MALFORMED_PARAMETER, "Invalid OCR Mode");
 	}
 
 	pixDestroy(&im);
@@ -180,26 +180,26 @@ char *_process_frame_color_basic(struct lib_hardsubx_ctx *ctx, AVFrame *frame, i
 	// TESSERACT OCR FOR THE FRAME HERE
 	switch (ctx->ocr_mode)
 	{
-		case HARDSUBX_OCRMODE_WORD:
-			if (ctx->conf_thresh > 0)
-				subtitle_text = get_ocr_text_wordwise_threshold(ctx, feat_im, ctx->conf_thresh);
-			else
-				subtitle_text = get_ocr_text_wordwise(ctx, feat_im);
-			break;
-		case HARDSUBX_OCRMODE_LETTER:
-			if (ctx->conf_thresh > 0)
-				subtitle_text = get_ocr_text_letterwise_threshold(ctx, feat_im, ctx->conf_thresh);
-			else
-				subtitle_text = get_ocr_text_letterwise(ctx, feat_im);
-			break;
-		case HARDSUBX_OCRMODE_FRAME:
-			if (ctx->conf_thresh > 0)
-				subtitle_text = get_ocr_text_simple_threshold(ctx, feat_im, ctx->conf_thresh);
-			else
-				subtitle_text = get_ocr_text_simple(ctx, feat_im);
-			break;
-		default:
-			fatal(EXIT_MALFORMED_PARAMETER, "Invalid OCR Mode");
+	case HARDSUBX_OCRMODE_WORD:
+		if (ctx->conf_thresh > 0)
+			subtitle_text = get_ocr_text_wordwise_threshold(ctx, feat_im, ctx->conf_thresh);
+		else
+			subtitle_text = get_ocr_text_wordwise(ctx, feat_im);
+		break;
+	case HARDSUBX_OCRMODE_LETTER:
+		if (ctx->conf_thresh > 0)
+			subtitle_text = get_ocr_text_letterwise_threshold(ctx, feat_im, ctx->conf_thresh);
+		else
+			subtitle_text = get_ocr_text_letterwise(ctx, feat_im);
+		break;
+	case HARDSUBX_OCRMODE_FRAME:
+		if (ctx->conf_thresh > 0)
+			subtitle_text = get_ocr_text_simple_threshold(ctx, feat_im, ctx->conf_thresh);
+		else
+			subtitle_text = get_ocr_text_simple(ctx, feat_im);
+		break;
+	default:
+		fatal(EXIT_MALFORMED_PARAMETER, "Invalid OCR Mode");
 	}
 
 	pixDestroy(&im);
@@ -375,7 +375,6 @@ char *_process_frame_tickertext(struct lib_hardsubx_ctx *ctx, AVFrame *frame, in
 int hardsubx_process_frames_tickertext(struct lib_hardsubx_ctx *ctx, struct encoder_ctx *enc_ctx)
 {
 	// Search for ticker text at the bottom of the screen, such as in Russia TV1 or stock prices
-	int got_frame;
 	int cur_sec = 0, total_sec, progress;
 	int frame_number = 0;
 	char *ticker_text = NULL;
@@ -386,18 +385,18 @@ int hardsubx_process_frames_tickertext(struct lib_hardsubx_ctx *ctx, struct enco
 		{
 			frame_number++;
 			// Decode the video stream packet
-			avcodec_decode_video2(ctx->codec_ctx, ctx->frame, &got_frame, &ctx->packet);
-			if (got_frame && frame_number % 1000 == 0)
+			avcodec_send_packet(ctx->codec_ctx, &ctx->packet);
+			if (avcodec_receive_frame(ctx->codec_ctx, ctx->frame) == 0 && frame_number % 1000 == 0)
 			{
 				// sws_scale is used to convert the pixel format to RGB24 from all other cases
 				sws_scale(
-				    ctx->sws_ctx,
-				    (uint8_t const *const *)ctx->frame->data,
-				    ctx->frame->linesize,
-				    0,
-				    ctx->codec_ctx->height,
-				    ctx->rgb_frame->data,
-				    ctx->rgb_frame->linesize);
+					ctx->sws_ctx,
+					(uint8_t const *const *)ctx->frame->data,
+					ctx->frame->linesize,
+					0,
+					ctx->codec_ctx->height,
+					ctx->rgb_frame->data,
+					ctx->rgb_frame->linesize);
 
 				ticker_text = _process_frame_tickertext(ctx, ctx->rgb_frame, ctx->codec_ctx->width, ctx->codec_ctx->height, frame_number);
 				printf("frame_number: %d\n", frame_number);
@@ -422,13 +421,12 @@ void hardsubx_process_frames_linear(struct lib_hardsubx_ctx *ctx, struct encoder
 	// Do an exhaustive linear search over the video
 
 	int prev_sub_encoded = 1; // Previous seen subtitle encoded or not
-	int got_frame;
 	int dist = 0;
 	int cur_sec = 0, total_sec, progress;
 	int frame_number = 0;
 	int64_t prev_begin_time = 0, prev_end_time = 0; // Begin and end time of previous seen subtitle
 	int64_t prev_packet_pts = 0;
-	char *subtitle_text = NULL;	 // Subtitle text of current frame
+	char *subtitle_text = NULL;		 // Subtitle text of current frame
 	char *prev_subtitle_text = NULL; // Previously seen subtitle text
 
 	while (av_read_frame(ctx->format_ctx, &ctx->packet) >= 0)
@@ -438,9 +436,8 @@ void hardsubx_process_frames_linear(struct lib_hardsubx_ctx *ctx, struct encoder
 			frame_number++;
 
 			// Decode the video stream packet
-			avcodec_decode_video2(ctx->codec_ctx, ctx->frame, &got_frame, &ctx->packet);
-
-			if (got_frame && frame_number % 25 == 0)
+			avcodec_send_packet(ctx->codec_ctx, &ctx->packet);
+			if (avcodec_receive_frame(ctx->codec_ctx, ctx->frame) == 0 && frame_number % 25 == 0)
 			{
 				float diff = (float)convert_pts_to_ms(ctx->packet.pts - prev_packet_pts, ctx->format_ctx->streams[ctx->video_stream_id]->time_base);
 				if (fabsf(diff) < 1000 * ctx->min_sub_duration) // If the minimum duration of a subtitle line is exceeded, process packet
@@ -448,13 +445,13 @@ void hardsubx_process_frames_linear(struct lib_hardsubx_ctx *ctx, struct encoder
 
 				// sws_scale is used to convert the pixel format to RGB24 from all other cases
 				sws_scale(
-				    ctx->sws_ctx,
-				    (uint8_t const *const *)ctx->frame->data,
-				    ctx->frame->linesize,
-				    0,
-				    ctx->codec_ctx->height,
-				    ctx->rgb_frame->data,
-				    ctx->rgb_frame->linesize);
+					ctx->sws_ctx,
+					(uint8_t const *const *)ctx->frame->data,
+					ctx->frame->linesize,
+					0,
+					ctx->codec_ctx->height,
+					ctx->rgb_frame->data,
+					ctx->rgb_frame->linesize);
 
 				// Send the frame to other functions for processing
 				if (ctx->subcolor == HARDSUBX_COLOR_WHITE)
@@ -563,13 +560,12 @@ void process_hardsubx_linear_frames_and_normal_subs(struct lib_hardsubx_ctx *har
 
 	// variables for burnt-in subtitle extraction
 	int prev_sub_encoded_hard = 1; // Previous seen burnt-in subtitle encoded or not
-	int got_frame;
 	int dist = 0;
 	int cur_sec = 0, total_sec, progress;
 	int frame_number = 0;
 	int64_t prev_begin_time_hard = 0, prev_end_time_hard = 0; // Begin and end time of previous seen burnt-in subtitle
 	int64_t prev_packet_pts_hard = 0;
-	char *subtitle_text_hard = NULL;      // Subtitle text of current frame (burnt_in)
+	char *subtitle_text_hard = NULL;	  // Subtitle text of current frame (burnt_in)
 	char *prev_subtitle_text_hard = NULL; // Previously seen burnt-in subtitle text
 
 	stream_mode = ctx->demux_ctx->get_stream_mode(ctx->demux_ctx);
@@ -579,40 +575,40 @@ void process_hardsubx_linear_frames_and_normal_subs(struct lib_hardsubx_ctx *har
 
 	switch (stream_mode)
 	{
-		case CCX_SM_ELEMENTARY_OR_NOT_FOUND:
-			get_more_data = &general_get_more_data;
-			break;
-		case CCX_SM_TRANSPORT:
-			get_more_data = &ts_get_more_data;
-			break;
-		case CCX_SM_PROGRAM:
-			get_more_data = &ps_get_more_data;
-			break;
-		case CCX_SM_ASF:
-			get_more_data = &asf_get_more_data;
-			break;
-		case CCX_SM_WTV:
-			get_more_data = &wtv_get_more_data;
-			break;
-			// case CCX_SM_GXF:
-			// 	get_more_data = &ccx_gxf_get_more_data;
-			// 	break;
-#ifdef ENABLE_FFMPEG
-		case CCX_SM_FFMPEG:
-			get_more_data = &ffmpeg_get_more_data;
-			break;
-#endif
-		// case CCX_SM_MXF:
-		// 	get_more_data = ccx_mxf_getmoredata;
-		// 	// The MXFContext might have already been initialized if the
-		// 	// stream type was autodetected
-		// 	if (ctx->demux_ctx->private_data == NULL)
-		// 	{
-		// 		ctx->demux_ctx->private_data = ccx_gxf_init(ctx->demux_ctx);
-		// 	}
+	case CCX_SM_ELEMENTARY_OR_NOT_FOUND:
+		get_more_data = &general_get_more_data;
+		break;
+	case CCX_SM_TRANSPORT:
+		get_more_data = &ts_get_more_data;
+		break;
+	case CCX_SM_PROGRAM:
+		get_more_data = &ps_get_more_data;
+		break;
+	case CCX_SM_ASF:
+		get_more_data = &asf_get_more_data;
+		break;
+	case CCX_SM_WTV:
+		get_more_data = &wtv_get_more_data;
+		break;
+		// case CCX_SM_GXF:
+		// 	get_more_data = &ccx_gxf_get_more_data;
 		// 	break;
-		default:
-			fatal(CCX_COMMON_EXIT_BUG_BUG, "In general_loop: Impossible value for stream_mode");
+#ifdef ENABLE_FFMPEG
+	case CCX_SM_FFMPEG:
+		get_more_data = &ffmpeg_get_more_data;
+		break;
+#endif
+	// case CCX_SM_MXF:
+	// 	get_more_data = ccx_mxf_getmoredata;
+	// 	// The MXFContext might have already been initialized if the
+	// 	// stream type was autodetected
+	// 	if (ctx->demux_ctx->private_data == NULL)
+	// 	{
+	// 		ctx->demux_ctx->private_data = ccx_gxf_init(ctx->demux_ctx);
+	// 	}
+	// 	break;
+	default:
+		fatal(CCX_COMMON_EXIT_BUG_BUG, "In general_loop: Impossible value for stream_mode");
 	}
 	end_of_file = 0;
 	int status = 0;
@@ -646,13 +642,13 @@ void process_hardsubx_linear_frames_and_normal_subs(struct lib_hardsubx_ctx *har
 					if (dec_ctx == NULL || hard_ctx->dec_sub->start_time >= (dec_ctx->dec_sub).start_time || status < 0)
 					{
 						int ret = process_non_multiprogram_general_loop(ctx,
-												&datalist,
-												&data_node,
-												&dec_ctx,
-												&enc_ctx,
-												&min_pts,
-												ret,
-												&caps);
+																		&datalist,
+																		&data_node,
+																		&dec_ctx,
+																		&enc_ctx,
+																		&min_pts,
+																		ret,
+																		&caps);
 					}
 				}
 				if (ctx->live_stream)
@@ -707,44 +703,42 @@ void process_hardsubx_linear_frames_and_normal_subs(struct lib_hardsubx_ctx *har
 			{
 				frame_number++;
 
-				avcodec_decode_video2(hard_ctx->codec_ctx,
-						      hard_ctx->frame,
-						      &got_frame,
-						      &hard_ctx->packet);
-
-				if (got_frame && frame_number % 25 == 0)
+				avcodec_send_packet(hard_ctx->codec_ctx, &hard_ctx->packet);
+				if (avcodec_receive_frame(hard_ctx->codec_ctx,
+										  hard_ctx->frame) == 0 &&
+					frame_number % 25 == 0)
 				{
 					float diff = (float)convert_pts_to_ms(hard_ctx->packet.pts - prev_packet_pts_hard,
-									      hard_ctx->format_ctx->streams[hard_ctx->video_stream_id]->time_base);
+														  hard_ctx->format_ctx->streams[hard_ctx->video_stream_id]->time_base);
 
 					if (fabsf(diff) >= 1000 * hard_ctx->min_sub_duration)
 					{
 
 						// sws_scale is used to convert the pixel format to RGB24 from all other cases
 						sws_scale(
-						    hard_ctx->sws_ctx,
-						    (uint8_t const *const *)hard_ctx->frame->data,
-						    hard_ctx->frame->linesize,
-						    0,
-						    hard_ctx->codec_ctx->height,
-						    hard_ctx->rgb_frame->data,
-						    hard_ctx->rgb_frame->linesize);
+							hard_ctx->sws_ctx,
+							(uint8_t const *const *)hard_ctx->frame->data,
+							hard_ctx->frame->linesize,
+							0,
+							hard_ctx->codec_ctx->height,
+							hard_ctx->rgb_frame->data,
+							hard_ctx->rgb_frame->linesize);
 
 						if (hard_ctx->subcolor == HARDSUBX_COLOR_WHITE)
 						{
 							subtitle_text_hard = _process_frame_white_basic(hard_ctx,
-													hard_ctx->rgb_frame,
-													hard_ctx->codec_ctx->width,
-													hard_ctx->codec_ctx->height,
-													frame_number);
+																			hard_ctx->rgb_frame,
+																			hard_ctx->codec_ctx->width,
+																			hard_ctx->codec_ctx->height,
+																			frame_number);
 						}
 						else
 						{
 							subtitle_text_hard = _process_frame_color_basic(hard_ctx,
-													hard_ctx->rgb_frame,
-													hard_ctx->codec_ctx->width,
-													hard_ctx->codec_ctx->height,
-													frame_number);
+																			hard_ctx->rgb_frame,
+																			hard_ctx->codec_ctx->width,
+																			hard_ctx->codec_ctx->height,
+																			frame_number);
 						}
 
 						_display_frame(hard_ctx, hard_ctx->rgb_frame, hard_ctx->codec_ctx->width, hard_ctx->codec_ctx->height, frame_number);
@@ -821,7 +815,6 @@ void hardsubx_process_frames_binary(struct lib_hardsubx_ctx *ctx)
 {
 	// Do a binary search over the input video for faster processing
 	// printf("Duration: %d\n", (int)ctx->format_ctx->duration);
-	int got_frame;
 	int seconds_time = 0;
 	for (seconds_time = 0; seconds_time < 20; seconds_time++)
 	{
@@ -841,8 +834,8 @@ void hardsubx_process_frames_binary(struct lib_hardsubx_ctx *ctx)
 			{
 				if (ctx->packet.stream_index == ctx->video_stream_id)
 				{
-					avcodec_decode_video2(ctx->codec_ctx, ctx->frame, &got_frame, &ctx->packet);
-					if (got_frame)
+					avcodec_send_packet(ctx->codec_ctx, &ctx->packet);
+					if (avcodec_receive_frame(ctx->codec_ctx, ctx->frame) == 0)
 					{
 						// printf("%d\n", seek_time);
 						if (ctx->packet.pts < seek_time)
@@ -850,13 +843,13 @@ void hardsubx_process_frames_binary(struct lib_hardsubx_ctx *ctx)
 						// printf("GOT FRAME: %d\n",ctx->packet.pts);
 						// sws_scale is used to convert the pixel format to RGB24 from all other cases
 						sws_scale(
-						    ctx->sws_ctx,
-						    (uint8_t const *const *)ctx->frame->data,
-						    ctx->frame->linesize,
-						    0,
-						    ctx->codec_ctx->height,
-						    ctx->rgb_frame->data,
-						    ctx->rgb_frame->linesize);
+							ctx->sws_ctx,
+							(uint8_t const *const *)ctx->frame->data,
+							ctx->frame->linesize,
+							0,
+							ctx->codec_ctx->height,
+							ctx->rgb_frame->data,
+							ctx->rgb_frame->linesize);
 						// Send the frame to other functions for processing
 						_display_frame(ctx, ctx->rgb_frame, ctx->codec_ctx->width, ctx->codec_ctx->height, seconds_time);
 						break;

--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -127,6 +127,11 @@ char *probe_tessdata_location(const char *lang)
 	ret = search_language_pack(tessdata_dir_path, lang);
 	if (!ret)
 		return tessdata_dir_path;
+	
+	tessdata_dir_path = "/usr/share/tesseract-ocr/5/";
+	ret = search_language_pack(tessdata_dir_path, lang);
+	if (!ret)
+		return tessdata_dir_path;
 
 	return NULL;
 }

--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -97,41 +97,22 @@ void delete_ocr(void **arg)
 char *probe_tessdata_location(const char *lang)
 {
 	int ret = 0;
-	char *tessdata_dir_path = getenv("TESSDATA_PREFIX");
 
-	ret = search_language_pack(tessdata_dir_path, lang);
-	if (!ret)
-		return tessdata_dir_path;
+	const char *paths[] = {
+	    getenv("TESSDATA_PREFIX"),
+	    "./",
+	    "/usr/share/",
+	    "/usr/local/share/",
+	    "/usr/share/tesseract-ocr/",
+	    "/usr/share/tesseract-ocr/4.00/",
+	    "/usr/share/tesseract-ocr/5/",
+	    "/usr/share/tesseract/"};
 
-	tessdata_dir_path = "./";
-	ret = search_language_pack(tessdata_dir_path, lang);
-	if (!ret)
-		return tessdata_dir_path;
-
-	tessdata_dir_path = "/usr/share/";
-	ret = search_language_pack(tessdata_dir_path, lang);
-	if (!ret)
-		return tessdata_dir_path;
-
-	tessdata_dir_path = "/usr/local/share/";
-	ret = search_language_pack(tessdata_dir_path, lang);
-	if (!ret)
-		return tessdata_dir_path;
-
-	tessdata_dir_path = "/usr/share/tesseract-ocr/";
-	ret = search_language_pack(tessdata_dir_path, lang);
-	if (!ret)
-		return tessdata_dir_path;
-
-	tessdata_dir_path = "/usr/share/tesseract-ocr/4.00/";
-	ret = search_language_pack(tessdata_dir_path, lang);
-	if (!ret)
-		return tessdata_dir_path;
-	
-	tessdata_dir_path = "/usr/share/tesseract-ocr/5/";
-	ret = search_language_pack(tessdata_dir_path, lang);
-	if (!ret)
-		return tessdata_dir_path;
+	for (int i = 0; i < sizeof(paths) / sizeof(paths[0]); i++)
+	{
+		if (!search_language_pack(paths[i], lang))
+			return paths[i];
+	}
 
 	return NULL;
 }

--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -111,7 +111,7 @@ char *probe_tessdata_location(const char *lang)
 	for (int i = 0; i < sizeof(paths) / sizeof(paths[0]); i++)
 	{
 		if (!search_language_pack(paths[i], lang))
-			return paths[i];
+			return (char *)paths[i];
 	}
 
 	return NULL;


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

CCExtractor build fails when using build_hardsubx with ffmpeg 5.0 and tesseract 5.0, This PR is for fixing the build of hardsubx with ffmpeg 5.x and tesseract 5.x.
- For FFmpeg, Basically `codec` is now deprecated in favor of `codecpar` and `av_register_all` is deprecated in many places
- For Tesseract, now the tessdata is located in /usr/share/tesseract-ocr/5/
- For Hardsubx. I have changed the code for getting the codec to fix 0x0 widthxheight error.

Resolves: #1418