### PR TITLE
[FIX] #1516 in webvtt added support to two-three-four utf-8 bytes

### DIFF
--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -470,6 +470,7 @@ int write_cc_buffer_as_webvtt(struct eia608_screen *data, struct encoder_ctx *co
 			// Write symbol by symbol with events
 			for (int j = 0; j < length; j++)
 			{
+
 				if (ccx_options.use_webvtt_styling)
 				{
 					// opening events for fonts
@@ -488,13 +489,38 @@ int write_cc_buffer_as_webvtt(struct eia608_screen *data, struct encoder_ctx *co
 					{
 						write_wrapped(context->out->fh, strdup("<c."), 3);
 						write_wrapped(context->out->fh, color_text[open_color][0], strlen(color_text[open_color][0]));
-						write_wrapped(context->out->fh, ">", 1);
+						write_wrapped(context->out->fh, ">", 1);	
 					}
 				}
 
 				// write current text symbol
 				if (context->subline[j] != '\0')
-					write_wrapped(context->out->fh, &(context->subline[j]), 1);
+					if((context->subline[j])>240){ //4bytes
+						char c[4];
+						c[0]=context->subline[j];
+						c[1]=context->subline[j+1];
+						c[2]=context->subline[j+2];
+						c[3]=context->subline[j+3];
+						write_wrapped(context->out->fh, c, 4);
+					}
+					else if((context->subline[j])>224){ //3bytes
+						char c[3];
+						c[0]=context->subline[j];
+						c[1]=context->subline[j+1];
+						c[2]=context->subline[j+2];
+						write_wrapped(context->out->fh, c, 3);
+					}
+					else if((context->subline[j])>192){//2bytes
+						char c[2];
+						c[0]=context->subline[j];
+						c[1]=context->subline[j+1];
+						write_wrapped(context->out->fh, c, 2);
+					}
+					else if((context->subline[j])>128 && (context->subline[j])<192){
+					}
+					else{//1byte
+						write_wrapped(context->out->fh, &(context->subline[j]), 1);
+					}
 
 				if (ccx_options.use_webvtt_styling)
 				{

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -489,36 +489,41 @@ int write_cc_buffer_as_webvtt(struct eia608_screen *data, struct encoder_ctx *co
 					{
 						write_wrapped(context->out->fh, strdup("<c."), 3);
 						write_wrapped(context->out->fh, color_text[open_color][0], strlen(color_text[open_color][0]));
-						write_wrapped(context->out->fh, ">", 1);	
+						write_wrapped(context->out->fh, ">", 1);
 					}
 				}
 
 				// write current text symbol
 				if (context->subline[j] != '\0')
-					if((context->subline[j])>240){ //4bytes
+					if ((context->subline[j]) > 240)
+					{ // 4bytes
 						char c[4];
-						c[0]=context->subline[j];
-						c[1]=context->subline[j+1];
-						c[2]=context->subline[j+2];
-						c[3]=context->subline[j+3];
+						c[0] = context->subline[j];
+						c[1] = context->subline[j + 1];
+						c[2] = context->subline[j + 2];
+						c[3] = context->subline[j + 3];
 						write_wrapped(context->out->fh, c, 4);
 					}
-					else if((context->subline[j])>224){ //3bytes
+					else if ((context->subline[j]) > 224)
+					{ // 3bytes
 						char c[3];
-						c[0]=context->subline[j];
-						c[1]=context->subline[j+1];
-						c[2]=context->subline[j+2];
+						c[0] = context->subline[j];
+						c[1] = context->subline[j + 1];
+						c[2] = context->subline[j + 2];
 						write_wrapped(context->out->fh, c, 3);
 					}
-					else if((context->subline[j])>192){//2bytes
+					else if ((context->subline[j]) > 192)
+					{ // 2bytes
 						char c[2];
-						c[0]=context->subline[j];
-						c[1]=context->subline[j+1];
+						c[0] = context->subline[j];
+						c[1] = context->subline[j + 1];
 						write_wrapped(context->out->fh, c, 2);
 					}
-					else if((context->subline[j])>128 && (context->subline[j])<192){
+					else if ((context->subline[j]) > 128 && (context->subline[j]) < 192)
+					{
 					}
-					else{//1byte
+					else
+					{ // 1byte
 						write_wrapped(context->out->fh, &(context->subline[j]), 1);
 					}
 


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

This pr solves the but #1516 
