### PR TITLE
[FIX] linux/Makefile.am: Add missing generated header.

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -11,6 +11,7 @@
 - Fix: missing `#` in color attribute of font tag
 - Fix: ffmpeg 5.0, tesseract 5.0 compatibility and remove deprecated methods
 - Fix: tesseract 5.x traineddata location in ocr
+- Fix: add missing compile_info_real.h source to Autotools build
 
 0.94 (2021-12-14)
 -----------------

--- a/linux/Makefile.am
+++ b/linux/Makefile.am
@@ -118,6 +118,7 @@ ccextractor_SOURCES = \
 				../src/lib_ccx/bitstream.h \
 				../src/lib_ccx/ccx_common_option.c \
 				../src/lib_ccx/ccx_common_common.c \
+				../src/lib_ccx/compile_info_real.h \
 				../src/lib_ccx/utility.c \
 				../src/lib_ccx/activity.c \
 				../src/lib_ccx/asf_functions.c \


### PR DESCRIPTION
This header is generated by the pre-build.sh script.  The compilation fails if it is missing.

* linux/Makefile.am (ccextractor_SOURCES): Add ../src/lib_ccx/compile_info_real.h.

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [x] I have never used CCExtractor.

---