### PR TITLE
[FIX] #1520 keep webvtt-full formatting in sync

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -14,6 +14,7 @@
 - Fix: fix autoconf tesseract detection problem (#1503)
 - Fix: add missing compile_info_real.h source to Autotools build
 - Fix: add missing `-lavfilter` for hardsubx linking
+- Fix: make webvtt-full work correctly with multi-byte utf-8 characters
 
 0.94 (2021-12-14)
 -----------------

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -446,7 +446,7 @@ int write_cc_buffer_as_webvtt(struct eia608_screen *data, struct encoder_ctx *co
 			if (written != used)
 				return -1;
 
-			int length = get_line_encoded(context, context->subline, i, data);
+			char *line = data->characters[i];
 
 			if (context->encoding != CCX_ENC_UNICODE)
 			{
@@ -458,19 +458,16 @@ int write_cc_buffer_as_webvtt(struct eia608_screen *data, struct encoder_ctx *co
 			int *font_events;
 			if (ccx_options.use_webvtt_styling)
 			{
-				color_events = (int *)malloc(sizeof(int) * length);
-				font_events = (int *)malloc(sizeof(int) * length);
-				memset(color_events, 0, sizeof(int) * length);
-				memset(font_events, 0, sizeof(int) * length);
+				color_events = (int *)calloc(COLUMNS + 1, sizeof(int));
+				font_events = (int *)calloc(COLUMNS + 1, sizeof(int));
 
 				get_color_events(color_events, i, data);
 				get_font_events(font_events, i, data);
 			}
 
 			// Write symbol by symbol with events
-			for (int j = 0; j < length; j++)
+			for (int j = 0; j < COLUMNS + 1; j++)
 			{
-
 				if (ccx_options.use_webvtt_styling)
 				{
 					// opening events for fonts
@@ -494,38 +491,13 @@ int write_cc_buffer_as_webvtt(struct eia608_screen *data, struct encoder_ctx *co
 				}
 
 				// write current text symbol
-				if (context->subline[j] != '\0')
-					if ((context->subline[j]) > 240)
-					{ // 4bytes
-						char c[4];
-						c[0] = context->subline[j];
-						c[1] = context->subline[j + 1];
-						c[2] = context->subline[j + 2];
-						c[3] = context->subline[j + 3];
-						write_wrapped(context->out->fh, c, 4);
-					}
-					else if ((context->subline[j]) > 224)
-					{ // 3bytes
-						char c[3];
-						c[0] = context->subline[j];
-						c[1] = context->subline[j + 1];
-						c[2] = context->subline[j + 2];
-						write_wrapped(context->out->fh, c, 3);
-					}
-					else if ((context->subline[j]) > 192)
-					{ // 2bytes
-						char c[2];
-						c[0] = context->subline[j];
-						c[1] = context->subline[j + 1];
-						write_wrapped(context->out->fh, c, 2);
-					}
-					else if ((context->subline[j]) > 128 && (context->subline[j]) < 192)
-					{
-					}
-					else
-					{ // 1byte
-						write_wrapped(context->out->fh, &(context->subline[j]), 1);
-					}
+				if (line[j] != '\0')
+				{
+					unsigned char buf[5] = {0};
+					// Note: reference should be safe even when j == COLUMNS; characters is nul-terminated
+					int bytes = get_char_in_utf_8(buf, data->characters[i][j]);
+					write_wrapped(context->out->fh, buf, bytes);
+				}
 
 				if (ccx_options.use_webvtt_styling)
 				{
@@ -540,10 +512,10 @@ int write_cc_buffer_as_webvtt(struct eia608_screen *data, struct encoder_ctx *co
 					int close_font = font_events[j] >> 16; // First 16 bytes
 					if (close_font != FONT_REGULAR)
 					{
-						if (close_font & FONT_ITALICS)
-							write_wrapped(context->out->fh, strdup("</i>"), 4);
 						if (close_font & FONT_UNDERLINED)
 							write_wrapped(context->out->fh, strdup("</u>"), 4);
+						if (close_font & FONT_ITALICS)
+							write_wrapped(context->out->fh, strdup("</i>"), 4);
 					}
 				}
 			}


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [X] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Fixes #1520 so that style and text donʼt get out of sync.

I can see a few other issues (mentioned below) which I donʼt have sample files for so I can neither submit full issues nor personally fix, and fixing them might mean a rewrite of the entire loop or even the function:
 * It can still have mis-nested HTML tags (it can output `normal<i>italics<u>both</i>underlined`, or even worse with colors)
 * Even without `--nohtmlescape` it does not escape unsafe characters (which SRT also doesnʼt).

Fixing those probably requires a much bigger refactor than I am able to do at the moment, and probably for most cases the first wonʼt be an issue (I expect most parsers to handle it properly but havenʼt checked), and unless the subtitles contain HTML the second probably isnʼt an issue either.

The reason I made `buf` five bytes is in case Iʼm wrong about it needing a full rewrite; this way it can fit all of `&amp;`, although it will never contain it as things are now.