### PR TITLE
[FIX] ccx_encoders_smptett.c: Enforce int for sprintf

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -13,6 +13,7 @@
 - Fix: tesseract 5.x traineddata location in ocr
 - Fix: fix autoconf tesseract detection problem (#1503)
 - Fix: add missing compile_info_real.h source to Autotools build
+- Fix: refactors SMPTE-TT encoding with int values to avoid locale issues with sprintf 
 
 0.94 (2021-12-14)
 -----------------

--- a/src/lib_ccx/ccx_encoders_smptett.c
+++ b/src/lib_ccx/ccx_encoders_smptett.c
@@ -203,7 +203,7 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
 
 			// ROWS is actually 90% of the screen size
 			// Add +10% because row 0 is at position 10%
-			row1 = round((((100 * row) / (ROWS / 0.8)) + 10));
+			row1 = round(((100 * row) / (ROWS / 0.8)) + 10);
 
 			for (int column = 0; column < COLUMNS; column++)
 			{
@@ -220,7 +220,7 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
 			}
 			// COLUMNS is actually 90% of the screen size
 			// Add +10% because column 0 is at position 10%
-			col1 = round((((100 * firstcol) / (COLUMNS / 0.8)) + 10));
+			col1 = round(((100 * firstcol) / (COLUMNS / 0.8)) + 10);
 
 			if (firstcol >= 0)
 			{

--- a/src/lib_ccx/ccx_encoders_smptett.c
+++ b/src/lib_ccx/ccx_encoders_smptett.c
@@ -24,7 +24,7 @@
 
 /*
 	Up-to-date standards as of March 2023 can be found at
-	https://www.w3.org/TR/ttml1/ and 
+	https://www.w3.org/TR/ttml1/ and
 	https://ieeexplore.ieee.org/document/7291854
 */
 

--- a/src/lib_ccx/ccx_encoders_smptett.c
+++ b/src/lib_ccx/ccx_encoders_smptett.c
@@ -191,11 +191,14 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
 		{
 			float row1 = 0;
 			float col1 = 0;
+            int row1_int, col1_int, row1_dec, col1_dec;
 			int firstcol = -1;
 
 			// ROWS is actually 90% of the screen size
 			// Add +10% because row 0 is at position 10%
 			row1 = ((100 * row) / (ROWS / 0.8)) + 10;
+            row1_int = row1;
+            row1_dec = (row1 - row1_int) * 1000;
 
 			for (int column = 0; column < COLUMNS; column++)
 			{
@@ -213,13 +216,16 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
 			// COLUMNS is actually 90% of the screen size
 			// Add +10% because column 0 is at position 10%
 			col1 = ((100 * firstcol) / (COLUMNS / 0.8)) + 10;
+            col1_int = col1;
+            col1_dec = (col1 - col1_int) * 1000;
 
 			if (firstcol >= 0)
 			{
 				wrote_something = 1;
 
-				sprintf(str, "      <p begin=\"%02u:%02u:%02u.%03u\" end=\"%02u:%02u:%02u.%03u\" tts:origin=\"%1.3f%% %1.3f%%\">\n        <span>", h1, m1, s1, ms1, h2, m2, s2, ms2, col1, row1);
-				if (context->encoding != CCX_ENC_UNICODE)
+                sprintf(str, "      <p begin=\"%02u:%02u:%02u.%03u\" end=\"%02u:%02u:%02u.%03u\" tts:origin=\"%d.%03d%% %d.%03d%%\">\n        <span>", h1, m1, s1, ms1, h2, m2, s2, ms2, col1_int, col1_dec, row1_int, row1_dec);
+
+                if (context->encoding != CCX_ENC_UNICODE)
 				{
 					dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
 				}

--- a/src/lib_ccx/ccx_encoders_smptett.c
+++ b/src/lib_ccx/ccx_encoders_smptett.c
@@ -21,10 +21,18 @@
 	along with this program; if not, write to the Free Software
 	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
+
+/*
+	Up-to-date standards as of March 2023 can be found at
+	https://www.w3.org/TR/ttml1/ and 
+	https://ieeexplore.ieee.org/document/7291854
+*/
+
 #include "lib_ccx.h"
 #include "ccx_common_option.h"
 #include "ccx_encoders_common.h"
 #include <png.h>
+#include <math.h>
 #include "ocr.h"
 #include "utility.h"
 #include "ccx_encoders_helpers.h"
@@ -189,16 +197,13 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
 	{
 		if (data->row_used[row])
 		{
-			float row1 = 0;
-			float col1 = 0;
-			int row1_int, col1_int, row1_dec, col1_dec;
+			int row1 = 0;
+			int col1 = 0;
 			int firstcol = -1;
 
 			// ROWS is actually 90% of the screen size
 			// Add +10% because row 0 is at position 10%
-			row1 = ((100 * row) / (ROWS / 0.8)) + 10;
-			row1_int = row1;
-			row1_dec = (row1 - row1_int) * 1000;
+			row1 = round((((100 * row) / (ROWS / 0.8)) + 10));
 
 			for (int column = 0; column < COLUMNS; column++)
 			{
@@ -215,15 +220,13 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
 			}
 			// COLUMNS is actually 90% of the screen size
 			// Add +10% because column 0 is at position 10%
-			col1 = ((100 * firstcol) / (COLUMNS / 0.8)) + 10;
-			col1_int = col1;
-			col1_dec = (col1 - col1_int) * 1000;
+			col1 = round((((100 * firstcol) / (COLUMNS / 0.8)) + 10));
 
 			if (firstcol >= 0)
 			{
 				wrote_something = 1;
 
-				sprintf(str, "      <p begin=\"%02u:%02u:%02u.%03u\" end=\"%02u:%02u:%02u.%03u\" tts:origin=\"%d.%03d%% %d.%03d%%\">\n        <span>", h1, m1, s1, ms1, h2, m2, s2, ms2, col1_int, col1_dec, row1_int, row1_dec);
+				sprintf(str, "      <p begin=\"%02u:%02u:%02u.%03u\" end=\"%02u:%02u:%02u.%03u\" tts:origin=\"%u%% %u%%\">\n        <span>", h1, m1, s1, ms1, h2, m2, s2, ms2, col1, row1);
 
 				if (context->encoding != CCX_ENC_UNICODE)
 				{

--- a/src/lib_ccx/ccx_encoders_smptett.c
+++ b/src/lib_ccx/ccx_encoders_smptett.c
@@ -191,14 +191,14 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
 		{
 			float row1 = 0;
 			float col1 = 0;
-            int row1_int, col1_int, row1_dec, col1_dec;
+			int row1_int, col1_int, row1_dec, col1_dec;
 			int firstcol = -1;
 
 			// ROWS is actually 90% of the screen size
 			// Add +10% because row 0 is at position 10%
 			row1 = ((100 * row) / (ROWS / 0.8)) + 10;
-            row1_int = row1;
-            row1_dec = (row1 - row1_int) * 1000;
+			row1_int = row1;
+			row1_dec = (row1 - row1_int) * 1000;
 
 			for (int column = 0; column < COLUMNS; column++)
 			{
@@ -216,14 +216,14 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
 			// COLUMNS is actually 90% of the screen size
 			// Add +10% because column 0 is at position 10%
 			col1 = ((100 * firstcol) / (COLUMNS / 0.8)) + 10;
-            col1_int = col1;
-            col1_dec = (col1 - col1_int) * 1000;
+			col1_int = col1;
+			col1_dec = (col1 - col1_int) * 1000;
 
 			if (firstcol >= 0)
 			{
 				wrote_something = 1;
 
-                sprintf(str, "      <p begin=\"%02u:%02u:%02u.%03u\" end=\"%02u:%02u:%02u.%03u\" tts:origin=\"%d.%03d%% %d.%03d%%\">\n        <span>", h1, m1, s1, ms1, h2, m2, s2, ms2, col1_int, col1_dec, row1_int, row1_dec);
+				sprintf(str, "      <p begin=\"%02u:%02u:%02u.%03u\" end=\"%02u:%02u:%02u.%03u\" tts:origin=\"%d.%03d%% %d.%03d%%\">\n        <span>", h1, m1, s1, ms1, h2, m2, s2, ms2, col1_int, col1_dec, row1_int, row1_dec);
 
                 if (context->encoding != CCX_ENC_UNICODE)
 				{

--- a/src/lib_ccx/ccx_encoders_smptett.c
+++ b/src/lib_ccx/ccx_encoders_smptett.c
@@ -225,7 +225,7 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
 
 				sprintf(str, "      <p begin=\"%02u:%02u:%02u.%03u\" end=\"%02u:%02u:%02u.%03u\" tts:origin=\"%d.%03d%% %d.%03d%%\">\n        <span>", h1, m1, s1, ms1, h2, m2, s2, ms2, col1_int, col1_dec, row1_int, row1_dec);
 
-                if (context->encoding != CCX_ENC_UNICODE)
+				if (context->encoding != CCX_ENC_UNICODE)
 				{
 					dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
 				}

--- a/src/lib_ccx/ccx_encoders_smptett.c
+++ b/src/lib_ccx/ccx_encoders_smptett.c
@@ -32,7 +32,6 @@
 #include "ccx_common_option.h"
 #include "ccx_encoders_common.h"
 #include <png.h>
-#include <math.h>
 #include "ocr.h"
 #include "utility.h"
 #include "ccx_encoders_helpers.h"
@@ -197,13 +196,16 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
 	{
 		if (data->row_used[row])
 		{
-			int row1 = 0;
-			int col1 = 0;
+			float row1 = 0;
+			float col1 = 0;
 			int firstcol = -1;
+			int row1_int, row1_dec, col1_int, col1_dec;
 
 			// ROWS is actually 90% of the screen size
 			// Add +10% because row 0 is at position 10%
-			row1 = round(((100 * row) / (ROWS / 0.8)) + 10);
+			row1 = ((100 * row) / (ROWS / 0.8)) + 10;
+			row1_int = (int)row1;
+			row1_dec = ((int)(row1 * 1000) % 1000);
 
 			for (int column = 0; column < COLUMNS; column++)
 			{
@@ -220,13 +222,15 @@ int write_cc_buffer_as_smptett(struct eia608_screen *data, struct encoder_ctx *c
 			}
 			// COLUMNS is actually 90% of the screen size
 			// Add +10% because column 0 is at position 10%
-			col1 = round(((100 * firstcol) / (COLUMNS / 0.8)) + 10);
+			col1 = ((100 * firstcol) / (COLUMNS / 0.8)) + 10;
+			col1_int = (int)col1;
+			col1_dec = ((int)(col1 * 1000) % 1000);
 
 			if (firstcol >= 0)
 			{
 				wrote_something = 1;
 
-				sprintf(str, "      <p begin=\"%02u:%02u:%02u.%03u\" end=\"%02u:%02u:%02u.%03u\" tts:origin=\"%u%% %u%%\">\n        <span>", h1, m1, s1, ms1, h2, m2, s2, ms2, col1, row1);
+				sprintf(str, "      <p begin=\"%02u:%02u:%02u.%03u\" end=\"%02u:%02u:%02u.%03u\" tts:origin=\"%u.%u%% %u.%u%%\">\n        <span>", h1, m1, s1, ms1, h2, m2, s2, ms2, col1_int, col1_dec, row1_int, row1_dec);
 
 				if (context->encoding != CCX_ENC_UNICODE)
 				{


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

For issue #1483, refactors formatting of `col1` and `row1` variables to avoid issues with LC_NUMERIC auto-formatting float values.


