### PR TITLE
[WIP] [FIX] #1499 Persistent `Dtvcc` struct for CEA-708 decoding in Rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ windows/.vs/**
 *.opendb
 *.db
 *.vscode
+.cache
 
 ####
 # Ignore the header file that is updated upon build

--- a/src/lib_ccx/ccx_decoders_common.c
+++ b/src/lib_ccx/ccx_decoders_common.c
@@ -18,6 +18,8 @@ made to reuse, not duplicate, as many functions as possible */
 #ifndef DISABLE_RUST
 extern int ccxr_process_cc_data(struct lib_cc_decode *dec_ctx, unsigned char *cc_data, int cc_count);
 extern void ccxr_flush_decoder(struct dtvcc_ctx *dtvcc, struct dtvcc_service_decoder *decoder);
+extern void *ccxr_dtvcc_init(struct ccx_decoder_dtvcc_settings *decoder_settings);
+extern void ccxr_dtvcc_free(void *dtvcc_rust);
 #endif
 
 uint64_t utc_refvalue = UINT64_MAX; /* _UI64_MAX/UINT64_MAX means don't use UNIX, 0 = use current system time as reference, +1 use a specific reference */
@@ -232,6 +234,9 @@ int do_cb(struct lib_cc_decode *ctx, unsigned char *cc_block, struct cc_subtitle
 void dinit_cc_decode(struct lib_cc_decode **ctx)
 {
 	struct lib_cc_decode *lctx = *ctx;
+#ifndef DISABLE_RUST
+	ccxr_dtvcc_free(lctx->dtvcc_rust);
+#endif
 	dtvcc_free(&lctx->dtvcc);
 	dinit_avc(&lctx->avc_ctx);
 	ccx_decoder_608_dinit_library(&lctx->context_cc608_field_1);
@@ -261,6 +266,9 @@ struct lib_cc_decode *init_cc_decode(struct ccx_decoders_common_settings_t *sett
 	ctx->no_rollup = setting->no_rollup;
 	ctx->noscte20 = setting->noscte20;
 
+#ifndef DISABLE_RUST
+	ctx->dtvcc = ccxr_dtvcc_init(setting->settings_dtvcc);
+#endif
 	ctx->dtvcc = dtvcc_init(setting->settings_dtvcc);
 	ctx->dtvcc->is_active = setting->settings_dtvcc->enabled;
 

--- a/src/lib_ccx/ccx_decoders_common.c
+++ b/src/lib_ccx/ccx_decoders_common.c
@@ -18,7 +18,7 @@ made to reuse, not duplicate, as many functions as possible */
 #ifndef DISABLE_RUST
 extern int ccxr_process_cc_data(struct lib_cc_decode *dec_ctx, unsigned char *cc_data, int cc_count);
 extern void ccxr_flush_decoder(struct dtvcc_ctx *dtvcc, struct dtvcc_service_decoder *decoder);
-extern void *ccxr_dtvcc_init(struct ccx_decoder_dtvcc_settings *decoder_settings);
+extern void *ccxr_dtvcc_init(struct ccx_decoder_dtvcc_settings *settings_dtvcc);
 extern void ccxr_dtvcc_free(void *dtvcc_rust);
 #endif
 
@@ -267,7 +267,7 @@ struct lib_cc_decode *init_cc_decode(struct ccx_decoders_common_settings_t *sett
 	ctx->noscte20 = setting->noscte20;
 
 #ifndef DISABLE_RUST
-	ctx->dtvcc = ccxr_dtvcc_init(setting->settings_dtvcc);
+	ctx->dtvcc_rust = ccxr_dtvcc_init(setting->settings_dtvcc);
 #endif
 	ctx->dtvcc = dtvcc_init(setting->settings_dtvcc);
 	ctx->dtvcc->is_active = setting->settings_dtvcc->enabled;

--- a/src/lib_ccx/ccx_decoders_structs.h
+++ b/src/lib_ccx/ccx_decoders_structs.h
@@ -11,11 +11,10 @@
 #define CCX_DECODER_608_SCREEN_ROWS 15
 #define CCX_DECODER_608_SCREEN_WIDTH 32
 #define MAXBFRAMES 50
-#define SORTBUF (2*MAXBFRAMES+1)
-
+#define SORTBUF (2 * MAXBFRAMES + 1)
 
 /* flag raised when end of display marker arrives in Dvb Subtitle */
-#define SUB_EOD_MARKER (1 << 0 )
+#define SUB_EOD_MARKER (1 << 0)
 struct cc_bitmap
 {
 	int x;
@@ -77,13 +76,13 @@ enum ccx_decoder_608_color_code
 };
 
 /**
-* This structure have fields which need to be ignored according to format,
-* for example if format is SFORMAT_XDS then all fields other then
-* xds related (xds_str, xds_len and  cur_xds_packet_class) should be
-* ignored and not to be dereferenced.
-*
-* TODO use union inside struct for each kind of fields
-*/
+ * This structure have fields which need to be ignored according to format,
+ * for example if format is SFORMAT_XDS then all fields other then
+ * xds related (xds_str, xds_len and  cur_xds_packet_class) should be
+ * ignored and not to be dereferenced.
+ *
+ * TODO use union inside struct for each kind of fields
+ */
 struct eia608_screen // A CC buffer
 {
 	/** format of data inside this structure */
@@ -91,8 +90,8 @@ struct eia608_screen // A CC buffer
 	unsigned char characters[CCX_DECODER_608_SCREEN_ROWS][CCX_DECODER_608_SCREEN_WIDTH + 1];
 	enum ccx_decoder_608_color_code colors[CCX_DECODER_608_SCREEN_ROWS][CCX_DECODER_608_SCREEN_WIDTH + 1];
 	enum font_bits fonts[CCX_DECODER_608_SCREEN_ROWS][CCX_DECODER_608_SCREEN_WIDTH + 1]; // Extra char at the end for a 0
-	int row_used[CCX_DECODER_608_SCREEN_ROWS];            // Any data in row?
-	int empty;                   // Buffer completely empty?
+	int row_used[CCX_DECODER_608_SCREEN_ROWS];					     // Any data in row?
+	int empty;									     // Buffer completely empty?
 	/** start time of this CC buffer */
 	LLONG start_time;
 	/** end time of this CC buffer */
@@ -110,20 +109,20 @@ struct eia608_screen // A CC buffer
 
 struct ccx_decoders_common_settings_t
 {
-	LLONG subs_delay;                                          // ms to delay (or advance) subs
-	enum ccx_output_format output_format;                      // What kind of output format should be used?
-	int fix_padding;                                           // Replace 0000 with 8080 in HDTV (needed for some cards)
+	LLONG subs_delay;					   // ms to delay (or advance) subs
+	enum ccx_output_format output_format;			   // What kind of output format should be used?
+	int fix_padding;					   // Replace 0000 with 8080 in HDTV (needed for some cards)
 	struct ccx_boundary_time extraction_start, extraction_end; // Segment we actually process
 	int cc_to_stdout;
-	int extract;                                               // Extract 1st, 2nd or both fields
-	int fullbin;                                               // Disable pruning of padding cc blocks
+	int extract; // Extract 1st, 2nd or both fields
+	int fullbin; // Disable pruning of padding cc blocks
 	int no_rollup;
 	int noscte20;
-	struct ccx_decoder_608_settings *settings_608;             // Contains the settings for the 608 decoder.
-	ccx_decoder_dtvcc_settings *settings_dtvcc;                // Same for cea 708 captions decoder (dtvcc)
-	int cc_channel;                                            // Channel we want to dump in srt mode
+	struct ccx_decoder_608_settings *settings_608; // Contains the settings for the 608 decoder.
+	ccx_decoder_dtvcc_settings *settings_dtvcc;    // Same for cea 708 captions decoder (dtvcc)
+	int cc_channel;				       // Channel we want to dump in srt mode
 	unsigned send_to_srv;
-	unsigned int hauppauge_mode;                               // If 1, use PID=1003, process specially and so on
+	unsigned int hauppauge_mode; // If 1, use PID=1003, process specially and so on
 	int program_number;
 	enum ccx_code_type codec;
 	int xds_write_to_file;
@@ -142,17 +141,17 @@ struct lib_cc_decode
 	void *context_cc608_field_1;
 	void *context_cc608_field_2;
 
-	int no_rollup;                                             // If 1, write one line at a time
+	int no_rollup; // If 1, write one line at a time
 	int noscte20;
-	int fix_padding;                                           // Replace 0000 with 8080 in HDTV (needed for some cards)
-	enum ccx_output_format write_format;                       // 0 = Raw, 1 = srt, 2 = SMI
+	int fix_padding;					   // Replace 0000 with 8080 in HDTV (needed for some cards)
+	enum ccx_output_format write_format;			   // 0 = Raw, 1 = srt, 2 = SMI
 	struct ccx_boundary_time extraction_start, extraction_end; // Segment we actually process
-	LLONG subs_delay;                                          // ms to delay (or advance) subs
-	int extract;                                               // Extract 1st, 2nd or both fields
-	int fullbin;                                               // Disable pruning of padding cc blocks
+	LLONG subs_delay;					   // ms to delay (or advance) subs
+	int extract;						   // Extract 1st, 2nd or both fields
+	int fullbin;						   // Disable pruning of padding cc blocks
 	struct cc_subtitle dec_sub;
 	enum ccx_bufferdata_type in_bufferdatatype;
-	unsigned int hauppauge_mode;                               // If 1, use PID=1003, process specially and so on
+	unsigned int hauppauge_mode; // If 1, use PID=1003, process specially and so on
 
 	int frames_since_last_gop;
 	/* GOP-based timing */
@@ -185,7 +184,7 @@ struct lib_cc_decode
 	int in_pic_data;
 
 	unsigned int current_progressive_sequence;
-	unsigned int current_pulldownfields ;
+	unsigned int current_pulldownfields;
 
 	int temporal_reference;
 	enum ccx_frame_type picture_coding_type;
@@ -197,17 +196,18 @@ struct lib_cc_decode
 	/* Required in es_function.c and es_userdata.c */
 	unsigned top_field_first; // Needs to be global
 
-    /* Stats. Modified in es_userdata.c*/
-    int stat_numuserheaders;
-    int stat_dvdccheaders;
-    int stat_scte20ccheaders;
-    int stat_replay5000headers;
-    int stat_replay4000headers;
-    int stat_dishheaders;
-    int stat_hdtv;
-    int stat_divicom;
-    int false_pict_header;
+	/* Stats. Modified in es_userdata.c*/
+	int stat_numuserheaders;
+	int stat_dvdccheaders;
+	int stat_scte20ccheaders;
+	int stat_replay5000headers;
+	int stat_replay4000headers;
+	int stat_dishheaders;
+	int stat_hdtv;
+	int stat_divicom;
+	int false_pict_header;
 
+	void *dtvcc_rust;
 	dtvcc_ctx *dtvcc;
 	int current_field;
 	// Analyse/use the picture information
@@ -217,7 +217,7 @@ struct lib_cc_decode
 	// Store fts;
 	LLONG cc_fts[SORTBUF];
 	// Store HD CC packets
-	unsigned char cc_data_pkts[SORTBUF][10*31*3+1]; // *10, because MP4 seems to have different limits
+	unsigned char cc_data_pkts[SORTBUF][10 * 31 * 3 + 1]; // *10, because MP4 seems to have different limits
 
 	// The sequence number of the current anchor frame.  All currently read
 	// B-Frames belong to this I- or P-frame.
@@ -227,7 +227,7 @@ struct lib_cc_decode
 
 	int (*writedata)(const unsigned char *data, int length, void *private_data, struct cc_subtitle *sub);
 
-	//dvb subtitle related
+	// dvb subtitle related
 	int ocr_quantmode;
 	struct lib_cc_decode *prev;
 };

--- a/src/lib_ccx/ccx_decoders_structs.h
+++ b/src/lib_ccx/ccx_decoders_structs.h
@@ -11,10 +11,11 @@
 #define CCX_DECODER_608_SCREEN_ROWS 15
 #define CCX_DECODER_608_SCREEN_WIDTH 32
 #define MAXBFRAMES 50
-#define SORTBUF (2 * MAXBFRAMES + 1)
+#define SORTBUF (2*MAXBFRAMES+1)
+
 
 /* flag raised when end of display marker arrives in Dvb Subtitle */
-#define SUB_EOD_MARKER (1 << 0)
+#define SUB_EOD_MARKER (1 << 0 )
 struct cc_bitmap
 {
 	int x;
@@ -76,13 +77,13 @@ enum ccx_decoder_608_color_code
 };
 
 /**
- * This structure have fields which need to be ignored according to format,
- * for example if format is SFORMAT_XDS then all fields other then
- * xds related (xds_str, xds_len and  cur_xds_packet_class) should be
- * ignored and not to be dereferenced.
- *
- * TODO use union inside struct for each kind of fields
- */
+* This structure have fields which need to be ignored according to format,
+* for example if format is SFORMAT_XDS then all fields other then
+* xds related (xds_str, xds_len and  cur_xds_packet_class) should be
+* ignored and not to be dereferenced.
+*
+* TODO use union inside struct for each kind of fields
+*/
 struct eia608_screen // A CC buffer
 {
 	/** format of data inside this structure */
@@ -90,8 +91,8 @@ struct eia608_screen // A CC buffer
 	unsigned char characters[CCX_DECODER_608_SCREEN_ROWS][CCX_DECODER_608_SCREEN_WIDTH + 1];
 	enum ccx_decoder_608_color_code colors[CCX_DECODER_608_SCREEN_ROWS][CCX_DECODER_608_SCREEN_WIDTH + 1];
 	enum font_bits fonts[CCX_DECODER_608_SCREEN_ROWS][CCX_DECODER_608_SCREEN_WIDTH + 1]; // Extra char at the end for a 0
-	int row_used[CCX_DECODER_608_SCREEN_ROWS];					     // Any data in row?
-	int empty;									     // Buffer completely empty?
+	int row_used[CCX_DECODER_608_SCREEN_ROWS];            // Any data in row?
+	int empty;                   // Buffer completely empty?
 	/** start time of this CC buffer */
 	LLONG start_time;
 	/** end time of this CC buffer */
@@ -109,20 +110,20 @@ struct eia608_screen // A CC buffer
 
 struct ccx_decoders_common_settings_t
 {
-	LLONG subs_delay;					   // ms to delay (or advance) subs
-	enum ccx_output_format output_format;			   // What kind of output format should be used?
-	int fix_padding;					   // Replace 0000 with 8080 in HDTV (needed for some cards)
+	LLONG subs_delay;                                          // ms to delay (or advance) subs
+	enum ccx_output_format output_format;                      // What kind of output format should be used?
+	int fix_padding;                                           // Replace 0000 with 8080 in HDTV (needed for some cards)
 	struct ccx_boundary_time extraction_start, extraction_end; // Segment we actually process
 	int cc_to_stdout;
-	int extract; // Extract 1st, 2nd or both fields
-	int fullbin; // Disable pruning of padding cc blocks
+	int extract;                                               // Extract 1st, 2nd or both fields
+	int fullbin;                                               // Disable pruning of padding cc blocks
 	int no_rollup;
 	int noscte20;
-	struct ccx_decoder_608_settings *settings_608; // Contains the settings for the 608 decoder.
-	ccx_decoder_dtvcc_settings *settings_dtvcc;    // Same for cea 708 captions decoder (dtvcc)
-	int cc_channel;				       // Channel we want to dump in srt mode
+	struct ccx_decoder_608_settings *settings_608;             // Contains the settings for the 608 decoder.
+	ccx_decoder_dtvcc_settings *settings_dtvcc;                // Same for cea 708 captions decoder (dtvcc)
+	int cc_channel;                                            // Channel we want to dump in srt mode
 	unsigned send_to_srv;
-	unsigned int hauppauge_mode; // If 1, use PID=1003, process specially and so on
+	unsigned int hauppauge_mode;                               // If 1, use PID=1003, process specially and so on
 	int program_number;
 	enum ccx_code_type codec;
 	int xds_write_to_file;
@@ -141,17 +142,17 @@ struct lib_cc_decode
 	void *context_cc608_field_1;
 	void *context_cc608_field_2;
 
-	int no_rollup; // If 1, write one line at a time
+	int no_rollup;                                             // If 1, write one line at a time
 	int noscte20;
-	int fix_padding;					   // Replace 0000 with 8080 in HDTV (needed for some cards)
-	enum ccx_output_format write_format;			   // 0 = Raw, 1 = srt, 2 = SMI
+	int fix_padding;                                           // Replace 0000 with 8080 in HDTV (needed for some cards)
+	enum ccx_output_format write_format;                       // 0 = Raw, 1 = srt, 2 = SMI
 	struct ccx_boundary_time extraction_start, extraction_end; // Segment we actually process
-	LLONG subs_delay;					   // ms to delay (or advance) subs
-	int extract;						   // Extract 1st, 2nd or both fields
-	int fullbin;						   // Disable pruning of padding cc blocks
+	LLONG subs_delay;                                          // ms to delay (or advance) subs
+	int extract;                                               // Extract 1st, 2nd or both fields
+	int fullbin;                                               // Disable pruning of padding cc blocks
 	struct cc_subtitle dec_sub;
 	enum ccx_bufferdata_type in_bufferdatatype;
-	unsigned int hauppauge_mode; // If 1, use PID=1003, process specially and so on
+	unsigned int hauppauge_mode;                               // If 1, use PID=1003, process specially and so on
 
 	int frames_since_last_gop;
 	/* GOP-based timing */
@@ -184,7 +185,7 @@ struct lib_cc_decode
 	int in_pic_data;
 
 	unsigned int current_progressive_sequence;
-	unsigned int current_pulldownfields;
+	unsigned int current_pulldownfields ;
 
 	int temporal_reference;
 	enum ccx_frame_type picture_coding_type;
@@ -196,18 +197,18 @@ struct lib_cc_decode
 	/* Required in es_function.c and es_userdata.c */
 	unsigned top_field_first; // Needs to be global
 
-	/* Stats. Modified in es_userdata.c*/
-	int stat_numuserheaders;
-	int stat_dvdccheaders;
-	int stat_scte20ccheaders;
-	int stat_replay5000headers;
-	int stat_replay4000headers;
-	int stat_dishheaders;
-	int stat_hdtv;
-	int stat_divicom;
-	int false_pict_header;
+    /* Stats. Modified in es_userdata.c*/
+    int stat_numuserheaders;
+    int stat_dvdccheaders;
+    int stat_scte20ccheaders;
+    int stat_replay5000headers;
+    int stat_replay4000headers;
+    int stat_dishheaders;
+    int stat_hdtv;
+    int stat_divicom;
+    int false_pict_header;
 
-	void *dtvcc_rust;
+    	void *dtvcc_rust;
 	dtvcc_ctx *dtvcc;
 	int current_field;
 	// Analyse/use the picture information
@@ -217,7 +218,7 @@ struct lib_cc_decode
 	// Store fts;
 	LLONG cc_fts[SORTBUF];
 	// Store HD CC packets
-	unsigned char cc_data_pkts[SORTBUF][10 * 31 * 3 + 1]; // *10, because MP4 seems to have different limits
+	unsigned char cc_data_pkts[SORTBUF][10*31*3+1]; // *10, because MP4 seems to have different limits
 
 	// The sequence number of the current anchor frame.  All currently read
 	// B-Frames belong to this I- or P-frame.
@@ -227,7 +228,7 @@ struct lib_cc_decode
 
 	int (*writedata)(const unsigned char *data, int length, void *private_data, struct cc_subtitle *sub);
 
-	// dvb subtitle related
+	//dvb subtitle related
 	int ocr_quantmode;
 	struct lib_cc_decode *prev;
 };

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -900,8 +900,9 @@ int process_non_multiprogram_general_loop(struct lib_ccx_ctx *ctx,
 	cinfo = get_cinfo(ctx->demux_ctx, pid);
 	*enc_ctx = update_encoder_list_cinfo(ctx, cinfo);
 	*dec_ctx = update_decoder_list_cinfo(ctx, cinfo);
+#ifdef DISABLE_RUST
 	(*dec_ctx)->dtvcc->encoder = (void *)(*enc_ctx);
-#ifndef DISABLE_RUST
+#else
 	ccxr_dtvcc_set_encoder((*dec_ctx)->dtvcc_rust, *enc_ctx);
 #endif
 
@@ -1100,8 +1101,9 @@ int general_loop(struct lib_ccx_ctx *ctx)
 
 				enc_ctx = update_encoder_list_cinfo(ctx, cinfo);
 				dec_ctx = update_decoder_list_cinfo(ctx, cinfo);
+#ifdef DISABLE_RUST
 				dec_ctx->dtvcc->encoder = (void *)enc_ctx; // WARN: otherwise cea-708 will not work
-#ifndef DISABLE_RUST
+#else
 				ccxr_dtvcc_set_encoder(dec_ctx->dtvcc_rust, (void *)enc_ctx);
 #endif
 
@@ -1278,8 +1280,9 @@ int rcwt_loop(struct lib_ccx_ctx *ctx)
 	}
 
 	dec_ctx = update_decoder_list(ctx);
+#ifdef DISABLE_RUST
 	dec_ctx->dtvcc->encoder = (void *)enc_ctx; // WARN: otherwise cea-708 will not work
-#ifndef DISABLE_RUST
+#else
 	ccxr_dtvcc_set_encoder(dec_ctx->dtvcc_rust, (void *)enc_ctx);
 #endif
 	if (parsebuf[6] == 0 && parsebuf[7] == 2)

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -18,6 +18,10 @@
 #include "dvd_subtitle_decoder.h"
 #include "ccx_demuxer_mxf.h"
 
+#ifndef DISABLE_RUST
+extern void ccxr_dtvcc_set_encoder(void *dtvcc_rust, void *encoder);
+#endif
+
 int end_of_file = 0; // End of file?
 
 // Program stream specific data grabber
@@ -897,6 +901,9 @@ int process_non_multiprogram_general_loop(struct lib_ccx_ctx *ctx,
 	*enc_ctx = update_encoder_list_cinfo(ctx, cinfo);
 	*dec_ctx = update_decoder_list_cinfo(ctx, cinfo);
 	(*dec_ctx)->dtvcc->encoder = (void *)(*enc_ctx);
+#ifndef DISABLE_RUST
+	ccxr_dtvcc_set_encoder((*dec_ctx)->dtvcc_rust, *enc_ctx);
+#endif
 
 	if ((*dec_ctx)->timing->min_pts == 0x01FFFFFFFFLL) // if we didn't set the min_pts of the program
 	{
@@ -1094,6 +1101,9 @@ int general_loop(struct lib_ccx_ctx *ctx)
 				enc_ctx = update_encoder_list_cinfo(ctx, cinfo);
 				dec_ctx = update_decoder_list_cinfo(ctx, cinfo);
 				dec_ctx->dtvcc->encoder = (void *)enc_ctx; // WARN: otherwise cea-708 will not work
+#ifndef DISABLE_RUST
+				ccxr_dtvcc_set_encoder(dec_ctx->dtvcc_rust, (void *)enc_ctx);
+#endif
 
 				if (dec_ctx->timing->min_pts == 0x01FFFFFFFFLL) // if we didn't set the min_pts of the program
 				{
@@ -1269,6 +1279,9 @@ int rcwt_loop(struct lib_ccx_ctx *ctx)
 
 	dec_ctx = update_decoder_list(ctx);
 	dec_ctx->dtvcc->encoder = (void *)enc_ctx; // WARN: otherwise cea-708 will not work
+#ifndef DISABLE_RUST
+	ccxr_dtvcc_set_encoder(dec_ctx->dtvcc_rust, (void *)enc_ctx);
+#endif
 	if (parsebuf[6] == 0 && parsebuf[7] == 2)
 	{
 		dec_ctx->codec = CCX_CODEC_TELETEXT;

--- a/src/lib_ccx/mp4.c
+++ b/src/lib_ccx/mp4.c
@@ -16,6 +16,11 @@
 
 #define GF_ISOM_SUBTYPE_C708 GF_4CC('c', '7', '0', '8')
 
+#ifndef DISABLE_RUST
+extern void ccxr_process_data(void *dtvcc_rust, unsigned char cc_valid, unsigned char cc_char, unsigned char data1, unsigned char data2);
+extern void ccxr_dtvcc_set_encoder(void *dtvcc_rust, void *encoder);
+#endif
+
 static short bswap16(short v)
 {
 	return ((v >> 8) & 0x00FF) | ((v << 8) & 0xFF00);
@@ -394,8 +399,13 @@ static int process_clcp(struct lib_ccx_ctx *ctx, struct encoder_ctx *enc_ctx,
 					continue;
 				}
 				// WARN: otherwise cea-708 will not work
+#ifdef DISABLE_RUST
 				dec_ctx->dtvcc->encoder = (void *)enc_ctx;
 				dtvcc_process_data(dec_ctx->dtvcc, (unsigned char *)temp);
+#else
+				ccxr_dtvcc_set_encoder(dec_ctx->dtvcc_rust, (void *)enc_ctx);
+				ccxr_process_data(dec_ctx->dtvcc_rust, cc_valid, cc_type, cc_data[1], cc_data[2]);
+#endif
 				cb_708++;
 			}
 			if (ctx->write_format == CCX_OF_MCC)

--- a/src/rust/build.rs
+++ b/src/rust/build.rs
@@ -59,6 +59,7 @@ fn main() {
     }
 
     let bindings = builder
+        .derive_default(true)
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.

--- a/src/rust/src/decoder/mod.rs
+++ b/src/rust/src/decoder/mod.rs
@@ -23,7 +23,7 @@ const CCX_DTVCC_SCREENGRID_COLUMNS: u8 = 210;
 const CCX_DTVCC_MAX_ROWS: u8 = 15;
 const CCX_DTVCC_MAX_COLUMNS: u8 = 32 * 2;
 const CCX_DTVCC_MAX_SERVICES: usize = 63;
-const CCX_DTVCC_MAX_WINDOWS: usize = 8;
+// const CCX_DTVCC_MAX_WINDOWS: usize = 8;
 
 /// Context required for processing 708 data
 pub struct Dtvcc<'a> {
@@ -44,18 +44,16 @@ pub struct Dtvcc<'a> {
 
 impl<'a> Dtvcc<'a> {
     /// Create a new dtvcc context
-    pub fn new<'b>(opts: &'b mut ccx_decoder_dtvcc_settings) -> Self {
+    pub fn new(opts: &'_ mut ccx_decoder_dtvcc_settings) -> Self {
         // closely follows `dtvcc_init` at `src/lib_ccx/ccx_dtvcc.c:76`
 
         let report = unsafe { opts.report.as_mut().unwrap() };
         report.reset_count = 0;
 
         let is_active = false;
-        let no_rollup = opts.no_rollup;
-        let active_services_count = opts.active_services_count;
-        let no_rollup = is_true(opts.no_rollup);
-        let active_services_count = opts.active_services_count as u8;
-        let services_active = opts.services_enabled.clone();
+        let _no_rollup = is_true(opts.no_rollup);
+        let _active_services_count = opts.active_services_count as u8;
+        let services_active = opts.services_enabled;
 
         // `dtvcc_clear_packet` does the following
         let packet_length = 0;
@@ -70,34 +68,38 @@ impl<'a> Dtvcc<'a> {
         // unlike C, here the decoders are allocated on the stack as an array.
         let decoders = {
             const INIT: Option<dtvcc_service_decoder> = None;
-            let mut val = [INIT; CCX_DTVCC_MAX_SERVICES];
+            let mut decoders = [INIT; CCX_DTVCC_MAX_SERVICES];
 
-            for i in 0..CCX_DTVCC_MAX_SERVICES {
-                if is_false(opts.services_enabled[i]) {
-                    continue;
-                }
+            decoders
+                .iter_mut()
+                .zip(opts.services_enabled)
+                .enumerate()
+                .for_each(|(i, (d, se))| {
+                    if is_false(se) {
+                        return;
+                    }
 
-                let mut decoder = dtvcc_service_decoder {
-                    // we cannot allocate this on the stack as `dtvcc_service_decoder` is a C
-                    // struct cannot be changed trivially
-                    tv: Box::into_raw(Box::new(dtvcc_tv_screen {
-                        cc_count: 0,
-                        service_number: i as i32 + 1,
-                        ..dtvcc_tv_screen::default()
-                    })),
-                    ..dtvcc_service_decoder::default()
-                };
+                    let mut decoder = dtvcc_service_decoder {
+                        // we cannot allocate this on the stack as `dtvcc_service_decoder` is a C
+                        // struct cannot be changed trivially
+                        tv: Box::into_raw(Box::new(dtvcc_tv_screen {
+                            cc_count: 0,
+                            service_number: i as i32 + 1,
+                            ..dtvcc_tv_screen::default()
+                        })),
+                        ..dtvcc_service_decoder::default()
+                    };
 
-                decoder.windows.iter_mut().for_each(|w| {
-                    w.memory_reserved = 0;
+                    decoder.windows.iter_mut().for_each(|w| {
+                        w.memory_reserved = 0;
+                    });
+
+                    unsafe { dtvcc_windows_reset(&mut decoder) };
+
+                    *d = Some(decoder);
                 });
 
-                unsafe { dtvcc_windows_reset(&mut decoder) };
-
-                val[i] = Some(decoder);
-            }
-
-            val
+            decoders
         };
 
         let encoder = None; // Unlike C, does not mention `encoder` and is initialised to `null` by default
@@ -105,8 +107,8 @@ impl<'a> Dtvcc<'a> {
         Self {
             report,
             is_active,
-            no_rollup,
-            active_services_count,
+            no_rollup: _no_rollup,
+            active_services_count: _active_services_count,
             services_active,
             packet_length,
             is_header_parsed,

--- a/src/rust/src/decoder/tv_screen.rs
+++ b/src/rust/src/decoder/tv_screen.rs
@@ -148,8 +148,8 @@ impl dtvcc_tv_screen {
         use_colors: bool,
     ) -> Result<(), String> {
         let mut buf = Vec::new();
-        let mut pen_color = dtvcc_pen_color::default();
-        let mut pen_attribs = dtvcc_pen_attribs::default();
+        let mut pen_color = dtvcc_pen_color::new();
+        let mut pen_attribs = dtvcc_pen_attribs::new();
         let (first, last) = self.get_write_interval(row_index);
         debug!("First: {}, Last: {}", first, last);
 
@@ -418,7 +418,7 @@ impl dtvcc_tv_screen {
             return;
         }
         let new_pen_attribs = if col_index >= CCX_DTVCC_SCREENGRID_COLUMNS as usize {
-            dtvcc_pen_attribs::default()
+            dtvcc_pen_attribs::new()
         } else {
             self.pen_attribs[row_index][col_index]
         };
@@ -455,7 +455,7 @@ impl dtvcc_tv_screen {
             return;
         }
         let new_pen_color = if col_index >= CCX_DTVCC_SCREENGRID_COLUMNS as usize {
-            dtvcc_pen_color::default()
+            dtvcc_pen_color::new()
         } else {
             self.pen_colors[row_index][col_index]
         };

--- a/src/rust/src/decoder/window.rs
+++ b/src/rust/src/decoder/window.rs
@@ -149,9 +149,9 @@ impl dtvcc_window {
     /// Clear all text from the window
     pub fn clear_text(&mut self) {
         // Set pen color to default value
-        self.pen_color_pattern = dtvcc_pen_color::default();
+        self.pen_color_pattern = dtvcc_pen_color::new();
         // Set pen attributes to default value
-        self.pen_attribs_pattern = dtvcc_pen_attribs::default();
+        self.pen_attribs_pattern = dtvcc_pen_attribs::new();
         for row in 0..CCX_DTVCC_MAX_ROWS as usize {
             self.clear_row(row);
         }
@@ -521,9 +521,9 @@ enum Opacity {
     Transparent = 3,
 }
 
-impl Default for dtvcc_pen_color {
+impl dtvcc_pen_color {
     /// Returns the default pen color
-    fn default() -> Self {
+    pub fn new() -> Self {
         Self {
             fg_color: 0x3F,
             fg_opacity: 0,
@@ -534,9 +534,9 @@ impl Default for dtvcc_pen_color {
     }
 }
 
-impl Default for dtvcc_pen_attribs {
+impl dtvcc_pen_attribs {
     /// Returns the default pen attributes
-    fn default() -> Self {
+    pub fn new() -> Self {
         Self {
             pen_size: dtvcc_pen_size::DTVCC_PEN_SIZE_STANDART as i32,
             offset: 0,

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -70,6 +70,11 @@ extern "C" fn ccxr_dtvcc_free(dtvcc_rust: *mut Dtvcc) {
     unsafe { dtvcc_rust.drop_in_place() };
 }
 
+#[no_mangle]
+extern "C" fn ccxr_dtvcc_set_encoder(dtvcc_rust: *mut Dtvcc, encoder: *mut encoder_ctx) {
+    unsafe { dtvcc_rust.as_mut() }.unwrap().encoder = Some(unsafe { encoder.as_mut() }.unwrap());
+}
+
 /// Process cc_data
 ///
 /// # Safety

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -44,6 +44,16 @@ pub extern "C" fn ccxr_init_logger() {
         .init();
 }
 
+#[no_mangle]
+extern "C" fn ccxr_dtvcc_init<'a>(opts: *mut ccx_decoder_dtvcc_settings) -> *mut Dtvcc<'a> {
+    Box::into_raw(Box::new(Dtvcc::new(unsafe { opts.as_mut() }.unwrap())))
+}
+
+#[no_mangle]
+extern "C" fn ccxr_dtvcc_free(dtvcc: *mut Dtvcc) {
+    unsafe { dtvcc.drop_in_place() };
+}
+
 /// Process cc_data
 ///
 /// # Safety

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -44,14 +44,30 @@ pub extern "C" fn ccxr_init_logger() {
         .init();
 }
 
+/// Create a `dtvcc_rust`
+///
+/// SAFETY:
+/// The following should not be `NULL`:
+///     - opts
+///     - opts.report
+///     - opts.timing
 #[no_mangle]
 extern "C" fn ccxr_dtvcc_init<'a>(opts: *mut ccx_decoder_dtvcc_settings) -> *mut Dtvcc<'a> {
     Box::into_raw(Box::new(Dtvcc::new(unsafe { opts.as_mut() }.unwrap())))
 }
 
+/// Frees `dtvcc_rust`
+///
+/// SAFETY:
+/// The following should not be `NULL`:
+///     - dtvcc_rust
+///     - dtvcc_rust.decoders[i] if dtvcc_rust.services_active[i] is true
+///     - dtvcc_rust.decoders[i].windows[j].rows[k] if
+///         dtvcc_rust.decoders[i].windows[j].memory_reserved is true
+///     - dtvcc_rust.decoders[i].tv
 #[no_mangle]
-extern "C" fn ccxr_dtvcc_free(dtvcc: *mut Dtvcc) {
-    unsafe { dtvcc.drop_in_place() };
+extern "C" fn ccxr_dtvcc_free(dtvcc_rust: *mut Dtvcc) {
+    unsafe { dtvcc_rust.drop_in_place() };
 }
 
 /// Process cc_data

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -76,6 +76,17 @@ extern "C" fn ccxr_dtvcc_set_encoder(dtvcc_rust: *mut Dtvcc, encoder: *mut encod
     unsafe { (*dtvcc_rust).encoder = encoder };
 }
 
+#[no_mangle]
+extern "C" fn ccxr_process_data(
+    dtvcc_rust: *mut Dtvcc,
+    cc_valid: u8,
+    cc_type: u8,
+    data1: u8,
+    data2: u8,
+) {
+    unsafe { dtvcc_rust.as_mut().unwrap() }.process_cc_data(cc_valid, cc_type, data1, data2);
+}
+
 /// Process cc_data
 ///
 /// # Safety

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -135,7 +135,7 @@ pub fn verify_parity(data: u8) -> bool {
 
 /// Process CC data according to its type
 pub fn do_cb(ctx: &mut lib_cc_decode, cc_block: &[u8]) -> bool {
-    let dtvcc: &mut Dtvcc = unsafe { std::mem::transmute(ctx.dtvcc_rust) };
+    let dtvcc = unsafe { &mut *(ctx.dtvcc_rust as *mut decoder::Dtvcc<'_>) };
     let cc_valid = (cc_block[0] & 4) >> 2;
     let cc_type = cc_block[0] & 3;
     let mut timeok = true;

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -52,8 +52,9 @@ pub extern "C" fn ccxr_init_logger() {
 ///     - opts.report
 ///     - opts.timing
 #[no_mangle]
-extern "C" fn ccxr_dtvcc_init<'a>(opts: *mut ccx_decoder_dtvcc_settings) -> *mut Dtvcc<'a> {
-    Box::into_raw(Box::new(Dtvcc::new(unsafe { opts.as_mut() }.unwrap())))
+extern "C" fn ccxr_dtvcc_init(opts_ptr: *const ccx_decoder_dtvcc_settings) -> *mut Dtvcc {
+    let opts = unsafe { opts_ptr.as_ref() }.unwrap();
+    Box::into_raw(Box::new(Dtvcc::new(opts)))
 }
 
 /// Frees `dtvcc_rust`
@@ -72,7 +73,7 @@ extern "C" fn ccxr_dtvcc_free(dtvcc_rust: *mut Dtvcc) {
 
 #[no_mangle]
 extern "C" fn ccxr_dtvcc_set_encoder(dtvcc_rust: *mut Dtvcc, encoder: *mut encoder_ctx) {
-    unsafe { dtvcc_rust.as_mut() }.unwrap().encoder = Some(unsafe { encoder.as_mut() }.unwrap());
+    unsafe { (*dtvcc_rust).encoder = encoder };
 }
 
 /// Process cc_data
@@ -140,7 +141,7 @@ pub fn verify_parity(data: u8) -> bool {
 
 /// Process CC data according to its type
 pub fn do_cb(ctx: &mut lib_cc_decode, cc_block: &[u8]) -> bool {
-    let dtvcc = unsafe { &mut *(ctx.dtvcc_rust as *mut decoder::Dtvcc<'_>) };
+    let dtvcc = unsafe { &mut *(ctx.dtvcc_rust as *mut decoder::Dtvcc) };
     let cc_valid = (cc_block[0] & 4) >> 2;
     let cc_type = cc_block[0] & 3;
     let mut timeok = true;

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -86,13 +86,11 @@ extern "C" fn ccxr_process_cc_data(
         .map(|x| unsafe { *data.add(x as usize) })
         .collect();
     let dec_ctx = unsafe { &mut *dec_ctx };
-    let dtvcc_ctx = unsafe { &mut *dec_ctx.dtvcc };
-    let mut dtvcc = Dtvcc::new(dtvcc_ctx);
     for cc_block in cc_data.chunks_exact_mut(3) {
         if !validate_cc_pair(cc_block) {
             continue;
         }
-        let success = do_cb(dec_ctx, &mut dtvcc, cc_block);
+        let success = do_cb(dec_ctx, cc_block);
         if success {
             ret = 0;
         }
@@ -136,7 +134,8 @@ pub fn verify_parity(data: u8) -> bool {
 }
 
 /// Process CC data according to its type
-pub fn do_cb(ctx: &mut lib_cc_decode, dtvcc: &mut Dtvcc, cc_block: &[u8]) -> bool {
+pub fn do_cb(ctx: &mut lib_cc_decode, cc_block: &[u8]) -> bool {
+    let dtvcc: &mut Dtvcc = unsafe { std::mem::transmute(ctx.dtvcc_rust) };
     let cc_valid = (cc_block[0] & 4) >> 2;
     let cc_type = cc_block[0] & 3;
     let mut timeok = true;


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

{pull request content here}
