### PR TITLE
[IMPROVEMENT] Make Environment variables for Hardsubx optional

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -81,8 +81,6 @@ jobs:
         cmake -DWITH_OCR=ON -DWITH_HARDSUBX=ON ../src
     - name: build
       run: |
-        FFMPEG_INCLUDE_DIR=/usr/include/x86_64-linux-gnu \
-        FFMPEG_PKG_CONFIG_PATH=/usr/x86_64-linux-gnu/lib/pkgconfig \
         make -j$(nproc)
       working-directory: build
     - name: Display version information

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -51,6 +51,4 @@ jobs:
         run: cargo fmt --all -- --check
       - name: clippy
         run: |
-          FFMPEG_INCLUDE_DIR=/usr/include/x86_64-linux-gnu \
-          FFMPEG_PKG_CONFIG_PATH=/usr/x86_64-linux-gnu/lib/pkgconfig \
           cargo clippy --all-features -- -D warnings

--- a/docs/COMPILATION.MD
+++ b/docs/COMPILATION.MD
@@ -58,7 +58,7 @@ cd ccextractor/linux
 ./build -debug            # same as ./build_debug
 
 # compile with hardsubx
-You need to set these environment variables correctly according to your machine,
+[Optional] You need to set these environment variables correctly according to your machine,
      FFMPEG_INCLUDE_DIR=/usr/include 
      FFMPEG_PKG_CONFIG_PATH=/usr/lib/pkgconfig
 
@@ -111,7 +111,7 @@ sudo make install
      `-DWITHOUT_RUST=ON` to disable rust.
      `-DWITH_HARDSUBX=ON` to enable burned-in subtitles
      
-(For hardsubx, you also need to set these environment variables correctly according to your machine)
+([OPTIONAL] For hardsubx, you also need to set these environment variables correctly according to your machine)
 
      FFMPEG_INCLUDE_DIR=/usr/include 
      FFMPEG_PKG_CONFIG_PATH=/usr/lib/pkgconfig
@@ -195,22 +195,25 @@ Dependencies are clang and rust. To enable OCR, rust i686-pc-windows-msvc target
 Other dependencies are required through vcpkg, so you can follow below steps:
 1. Download vcpkg (prefer version `2023.02.24` as it is supported)
 2. Integrate vcpkg into your system, run the below command in the downloaded vcpkg folder:
-```
-vcpkg integrate install
-```
+     ```
+     vcpkg integrate install
+     ```
 3. Set Environment Variable for Vcpkg triplet, you can choose between x86 or x64 based on your system.
-```
-setx VCPKG_DEFAULT_TRIPLET "x64-windows-static-md"
-```
-3. Install dependencies from vcpkg
-if building Debug-Full, Release-Full (HardSubx)
-```
-vcpkg install ffmpeg leptonica tesseract
-```
-otherwise if you have Debug, Release
-```
-vcpkg install libpng
-```
+     ```
+     setx VCPKG_DEFAULT_TRIPLET "x64-windows-static-md"
+     ```
+4. Install dependencies from vcpkg
+
+     In this step we are using `x64-windows-static-md` triplet, but you will have to use the triplet you set in Step 3
+
+     if building Debug-Full, Release-Full (HardSubx)
+     ```
+     vcpkg install ffmpeg leptonica tesseract --triplet x64-windows-static-md
+     ```
+     otherwise if you have Debug, Release
+     ```
+     vcpkg install libpng --triplet x64-windows-static-md
+     ```
 
 Note: Following screenshots and steps are based on Visual Studio 2017, but they should be more or less same for other versions.
 

--- a/docs/FFMPEG.md
+++ b/docs/FFMPEG.md
@@ -18,17 +18,21 @@ Note:If you installed ffmpeg on non-standard location, please change/update your
 ### Download and Install FFmpeg on your Windows pc:
 1. Download vcpkg (prefer version `2023.02.24` as it is supported)
 2. Integrate vcpkg into your system, run the below command in the downloaded vcpkg folder:
-```
-vcpkg integrate install
-```
+	```
+	vcpkg integrate install
+	```
 3. Set Environment Variable for Vcpkg triplet, you can choose between x86 or x64 based on your system.
-```
-setx VCPKG_DEFAULT_TRIPLET "x64-windows-static-md"
-```
-3. Install ffmpeg from vcpkg
-```
-vcpkg install ffmpeg
-```
+	```
+	setx VCPKG_DEFAULT_TRIPLET "x64-windows-static-md"
+	```
+4. Install ffmpeg from vcpkg
+
+
+	In this step we are using `x64-windows-static-md` triplet, but you will have to use the triplet you set in Step 3
+
+	```
+	vcpkg install ffmpeg --triplet x64-windows-static-md
+	```
 
 ## How to compile ccextractor
 

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -463,9 +463,9 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rsmpeg"
-version = "0.14.0+ffmpeg.6.0"
+version = "0.14.1+ffmpeg.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a0a7d94d291c7a070254344e799e136879d8d7ddfef4d27be4f43fc38f94132"
+checksum = "055510ebd8693dfe70570352b19a9147314da95e7435477526b976fc83b04455"
 dependencies = [
  "libc",
  "paste",
@@ -481,9 +481,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rusty_ffmpeg"
-version = "0.13.0+ffmpeg.6.0"
+version = "0.13.1+ffmpeg.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d757d403040f08d1a3b05905af00dfa00b01f5562f14588b1e8bccce6633ea"
+checksum = "0e7c726b08ea3ed199e21f6f4b3a1c23fc56a154be731b4445e4ef9ee004cffc"
 dependencies = [
  "bindgen 0.64.0",
  "camino",

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -55,8 +55,8 @@ dependencies = [
  "bitflags",
  "cexpr 0.4.0",
  "clang-sys",
- "clap 2.34.0",
- "env_logger 0.8.4",
+ "clap",
+ "env_logger",
  "lazy_static",
  "lazycell",
  "log",
@@ -67,29 +67,6 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "which 3.1.1",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.60.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
-dependencies = [
- "bitflags",
- "cexpr 0.6.0",
- "clang-sys",
- "clap 3.2.23",
- "env_logger 0.9.3",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "which 4.4.0",
 ]
 
 [[package]]
@@ -110,7 +87,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 1.0.109",
  "which 4.4.0",
 ]
 
@@ -122,16 +99,16 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "camino"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6031a462f977dd38968b6f23378356512feeace69cef817e1a4475108093cec3"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
 
 [[package]]
 name = "ccx_rust"
 version = "0.1.0"
 dependencies = [
  "bindgen 0.58.1",
- "env_logger 0.8.4",
+ "env_logger",
  "iconv",
  "leptonica-sys",
  "log",
@@ -184,34 +161,10 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim 0.8.0",
- "textwrap 0.11.0",
+ "strsim",
+ "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "clap"
-version = "3.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
-dependencies = [
- "atty",
- "bitflags",
- "clap_lex",
- "indexmap",
- "strsim 0.10.0",
- "termcolor",
- "textwrap 0.16.0",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -240,19 +193,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "find-crate"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,12 +206,6 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
@@ -299,16 +233,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "1.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libloading"
@@ -404,12 +328,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
-name = "os_str_bytes"
-version = "6.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
-
-[[package]]
 name = "palette"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,7 +348,7 @@ dependencies = [
  "find-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -475,7 +393,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -495,18 +413,18 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -545,9 +463,9 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rsmpeg"
-version = "0.12.0+ffmpeg.5.1"
+version = "0.14.0+ffmpeg.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7072f62239da603c78146486b5bf58dfe98ac385d6d6fc2cfa639dedfc4b5851"
+checksum = "6a0a7d94d291c7a070254344e799e136879d8d7ddfef4d27be4f43fc38f94132"
 dependencies = [
  "libc",
  "paste",
@@ -563,11 +481,11 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rusty_ffmpeg"
-version = "0.10.0+ffmpeg.5.1"
+version = "0.13.0+ffmpeg.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7499ed251c378578de349ef47b001de9bad7fa1e962417882598dc8bec1d01dc"
+checksum = "43d757d403040f08d1a3b05905af00dfa00b01f5562f14588b1e8bccce6633ea"
 dependencies = [
- "bindgen 0.60.1",
+ "bindgen 0.64.0",
  "camino",
  "libc",
  "once_cell",
@@ -577,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.154"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdd151213925e7f1ab45a9bbfb129316bd00799784b174b7cc7bcd16961c49e"
+checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
 
 [[package]]
 name = "shlex"
@@ -600,16 +518,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c622ae390c9302e214c31013517c2061ecb2699935882c60a9b37f82f8625ae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -647,29 +570,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-
-[[package]]
 name = "thiserror"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.4",
 ]
 
 [[package]]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4.0"
 env_logger = "0.8.4"
 iconv = "0.1.1"
 palette = "0.6.0"
-rsmpeg = { version = "0.14", optional = true, default-features = false, features = ["link_system_ffmpeg"] }
+rsmpeg = { version = "0.14", optional = true, default-features = false, features = ["link_system_ffmpeg", "ffmpeg5"] }
 tesseract-sys = { version = "0.5.14", optional = true, default-features = false}
 leptonica-sys = { version = "0.4.3", optional = true, default-features = false}
 

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4.0"
 env_logger = "0.8.4"
 iconv = "0.1.1"
 palette = "0.6.0"
-rsmpeg = { version = "0.14", optional = true, default-features = false, features = ["link_system_ffmpeg"] }
+rsmpeg = { version = "0.14.1", optional = true, features = ["link_system_ffmpeg"] }
 tesseract-sys = { version = "0.5.14", optional = true, default-features = false}
 leptonica-sys = { version = "0.4.3", optional = true, default-features = false}
 

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4.0"
 env_logger = "0.8.4"
 iconv = "0.1.1"
 palette = "0.6.0"
-rsmpeg = { version = "0.14", optional = true, default-features = false, features = ["link_system_ffmpeg", "ffmpeg5"] }
+rsmpeg = { version = "0.14", optional = true, default-features = false, features = ["link_system_ffmpeg"] }
 tesseract-sys = { version = "0.5.14", optional = true, default-features = false}
 leptonica-sys = { version = "0.4.3", optional = true, default-features = false}
 

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4.0"
 env_logger = "0.8.4"
 iconv = "0.1.1"
 palette = "0.6.0"
-rsmpeg = { version = "0.12.0", optional = true, default-features = false}
+rsmpeg = { version = "0.14", optional = true, default-features = false, features = ["link_system_ffmpeg"] }
 tesseract-sys = { version = "0.5.14", optional = true, default-features = false}
 leptonica-sys = { version = "0.4.3", optional = true, default-features = false}
 


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Previously Environment variables were necessary for rsmpeg but now they aren't, https://github.com/CCExtractor/rusty_ffmpeg/pull/90
