### PR TITLE
[IMPROVEMENT] adding the release flag to `cargo build` in linux/build

### DIFF
--- a/linux/build
+++ b/linux/build
@@ -91,7 +91,7 @@ else
     else
         (cd ../src/rust && CARGO_TARGET_DIR=../../linux/rust cargo build --release) || { echo "Failed. " ; exit 1; }
     fi
-    cp rust/debug/libccx_rust.a ./libccx_rust.a
+    cp rust/release/libccx_rust.a ./libccx_rust.a
 fi
 
 echo "Building ccextractor"

--- a/linux/build
+++ b/linux/build
@@ -87,9 +87,9 @@ else
     echo "${BLD_FLAGS}"
     tokens=( ${BLD_FLAGS} )
     if [ ${tokens[0]} = "-DENABLE_HARDSUBX" ]; then
-        (cd ../src/rust && CARGO_TARGET_DIR=../../linux/rust cargo build --features "hardsubx_ocr") || { echo "Failed. " ; exit 1; }
+        (cd ../src/rust && CARGO_TARGET_DIR=../../linux/rust cargo build --release --features "hardsubx_ocr") || { echo "Failed. " ; exit 1; }
     else
-        (cd ../src/rust && CARGO_TARGET_DIR=../../linux/rust cargo build) || { echo "Failed. " ; exit 1; }
+        (cd ../src/rust && CARGO_TARGET_DIR=../../linux/rust cargo build --release) || { echo "Failed. " ; exit 1; }
     fi
     cp rust/debug/libccx_rust.a ./libccx_rust.a
 fi


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

I noticed that the Linux `build` script did not compile Rust with the release flag. I haven't mentioned this in the changelog because I'm not sure if it qualifies to make that list.
