### PR TITLE
Fix typo in ffmpeg_intgr.h

### DIFF
--- a/src/lib_ccx/ffmpeg_intgr.h
+++ b/src/lib_ccx/ffmpeg_intgr.h
@@ -1,5 +1,5 @@
-#ifndef _FFMPEG_INTIGRATION
-#define _FFMPEG_INTIGRATION
+#ifndef _FFMPEG_INTEGRATION
+#define _FFMPEG_INTEGRATION
 
 #include "lib_ccx.h"
 #ifdef ENABLE_FFMPEG


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x ] I have checked that another pull request for this purpose does not exist.
- [ x] I have considered, and confirmed that this submission will be valuable to others.
- [x ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Minor typo fix in ffmpeg_intgr.h
```diff
-#ifndef _FFMPEG_INTIGRATION
-#define _FFMPEG_INTIGRATION
+#ifndef _FFMPEG_INTEGRATION
+#define _FFMPEG_INTEGRATION
```