### PR TITLE
[FIX] Compilation.md - Added a note for Ubuntu 23.10 

### DIFF
--- a/docs/COMPILATION.MD
+++ b/docs/COMPILATION.MD
@@ -33,6 +33,8 @@ sudo paru -S glew glfw curl tesseract leptonica cmake gcc clang
 
 Rust 1.54 or above is also required. [Install Rust](https://www.rust-lang.org/tools/install). Check specific compilation methods below, on how to compile without rust.
 
+**Note:** On Ubuntu Version 23.10 (Mantic), `libgpac-dev` isn't available, you should build gpac from source. 
+
 **Note:** On Ubuntu Version 18.04 (Bionic) and later, `libtesseract-dev` is installed rather than `tesseract-ocr-dev`, which does not exist anymore.
 
 **Note:** On Ubuntu Version 14.04 (Trusty) and earlier, you should build leptonica and tesseract from source

--- a/docs/COMPILATION.MD
+++ b/docs/COMPILATION.MD
@@ -17,7 +17,7 @@ git clone https://github.com/CCExtractor/ccextractor.git
 Debian:
 
 ```bash
-sudo apt-get install -y libglew-dev libglfw3-dev cmake gcc libcurl4-gnutls-dev tesseract-ocr libtesseract-dev libleptonica-dev clang libclang-dev
+sudo apt-get install -y libgpac-dev libglew-dev libglfw3-dev cmake gcc libcurl4-gnutls-dev tesseract-ocr libtesseract-dev libleptonica-dev clang libclang-dev
 ```
 
 RHEL:
@@ -33,7 +33,7 @@ sudo paru -S glew glfw curl tesseract leptonica cmake gcc clang
 
 Rust 1.54 or above is also required. [Install Rust](https://www.rust-lang.org/tools/install). Check specific compilation methods below, on how to compile without rust.
 
-**Note:** On Ubuntu Version 23.10 (Mantic), `libgpac-dev` isn't available, you should build gpac from source. 
+**Note:** On Ubuntu Version 23.10 (Mantic) and later, `libgpac-dev` isn't available, you should build gpac from source by following the easy build instructions [here](https://github.com/gpac/gpac/wiki/GPAC-Build-Guide-for-Linux)
 
 **Note:** On Ubuntu Version 18.04 (Bionic) and later, `libtesseract-dev` is installed rather than `tesseract-ocr-dev`, which does not exist anymore.
 


### PR DESCRIPTION
libgpac-dev isn't available on Ubuntu 23.10 (Mantic) added a note instructing to build it from source instead.

<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

The package `libgpac-dev` isn't available for the Ubuntu 23.10 Mantic release. [Package search returns no results](https://packages.ubuntu.com/search?suite=mantic&searchon=names&keywords=libgpac) which would lead the ccextractor build to fail while following the given instructions, Added a note instructing to build it from source instead.
