### PR TITLE
**[FIX]** fix infinite loop in MP4 file type detector and processor

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -21,6 +21,7 @@
 - Fix: Repeated values for enums
 - Cleanup: Remove the (unmaintained) Nuklear GUI code
 - Cleanup: Reduce the amount of Windows build options in the project file
+- Fix: infinite loop in MP4 file type detector.
 
 0.94 (2021-12-14)
 -----------------

--- a/src/lib_ccx/mp4.c
+++ b/src/lib_ccx/mp4.c
@@ -51,6 +51,15 @@ static int process_avc_sample(struct lib_ccx_ctx *ctx, u32 timescale, GF_AVCConf
 	{
 		u32 nal_length;
 
+		if (i + c->nal_unit_size > s->dataLength) {
+			mprint("Corrupted packet detected in process_avc_sample. dataLength "
+				"%u is less than index %u + nal_unit_size %u. Ignoring.\n",
+				s->dataLength, i, c->nal_unit_size);
+			// The packet is likely corrupted, it's unsafe to read this many bytes
+			// even to detect the length of the next `nal`. Ignoring this error,
+			// hopefully the outer loop in `process_avc_track` can recover.
+			return status;
+		}
 		switch (c->nal_unit_size)
 		{
 			case 1:
@@ -63,6 +72,7 @@ static int process_avc_sample(struct lib_ccx_ctx *ctx, u32 timescale, GF_AVCConf
 				nal_length = bswap32(*(long *)&s->data[i]);
 				break;
 		}
+		const u32 previous_index = i;
 		i += c->nal_unit_size;
 
 		s_nalu_stats.total += 1;
@@ -70,6 +80,15 @@ static int process_avc_sample(struct lib_ccx_ctx *ctx, u32 timescale, GF_AVCConf
 
 		temp_debug = 0;
 
+		if (i + nal_length <= previous_index || i + nal_length > s->dataLength) {
+			mprint("Corrupted sample detected in process_avc_sample. dataLength %u "
+				"is less than index %u + nal_unit_size %u + nal_length %u. Ignoring.\n",
+				s->dataLength, previous_index, c->nal_unit_size, nal_length);
+			// The packet is likely corrupted, it's unsafe to procell nal_length bytes
+			// because they are past the sample end. Ignoring this error, hopefully
+			// the outer loop in `process_avc_track` can recover.
+			return status;
+		}
 		if (nal_length > 0)
 			do_NAL(enc_ctx, dec_ctx, (unsigned char *)&(s->data[i]), nal_length, sub);
 		i += nal_length;

--- a/src/lib_ccx/mp4.c
+++ b/src/lib_ccx/mp4.c
@@ -74,12 +74,6 @@ static int process_avc_sample(struct lib_ccx_ctx *ctx, u32 timescale, GF_AVCConf
 		}
 		const u32 previous_index = i;
 		i += c->nal_unit_size;
-
-		s_nalu_stats.total += 1;
-		s_nalu_stats.type[s->data[i] & 0x1F] += 1;
-
-		temp_debug = 0;
-
 		if (i + nal_length <= previous_index || i + nal_length > s->dataLength) {
 			mprint("Corrupted sample detected in process_avc_sample. dataLength %u "
 				"is less than index %u + nal_unit_size %u + nal_length %u. Ignoring.\n",
@@ -89,8 +83,14 @@ static int process_avc_sample(struct lib_ccx_ctx *ctx, u32 timescale, GF_AVCConf
 			// the outer loop in `process_avc_track` can recover.
 			return status;
 		}
-		if (nal_length > 0)
+
+		s_nalu_stats.total += 1;
+		temp_debug = 0;
+
+		if (nal_length > 0) {
+			s_nalu_stats.type[s->data[i] & 0x1F] += 1;
 			do_NAL(enc_ctx, dec_ctx, (unsigned char *)&(s->data[i]), nal_length, sub);
+		}
 		i += nal_length;
 	} // outer for
 	assert(i == s->dataLength);

--- a/src/lib_ccx/mp4.c
+++ b/src/lib_ccx/mp4.c
@@ -51,10 +51,11 @@ static int process_avc_sample(struct lib_ccx_ctx *ctx, u32 timescale, GF_AVCConf
 	{
 		u32 nal_length;
 
-		if (i + c->nal_unit_size > s->dataLength) {
+		if (i + c->nal_unit_size > s->dataLength)
+		{
 			mprint("Corrupted packet detected in process_avc_sample. dataLength "
-				"%u is less than index %u + nal_unit_size %u. Ignoring.\n",
-				s->dataLength, i, c->nal_unit_size);
+			       "%u is less than index %u + nal_unit_size %u. Ignoring.\n",
+			       s->dataLength, i, c->nal_unit_size);
 			// The packet is likely corrupted, it's unsafe to read this many bytes
 			// even to detect the length of the next `nal`. Ignoring this error,
 			// hopefully the outer loop in `process_avc_track` can recover.
@@ -74,10 +75,11 @@ static int process_avc_sample(struct lib_ccx_ctx *ctx, u32 timescale, GF_AVCConf
 		}
 		const u32 previous_index = i;
 		i += c->nal_unit_size;
-		if (i + nal_length <= previous_index || i + nal_length > s->dataLength) {
+		if (i + nal_length <= previous_index || i + nal_length > s->dataLength)
+		{
 			mprint("Corrupted sample detected in process_avc_sample. dataLength %u "
-				"is less than index %u + nal_unit_size %u + nal_length %u. Ignoring.\n",
-				s->dataLength, previous_index, c->nal_unit_size, nal_length);
+			       "is less than index %u + nal_unit_size %u + nal_length %u. Ignoring.\n",
+			       s->dataLength, previous_index, c->nal_unit_size, nal_length);
 			// The packet is likely corrupted, it's unsafe to procell nal_length bytes
 			// because they are past the sample end. Ignoring this error, hopefully
 			// the outer loop in `process_avc_track` can recover.
@@ -87,7 +89,8 @@ static int process_avc_sample(struct lib_ccx_ctx *ctx, u32 timescale, GF_AVCConf
 		s_nalu_stats.total += 1;
 		temp_debug = 0;
 
-		if (nal_length > 0) {
+		if (nal_length > 0)
+		{
 			// s->data[i] is only relevant and safe to access here.
 			s_nalu_stats.type[s->data[i] & 0x1F] += 1;
 			do_NAL(enc_ctx, dec_ctx, (unsigned char *)&(s->data[i]), nal_length, sub);

--- a/src/lib_ccx/mp4.c
+++ b/src/lib_ccx/mp4.c
@@ -88,6 +88,7 @@ static int process_avc_sample(struct lib_ccx_ctx *ctx, u32 timescale, GF_AVCConf
 		temp_debug = 0;
 
 		if (nal_length > 0) {
+			// s->data[i] is only relevant and safe to access here.
 			s_nalu_stats.type[s->data[i] & 0x1F] += 1;
 			do_NAL(enc_ctx, dec_ctx, (unsigned char *)&(s->data[i]), nal_length, sub);
 		}

--- a/src/lib_ccx/stream_functions.c
+++ b/src/lib_ccx/stream_functions.c
@@ -99,13 +99,8 @@ void detect_stream_type(struct ccx_demuxer *ctx)
 		while (idx < ctx->startbytes_avail - 8)
 		{
 			// Check if we have a valid box
-			if (isValidMP4Box(ctx->startbytes, idx, &nextBoxLocation, &boxScore))
+			if (isValidMP4Box(ctx->startbytes, idx, &nextBoxLocation, &boxScore) && nextBoxLocation > idx)
 			{
-				if (nextBoxLocation <= idx)
-				{
-					// Likely malformed MP4 or not MP4 at all.
-					break;
-				}
 				idx = nextBoxLocation; // If the box is valid, a new box should be found on the next location... Not somewhere in between.
 				if (boxScore > 7)
 				{

--- a/src/lib_ccx/stream_functions.c
+++ b/src/lib_ccx/stream_functions.c
@@ -101,6 +101,11 @@ void detect_stream_type(struct ccx_demuxer *ctx)
 			// Check if we have a valid box
 			if (isValidMP4Box(ctx->startbytes, idx, &nextBoxLocation, &boxScore))
 			{
+				if (nextBoxLocation <= idx)
+				{
+					// Likely malformed MP4 or not MP4 at all.
+					break;
+				}
 				idx = nextBoxLocation; // If the box is valid, a new box should be found on the next location... Not somewhere in between.
 				if (boxScore > 7)
 				{


### PR DESCRIPTION
On bad inputs containing e.g. the following sequence of bytes within the first 1MiB "ff ff ff ff 6d 65 74 61" `detect_stream_type` was executing an infinite loop because "ff ff ff ff" was interpreted as a length of the candidate "meta" MP4 box, caused the size_t overflow inside `isValidMP4Box` which pointed `nextBoxLocation` to the previous byte and the execution flow processed the same "meta" again.

<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

{pull request content here}
