### PR TITLE
[FIX] Missing `#` in color attribute of font tag

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -8,6 +8,7 @@
 - Refactored: the `general_loop` function has some code moved to a new function
 - Fix: WebVTT X-TIMESTAMP-MAP placement (#1463)
 - Disable X-TIMESTAMP-MAP by default (changed option --no-timestamp-map to --timestamp-map)
+- Fix: missing `#` in color attribute of font tag
 
 0.94 (2021-12-14)
 -----------------

--- a/src/lib_ccx/ccx_decoders_708_output.c
+++ b/src/lib_ccx/ccx_decoders_708_output.c
@@ -75,7 +75,7 @@ void dtvcc_change_pen_colors(dtvcc_tv_screen *tv, dtvcc_pen_color pen_color, int
 			red = (255 / 3) * red;
 			green = (255 / 3) * green;
 			blue = (255 / 3) * blue;
-			(*buf_len) += sprintf(buf + (*buf_len), "<font color=\"%02x%02x%02x\">", red, green, blue);
+			(*buf_len) += sprintf(buf + (*buf_len), "<font color=\"#%02x%02x%02x\">", red, green, blue);
 		}
 	}
 }

--- a/src/rust/src/decoder/tv_screen.rs
+++ b/src/rust/src/decoder/tv_screen.rs
@@ -469,7 +469,7 @@ impl dtvcc_tv_screen {
                 red *= 255 / 3;
                 green *= 255 / 3;
                 blue *= 255 / 3;
-                let font_tag = format!("<font color=\"{:02x}{:02x}{:02x}\">", red, green, blue);
+                let font_tag = format!("<font color=\"#{:02x}{:02x}{:02x}\">", red, green, blue);
                 buf.extend_from_slice(font_tag.as_bytes());
             }
         }


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Link to sample video: https://drive.google.com/file/d/13p6HBxGXlm0BGpaS15JwCJjfnBdm_Qbm/view?usp=sharing
Running ccextractor on the above sample video WhackedOutVideos_short.mov produces a file WhackedOutVideos_short.p0.svc01.srt with the following contents:
```
1
00:00:02,502 --> 00:00:03,636
<font color="aaaaaa">Or is this synchronized</font>

2
00:00:03,637 --> 00:00:05,971
<font color="aaaaaa">Or is this synchronized</font>
<font color="aaaaaa">stick poking?</font>

.
.
.
```

Without the `#` in color attribute of font tag, the text is rendered by black color instead of `#aaaaaa`. This PR adds the missing `#`:
```
1
00:00:02,502 --> 00:00:03,636
<font color="#aaaaaa">Or is this synchronized</font>

2
00:00:03,637 --> 00:00:05,971
<font color="#aaaaaa">Or is this synchronized</font>
<font color="#aaaaaa">stick poking?</font>

.
.
.
```