### PR TITLE
[FIX] broken -hardsubx flag

### DIFF
--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -66,6 +66,15 @@ int api_start(struct ccx_s_options api_options)
 			fatal(EXIT_NOT_CLASSIFIED, "Unable to create Library Context %d\n", errno);
 	}
 
+#ifdef ENABLE_HARDSUBX
+	if (api_options.hardsubx)
+	{
+		// Perform burned in subtitle extraction
+		hardsubx(&api_options, ctx);
+		return 0;
+	}
+#endif
+
 #ifdef WITH_LIBCURL
 	curl_global_init(CURL_GLOBAL_ALL);
 
@@ -193,14 +202,6 @@ int api_start(struct ccx_s_options api_options)
 				if (api_options.ignore_pts_jumps)
 					ccx_common_timing_settings.disable_sync_check = 1;
 				mprint("\rAnalyzing data in general mode\n");
-#ifdef ENABLE_HARDSUBX
-				if (api_options.hardsubx)
-				{
-					// Perform burned in subtitle extraction
-					hardsubx(&api_options, ctx);
-					return 0;
-				}
-#endif
 				tmp = general_loop(ctx);
 				if (!ret)
 					ret = tmp;


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Hardsubx flag was broken by a bad commit, this PR fixes that.
