### PR TITLE
[FIX] tesseract 5.x traineddata location in ocr

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -10,6 +10,7 @@
 - Disable X-TIMESTAMP-MAP by default (changed option --no-timestamp-map to --timestamp-map)
 - Fix: missing `#` in color attribute of font tag
 - Fix: ffmpeg 5.0, tesseract 5.0 compatibility and remove deprecated methods
+- Fix: tesseract 5.x traineddata location in ocr
 
 0.94 (2021-12-14)
 -----------------

--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -160,7 +160,7 @@ void *init_ocr(int lang_index)
 	char *pars_values = strdup("tess.log");
 
 	ctx->api = TessBaseAPICreate();
-	if (!strncmp("4.", TessVersion(), 2))
+	if (!strncmp("4.", TessVersion(), 2) || !strncmp("5.", TessVersion(), 2))
 	{
 		char tess_path[1024];
 		snprintf(tess_path, 1024, "%s%s%s", tessdata_path, "/", "tessdata");


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

- fix tesseract versions 5.x traineddata location passed to `TessBaseAPIInit4`, mentioned in #1492 