### PR TITLE
[FIX] linux/configure.ac: Fix tesseract conditional problem.

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -11,6 +11,7 @@
 - Fix: missing `#` in color attribute of font tag
 - Fix: ffmpeg 5.0, tesseract 5.0 compatibility and remove deprecated methods
 - Fix: tesseract 5.x traineddata location in ocr
+- Fix: fix autoconf tesseract detection problem (#1503)
 
 0.94 (2021-12-14)
 -----------------

--- a/linux/configure.ac
+++ b/linux/configure.ac
@@ -149,7 +149,7 @@ AS_IF([ (test x$ocr = xtrue || test x$hardsubx = xtrue) && test ! $HAS_LEPT -gt 
 AM_CONDITIONAL(HARDSUBX_IS_ENABLED, [ test x$hardsubx = xtrue ])
 AM_CONDITIONAL(OCR_IS_ENABLED, [ test x$ocr = xtrue || test x$hardsubx = xtrue ])
 AM_CONDITIONAL(FFMPEG_IS_ENABLED, [ test x$ffmpeg = xtrue ])
-AM_CONDITIONAL(TESSERACT_PRESENT, [ test ! -z  `pkg-config --libs-only-l --silence-errors tesseract` ])
+AM_CONDITIONAL(TESSERACT_PRESENT, [ test -n  "$(pkg-config --libs-only-l --silence-errors tesseract)" ])
 AM_CONDITIONAL(TESSERACT_PRESENT_RPI, [ test -d "/usr/include/tesseract" && test `ls -A /usr/include/tesseract | wc -l` -gt 0 ])
 AM_CONDITIONAL(SYS_IS_LINUX, [ test `uname -s` = "Linux"])
 AM_CONDITIONAL(SYS_IS_MAC, [ test `uname -s` = "Darwin"])


### PR DESCRIPTION
Fixes #1503.

Using tesseract-ocr's stock pkg-config, it would produce an error due to unquoted whitespace:

  $ test ! -z `pkg-config --libs-only-l --silence-errors tesseract`
  bash: test: syntax error: `-larchive' unexpected

* linux/configure.ac: Use a positive test, and double-quote the $() command substitution.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [x] I have never used CCExtractor.

---