### PR TITLE
[FIX] encoding of solid block in latin-1 and unicode

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -15,6 +15,7 @@
 - Fix: add missing compile_info_real.h source to Autotools build
 - Fix: add missing `-lavfilter` for hardsubx linking
 - Fix: make webvtt-full work correctly with multi-byte utf-8 characters
+- Fix: encoding of solid block in latin-1 and unicode
 
 0.94 (2021-12-14)
 -----------------

--- a/src/lib_ccx/ccx_common_char_encoding.c
+++ b/src/lib_ccx/ccx_common_char_encoding.c
@@ -35,6 +35,8 @@ void get_char_in_latin_1(unsigned char *buffer, unsigned char c)
 			case 0x7e: // lowercase n tilde
 				c1 = 0xf1;
 				break;
+			case 0x7f: // Solid Block - Does not exist in Latin 1
+				break;
 			default:
 				c1 = c;
 				break;
@@ -292,6 +294,9 @@ void get_char_in_unicode(unsigned char *buffer, unsigned char c)
 	unsigned char c1, c2;
 	switch (c)
 	{
+		case 0x7f: // Solid block
+			c2 = 0x25;
+			c1 = 0xa0;
 		case 0x84: // Trademark symbol (TM)
 			c2 = 0x21;
 			c1 = 0x22;

--- a/src/lib_ccx/ccx_common_char_encoding.c
+++ b/src/lib_ccx/ccx_common_char_encoding.c
@@ -297,6 +297,7 @@ void get_char_in_unicode(unsigned char *buffer, unsigned char c)
 		case 0x7f: // Solid block
 			c2 = 0x25;
 			c1 = 0xa0;
+			break;
 		case 0x84: // Trademark symbol (TM)
 			c2 = 0x21;
 			c1 = 0x22;


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

The solid block character in Line-21 encoding (`0x7f`) is correctly encoded when converted to UTF-8 as `E2 96 A0` (which is `U+25A0`). But this character is missing in the conversion to latin-1 and unicode.