### PR TITLE
[IMPROVEMENT] `linux/build` script revamp

### DIFF
--- a/docs/COMPILATION.MD
+++ b/docs/COMPILATION.MD
@@ -55,7 +55,13 @@ cd ccextractor/linux
 ./build -without-rust
 
 # compile with debug info
-./builddebug
+./build -debug            # same as ./build_debug
+
+# compile with hardsubx
+./build -hardsubx         # same as ./build_hardsubx
+
+# compile in debug mode without rust
+./build -debug -without-rust
 
 # test your build
 ./ccextractor

--- a/linux/build
+++ b/linux/build
@@ -1,4 +1,34 @@
 #!/usr/bin/env bash
+
+RUST_LIB="rust/release/libccx_rust.a"
+RUST_PROFILE="--release"
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -debug)
+      DEBUG=true
+      BLD_FLAGS="$BLD_FLAGS -g"
+      RUST_PROFILE=""
+      RUST_LIB="rust/debug/libccx_rust.a"
+      shift
+      ;;
+    -without-rust)
+      WITHOUT_RUST=true
+      shift
+      ;;
+    -hardsubx)
+      HARDSUBX=true
+      RUST_FEATURES="--features hardsubx_ocr"
+      BLD_FLAGS="$BLD_FLAGS -DENABLE_HARDSUBX"
+      BLD_LINKER="$BLD_LINKER -lswscale -lavutil -pthread -lavformat -lavcodec -lxcb-shm -lxcb -lX11 -llzma -lswresample"
+      shift
+      ;;
+    -*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+  esac
+done
+
 BLD_FLAGS="$BLD_FLAGS -std=gnu99 -Wno-write-strings -Wno-pointer-sign -DGPAC_CONFIG_LINUX -D_FILE_OFFSET_BITS=64 -DVERSION_FILE_PRESENT -DENABLE_OCR -DFT2_BUILD_LIBRARY -DGPAC_DISABLE_VTT -DGPAC_DISABLE_OD_DUMP -DGPAC_DISABLE_REMOTERY -DNO_GZIP -DGPAC_HAVE_CONFIG_H"
 bit_os=$(getconf LONG_BIT)
 if [ "$bit_os"=="64" ]
@@ -61,7 +91,7 @@ echo "Running pre-build script..."
 ./pre-build.sh
 echo "Trying to compile..."
 
-if [ "$1" = "-without-rust" ]; then
+if [ "$WITHOUT_RUST" = true ]; then
     echo "Building without rust files..."
     BLD_FLAGS="$BLD_FLAGS -DDISABLE_RUST"
 else 
@@ -84,14 +114,9 @@ else
     fi 
     
     echo "Building rust files..."
-    echo "${BLD_FLAGS}"
-    tokens=( ${BLD_FLAGS} )
-    if [ ${tokens[0]} = "-DENABLE_HARDSUBX" ]; then
-        (cd ../src/rust && CARGO_TARGET_DIR=../../linux/rust cargo build --features "hardsubx_ocr") || { echo "Failed. " ; exit 1; }
-    else
-        (cd ../src/rust && CARGO_TARGET_DIR=../../linux/rust cargo build) || { echo "Failed. " ; exit 1; }
-    fi
-    cp rust/debug/libccx_rust.a ./libccx_rust.a
+    (cd ../src/rust && CARGO_TARGET_DIR=../../linux/rust cargo build $RUST_PROFILE $RUST_FEATURES) || { echo "Failed. " ; exit 1; }
+
+    cp $RUST_LIB ./libccx_rust.a
 fi
 
 echo "Building ccextractor"

--- a/linux/build-debug
+++ b/linux/build-debug
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+./build -debug

--- a/linux/build-hardsubx
+++ b/linux/build-hardsubx
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+./build -hardsubx

--- a/linux/build_hardsubx
+++ b/linux/build_hardsubx
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-export BLD_FLAGS="-DENABLE_HARDSUBX"
-export BLD_LINKER="-lswscale -lavutil -pthread -lavformat -lavcodec -lxcb-shm -lxcb -lX11 -llzma -lswresample"
-./build

--- a/linux/builddebug
+++ b/linux/builddebug
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-export BLD_FLAGS="-g"
-./build


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

This pull request aims to consolidate the `linux/build` script. The script now accepts 3 options, `-debug`, `-without-rust` and `-hardsubx`. The original behavior is completely intact and does not affect the workflow. This also solves the original script's shortcoming of compiling rust more gracefully than #1489 as it changes the profile based on the `-debug` flag.
