### PR TITLE
[FIX] Incorrect skipping of packets

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -17,6 +17,7 @@
 - Fix: make webvtt-full work correctly with multi-byte utf-8 characters
 - Fix: encoding of solid block in latin-1 and unicode
 - Fix: McPoodle Broadcast Raw format for field 1
+- Fix: Incorrect skipping of packets
 
 0.94 (2021-12-14)
 -----------------

--- a/src/lib_ccx/ccx_decoders_708.c
+++ b/src/lib_ccx/ccx_decoders_708.c
@@ -1406,7 +1406,7 @@ int dtvcc_handle_G0(dtvcc_service_decoder *decoder, unsigned char *data, int dat
 	if (decoder->current_window == -1)
 	{
 		ccx_common_logging.log_ftn("[CEA-708] dtvcc_handle_G0: Window has to be defined first\n");
-		return data_length;
+		return 1;
 	}
 
 	unsigned char c = data[0];

--- a/src/lib_ccx/ccx_dtvcc.c
+++ b/src/lib_ccx/ccx_dtvcc.c
@@ -58,6 +58,12 @@ void dtvcc_process_data(struct dtvcc_ctx *dtvcc,
 				}
 				else
 				{
+					if (dtvcc->is_current_packet_header_parsed)
+					{
+						ccx_common_logging.debug_ftn(CCX_DMT_708, "[CEA-708] dtvcc_process_data: "
+											  "Warning: Incorrect packet length specified. Packet will be skipped.\n");
+						dtvcc_clear_packet(dtvcc);
+					}
 					dtvcc->current_packet[dtvcc->current_packet_length++] = data[2];
 					dtvcc->current_packet[dtvcc->current_packet_length++] = data[3];
 					dtvcc->is_current_packet_header_parsed = 1;

--- a/src/rust/src/decoder/mod.rs
+++ b/src/rust/src/decoder/mod.rs
@@ -99,6 +99,10 @@ impl<'a> Dtvcc<'a> {
                     if self.packet_length > (CCX_DTVCC_MAX_PACKET_LENGTH - 1) {
                         warn!("dtvcc_process_data: Warning: Legal packet size exceeded (2), data not added.");
                     } else {
+                        if self.is_header_parsed {
+                            warn!("dtvcc_process_data: Warning: Incorrect packet length specified. Packet will be skipped.");
+                            self.clear_packet();
+                        }
                         self.add_data_to_packet(data1, data2);
                         self.is_header_parsed = true;
                     }

--- a/src/rust/src/decoder/service_decoder.rs
+++ b/src/rust/src/decoder/service_decoder.rs
@@ -1044,7 +1044,7 @@ impl dtvcc_service_decoder {
     pub fn handle_G0(&mut self, block: &[c_uchar]) -> i32 {
         if self.current_window == -1 {
             warn!("dtvcc_handle_G0: Window has to be defined first");
-            return block.len() as i32;
+            return 1;
         }
 
         let character = block[0];
@@ -1062,7 +1062,7 @@ impl dtvcc_service_decoder {
     pub fn handle_G1(&mut self, block: &[c_uchar]) -> i32 {
         if self.current_window == -1 {
             warn!("dtvcc_handle_G1: Window has to be defined first");
-            return block.len() as i32;
+            return 1;
         }
 
         let character = block[0];


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Partially Fixes #1468 

The reason why none of the text was showing up was because the given sample had service blocks of this kind:
`80 ff 8c ff 9c 18 46 19 00 1f 11 84 92 00 04 90 05 00 91 2a 00 00`
- `80` - Set Current Window to 0 - Does nothing since Window was never defined before.
- `ff` - character from G1 charset - The current implementation skips the entire packet if character is attempted to be inserted in an undefined window, which it was during this point.
- `8c ff` - Delete Windows specified with bitmap `ff` - Does nothing since no windows were defined in the first place.
- `9c ...` - Define Window 4 - Here comes the actual definition of the window that will contain all the text but this is never executed due to the second byte (`ff`).

All the window definitions followed the above pattern, hence a window was never defined, so all the text did not show up.
After fixing the implementation to only skip 1 character instead of entire packet, the following text was extracted:
```
1
00:00:01,234 --> 00:00:01,634
    <font color="#aaaaaa">Closed Captioning Insertion</font>

2
00:00:02,235 --> 00:00:02,635
    <font color="#aaaaaa">From PixelTools </font>

3
00:00:03,236 --> 00:00:03,636
    <font color="#aaaaaa">Have a Nice Day!</font>
```

Only the first line is skipped because the packet stream literally started from `This is a demo of the`. Definition of Window 4 only came later. We could fix it by defining all windows before hand but that will against the CEA-708 spec.

This was enough to get it fixed at the Rust side. The C side required more work.

The given sample file had packets of invalid length specified. The current implementation assumes the given packet length is valid. If the specified length is more than the actual length, it just keeps appending the content of the next packet too. (Here the actual length is till the next Packet Start). This problem was fixed by clearing the packet before the start of a new packet if it was not cleared previously. Hence this would skip the packets of invalid length.
Even though this error was not visible in Rust, I have still ported the code for parity's sake. The code at Rust side was able to clear the packet correctly even before this. I still haven't figured out how. Some help on this would be great.

Also, it is debatable if packets of invalid length should be processed or skipped. For now, I have chosen to skip them but they could very well be processed since such packets in the sample file had service number 0. Some advice on this will be very helpful.