### PR TITLE
[FIX] Fix McPoodle broadcast raw format output

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -16,6 +16,7 @@
 - Fix: add missing `-lavfilter` for hardsubx linking
 - Fix: make webvtt-full work correctly with multi-byte utf-8 characters
 - Fix: encoding of solid block in latin-1 and unicode
+- Fix: McPoodle Broadcast Raw format for field 1
 
 0.94 (2021-12-14)
 -----------------

--- a/src/lib_ccx/output.c
+++ b/src/lib_ccx/output.c
@@ -177,8 +177,9 @@ void printdata(struct lib_cc_decode *ctx, const unsigned char *data1, int length
 			ctx->current_field = 2;
 			if (ctx->extract != 1)
 				ctx->writedata(data2, length2, ctx, sub);
-			else // User doesn't want field 2 data, but we want XDS.
+			else if (ctx->writedata != writeraw)
 			{
+				// User doesn't want field 2 data, but we want XDS.
 				ctx->writedata(data2, length2, ctx, sub);
 			}
 		}


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Currently this only works with field 2, which is rarely used; the issue is that field 2 is output either way and this format only supports one field.  This PR gets rid of the extraneous output; the `writeraw` function doesnʼt read XDS so it wasnʼt doing any good in this case anyway.