### PR TITLE
[FEATURE] Port 708 decoder encoding module to RUST

### DIFF
--- a/src/lib_ccx/ccx_decoders_708_encoding.c
+++ b/src/lib_ccx/ccx_decoders_708_encoding.c
@@ -12,7 +12,7 @@ EIA-708, SO INTERNALLY WE USE THIS TABLE (FOR CONVENIENCE)
 A0-FF -> Group G1 as is - non-English characters and symbols
 */
 
-#if !defined(DISABLE_RUST)
+#if defined(DISABLE_RUST)
 
 unsigned char dtvcc_get_internal_from_G0(unsigned char g0_char)
 {

--- a/src/lib_ccx/ccx_decoders_708_encoding.c
+++ b/src/lib_ccx/ccx_decoders_708_encoding.c
@@ -12,6 +12,8 @@ EIA-708, SO INTERNALLY WE USE THIS TABLE (FOR CONVENIENCE)
 A0-FF -> Group G1 as is - non-English characters and symbols
 */
 
+#if !defined(DISABLE_RUST)
+
 unsigned char dtvcc_get_internal_from_G0(unsigned char g0_char)
 {
 	return g0_char;
@@ -43,3 +45,5 @@ unsigned char dtvcc_get_internal_from_G3(unsigned char g3_char)
 	// Rest unmapped, so we return a blank space
 	return 0x20;
 }
+
+#endif

--- a/src/lib_ccx/ccx_decoders_708_encoding.h
+++ b/src/lib_ccx/ccx_decoders_708_encoding.h
@@ -1,11 +1,18 @@
 #ifndef _CCX_DECODERS_708_ENCODING_H_
 #define _CCX_DECODERS_708_ENCODING_H_
 
-#define CCX_DTVCC_MUSICAL_NOTE_CHAR 9836	// Unicode Character 'BEAMED SIXTEENTH NOTES'
+#define CCX_DTVCC_MUSICAL_NOTE_CHAR 9836 // Unicode Character 'BEAMED SIXTEENTH NOTES'
 
+#ifndef DISABLE_RUST
+extern unsigned char dtvcc_get_internal_from_G0(unsigned char g0_char);
+extern unsigned char dtvcc_get_internal_from_G1(unsigned char g1_char);
+extern unsigned char dtvcc_get_internal_from_G2(unsigned char g2_char);
+extern unsigned char dtvcc_get_internal_from_G3(unsigned char g3_char);
+#else
 unsigned char dtvcc_get_internal_from_G0(unsigned char g0_char);
 unsigned char dtvcc_get_internal_from_G1(unsigned char g1_char);
 unsigned char dtvcc_get_internal_from_G2(unsigned char g2_char);
 unsigned char dtvcc_get_internal_from_G3(unsigned char g3_char);
+#endif
 
 #endif /*_CCX_DECODERS_708_ENCODING_H_*/

--- a/src/rust/build.rs
+++ b/src/rust/build.rs
@@ -59,6 +59,8 @@ fn main() {
     }
 
     let bindings = builder
+        .derive_default(true)
+        .no_default("dtvcc_pen_attribs|dtvcc_pen_color|dtvcc_symbol")
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.

--- a/src/rust/src/decoder/encoding.rs
+++ b/src/rust/src/decoder/encoding.rs
@@ -25,13 +25,10 @@ pub extern "C" fn dtvcc_get_internal_from_G1(g1_char: u8) -> u8 {
 /// G2: Extended Control Code Set 1
 #[no_mangle]
 pub extern "C" fn dtvcc_get_internal_from_G2(g2_char: u8) -> u8 {
-    if (0x20..=0x3F).contains(&g2_char) {
-        g2_char - 0x20
-    } else if (0x60..=0x7F).contains(&g2_char) {
-        g2_char + 0x20
-    } else {
-        // Rest unmapped, so we return a blank space
-        0x20
+    match g2_char {
+        0x20..=0x3F => g2_char - 0x20,
+        0x60..=0x7F => g2_char + 0x20,
+        _ => 0x20,
     }
 }
 

--- a/src/rust/src/decoder/encoding.rs
+++ b/src/rust/src/decoder/encoding.rs
@@ -1,0 +1,48 @@
+/// 256 BYTES IS ENOUGH FOR ALL THE SUPPORTED CHARACTERS IN
+/// EIA-708, SO INTERNALLY WE USE THIS TABLE (FOR CONVENIENCE)
+///
+/// 00-1F -> Characters that are in the G2 group in 20-3F,
+///          except for 06, which is used for the closed captions
+///          sign "CC" which is defined in group G3 as 00. (this
+///          is by the article 33).
+/// 20-7F -> Group G0 as is - corresponds to the ASCII code
+/// 80-9F -> Characters that are in the G2 group in 60-7F
+///          (there are several blank characters here, that's OK)
+/// A0-FF -> Group G1 as is - non-English characters and symbols
+
+// NOTE: Same as `lib_ccx/ccx_decoder_708_encoding.c` file
+
+#[no_mangle]
+pub extern "C" fn dtvcc_get_internal_from_G0(g0_char: u8) -> u8 {
+    g0_char
+}
+
+#[no_mangle]
+pub extern "C" fn dtvcc_get_internal_from_G1(g1_char: u8) -> u8 {
+    g1_char
+}
+
+/// G2: Extended Control Code Set 1
+#[no_mangle]
+pub extern "C" fn dtvcc_get_internal_from_G2(g2_char: u8) -> u8 {
+    if (0x20..=0x3F).contains(&g2_char) {
+        g2_char - 0x20
+    } else if (0x60..=0x7F).contains(&g2_char) {
+        g2_char + 0x20
+    } else {
+        // Rest unmapped, so we return a blank space
+        0x20
+    }
+}
+
+/// G3: Future Characters and Icon Expansion
+#[no_mangle]
+pub extern "C" fn dtvcc_get_internal_from_G3(g3_char: u8) -> u8 {
+    if g3_char == 0xa0 {
+        // The "CC" (closed captions) sign
+        0x06
+    } else {
+        // Rest unmapped, so we return a blank space
+        0x20
+    }
+}

--- a/src/rust/src/decoder/mod.rs
+++ b/src/rust/src/decoder/mod.rs
@@ -3,6 +3,7 @@
 //! Provides a CEA 708 decoder as defined by ANSI/CTA-708-E R-2018
 
 mod commands;
+mod encoding;
 mod output;
 mod service_decoder;
 mod timing;


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

I have migrated the logic and functions from the [lib_ccx/ccx_decoder_708_encoding.c](https://github.com/CCExtractor/ccextractor/blob/master/src/lib_ccx/ccx_decoders_708_encoding.c) file to Rust, located in decoder/encoding.rs. This conversion maintains the same functionality that was originally written in C, now implemented in Rust.

To know more See [ccx_decoder_708_encoding.c](https://github.com/CCExtractor/ccextractor/blob/master/src/lib_ccx/ccx_decoders_708_encoding.c) and compare with File Changed in PR, they are both same

### Background & Testing
- **Current codebase scenerio:** Only C code of [ccx_decoder_708_encoding.c](https://github.com/CCExtractor/ccextractor/blob/master/src/lib_ccx/ccx_decoders_708_encoding.c) file is available. So while making & running **Rust** test cases which requires these functions do not have body because `cargo test` is just seeing the rust code only.
- **After PR changes:**  Exact same logic of rust code will be there. And I did also added the conditional compilation so that if user build with `-without-rust` then only C code will work or else Rust code will build. And Yes I have manually tested that when compiling with rust src files, rust code is being used and giving the same result.