### PR TITLE
[IMPROVEMENT] getting rid of the warnings during rust builds

### DIFF
--- a/src/rust/build.rs
+++ b/src/rust/build.rs
@@ -2,13 +2,14 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    let mut allowlist_functions = vec![
+    let mut allowlist_functions = Vec::new();
+    allowlist_functions.extend_from_slice(&[
         ".*(?i)_?dtvcc_.*",
         "get_visible_.*",
         "get_fts",
         "printdata",
         "writercwtdata",
-    ];
+    ]);
 
     #[cfg(feature = "hardsubx_ocr")]
     allowlist_functions.extend_from_slice(&[
@@ -18,13 +19,14 @@ fn main() {
         "mprint",
     ]);
 
-    let mut allowlist_types = vec![
+    let mut allowlist_types = Vec::new();
+    allowlist_types.extend_from_slice(&[
         ".*(?i)_?dtvcc_.*",
         "encoder_ctx",
         "lib_cc_decode",
         "cc_subtitle",
         "ccx_output_format",
-    ];
+    ]);
 
     #[cfg(feature = "hardsubx_ocr")]
     allowlist_types.extend_from_slice(&["AVRational", "AVPacket", "AVFrame"]);


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

#1469 brought this up where we would get some warnings when compiling the rust module without the `hardsubx_ocr` feature. As stated later in the issue these `mut`s are actually necessary when the feature is turned on. This fix is a minor change which removes the warnings in both the cases. This might allow us to maybe use `RUSTFLAGS="--deny warnings"` in our workflows to fail on warnings.
