### PR TITLE
Typo in compilation docs

### DIFF
--- a/docs/COMPILATION.MD
+++ b/docs/COMPILATION.MD
@@ -57,7 +57,7 @@ cd ccextractor/linux
 ./build -without-rust
 
 # compile with debug info
-./build -debug            # same as ./build_debug
+./build -debug            # same as ./builddebug
 
 # compile with hardsubx
 [Optional] You need to set these environment variables correctly according to your machine,

--- a/linux/build
+++ b/linux/build
@@ -85,7 +85,7 @@ SRC_FREETYPE="../src/thirdparty/freetype/autofit/autofit.c
         ../src/thirdparty/freetype/type42/type42.c
         ../src/thirdparty/freetype/winfonts/winfnt.c"
 BLD_SOURCES="../src/ccextractor.c $SRC_CCX $SRC_GPAC $SRC_ZLIB $SRC_LIBPNG $SRC_HASH $SRC_PROTOBUF $SRC_UTF8PROC $SRC_FREETYPE"
-BLD_LINKER="$BLD_LINKER -lm -zmuldefs -l tesseract -l lept -lpthread -ldl -lgpac"
+BLD_LINKER="$BLD_LINKER -lm -zmuldefs -l tesseract -l leptonica -lpthread -ldl -lgpac"
 
 echo "Running pre-build script..."
 ./pre-build.sh


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [x] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

I was getting started with the project. Just trying to build ccextractor by following the [COMPILATION.md](https://github.com/CCExtractor/ccextractor/blob/master/docs/COMPILATION.MD) resulted in a linker error, which was caused due to a deprecated library name. This fixes the error on my machine.

OS: Arch linux 6.6.10 x86_64
gcc 13.2.1
clang 16.0.6

Used pacman to install all listed dependencies.