### PR TITLE
[WIP] [FIX] Initialize data structures for the rust CEA-708 decoder and correct Dtvcc

### DIFF
--- a/src/lib_ccx/ccx_decoders_common.c
+++ b/src/lib_ccx/ccx_decoders_common.c
@@ -219,7 +219,7 @@ int do_cb(struct lib_cc_decode *ctx, unsigned char *cc_block, struct cc_subtitle
 			default:
 				fatal(CCX_COMMON_EXIT_BUG_BUG, "In do_cb: Impossible value for cc_type, Please file a bug report on GitHub.\n");
 		} // switch (cc_type)
-	}	  // cc_valid
+	} // cc_valid
 	else
 	{
 		dbg_print(CCX_DMT_CBRAW, "    ..   ..   ..\n");
@@ -232,7 +232,11 @@ int do_cb(struct lib_cc_decode *ctx, unsigned char *cc_block, struct cc_subtitle
 void dinit_cc_decode(struct lib_cc_decode **ctx)
 {
 	struct lib_cc_decode *lctx = *ctx;
+#ifndef DISABLE_RUST
+	ccxr_dtvcc_free(lctx->dtvcc_rust);
+#else
 	dtvcc_free(&lctx->dtvcc);
+#endif
 	dinit_avc(&lctx->avc_ctx);
 	ccx_decoder_608_dinit_library(&lctx->context_cc608_field_1);
 	ccx_decoder_608_dinit_library(&lctx->context_cc608_field_2);
@@ -261,8 +265,12 @@ struct lib_cc_decode *init_cc_decode(struct ccx_decoders_common_settings_t *sett
 	ctx->no_rollup = setting->no_rollup;
 	ctx->noscte20 = setting->noscte20;
 
+#ifndef DISABLE_RUST
+	ctx->dtvcc_rust = ccxr_dtvcc_init(setting->settings_dtvcc);
+#else
 	ctx->dtvcc = dtvcc_init(setting->settings_dtvcc);
 	ctx->dtvcc->is_active = setting->settings_dtvcc->enabled;
+#endif
 
 	if (setting->codec == CCX_CODEC_ATSC_CC)
 	{

--- a/src/lib_ccx/ccx_decoders_structs.h
+++ b/src/lib_ccx/ccx_decoders_structs.h
@@ -208,6 +208,9 @@ struct lib_cc_decode
     int stat_divicom;
     int false_pict_header;
 
+	// For storing Dtvcc coming from rust
+	void *dtvcc_rust;
+
 	dtvcc_ctx *dtvcc;
 	int current_field;
 	// Analyse/use the picture information

--- a/src/lib_ccx/ccx_dtvcc.h
+++ b/src/lib_ccx/ccx_dtvcc.h
@@ -10,4 +10,9 @@ void dtvcc_process_data(struct dtvcc_ctx *dtvcc,
 dtvcc_ctx *dtvcc_init(ccx_decoder_dtvcc_settings *opts);
 void dtvcc_free(dtvcc_ctx **);
 
-#endif //CCEXTRACTOR_CCX_DTVCC_H
+#ifndef DISABLE_RUST
+extern void *ccxr_dtvcc_init(struct ccx_decoder_dtvcc_settings *settings_dtvcc);
+extern void ccxr_dtvcc_free(void *dtvcc_rust);
+#endif
+
+#endif // CCEXTRACTOR_CCX_DTVCC_H

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -896,7 +896,12 @@ int process_non_multiprogram_general_loop(struct lib_ccx_ctx *ctx,
 	cinfo = get_cinfo(ctx->demux_ctx, pid);
 	*enc_ctx = update_encoder_list_cinfo(ctx, cinfo);
 	*dec_ctx = update_decoder_list_cinfo(ctx, cinfo);
+
+#ifndef DISABLE_RUST
+	ccxr_dtvcc_set_encoder((*dec_ctx)->dtvcc_rust, *enc_ctx);
+#else
 	(*dec_ctx)->dtvcc->encoder = (void *)(*enc_ctx);
+#endif
 
 	if ((*dec_ctx)->timing->min_pts == 0x01FFFFFFFFLL) // if we didn't set the min_pts of the program
 	{
@@ -1093,7 +1098,12 @@ int general_loop(struct lib_ccx_ctx *ctx)
 
 				enc_ctx = update_encoder_list_cinfo(ctx, cinfo);
 				dec_ctx = update_decoder_list_cinfo(ctx, cinfo);
+
+#ifndef DISABLE_RUST
+				ccxr_dtvcc_set_encoder(dec_ctx->dtvcc_rust, enc_ctx);
+#else
 				dec_ctx->dtvcc->encoder = (void *)enc_ctx; // WARN: otherwise cea-708 will not work
+#endif
 
 				if (dec_ctx->timing->min_pts == 0x01FFFFFFFFLL) // if we didn't set the min_pts of the program
 				{
@@ -1268,7 +1278,13 @@ int rcwt_loop(struct lib_ccx_ctx *ctx)
 	}
 
 	dec_ctx = update_decoder_list(ctx);
+
+#ifndef DISABLE_RUST
+	ccxr_dtvcc_set_encoder(dec_ctx->dtvcc_rust, enc_ctx);
+#else
 	dec_ctx->dtvcc->encoder = (void *)enc_ctx; // WARN: otherwise cea-708 will not work
+#endif
+
 	if (parsebuf[6] == 0 && parsebuf[7] == 2)
 	{
 		dec_ctx->codec = CCX_CODEC_TELETEXT;

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -173,6 +173,10 @@ int general_loop(struct lib_ccx_ctx *ctx);
 void process_hex(struct lib_ccx_ctx *ctx, char *filename);
 int rcwt_loop(struct lib_ccx_ctx *ctx);
 
+#ifndef DISABLE_RUST
+void ccxr_dtvcc_set_encoder(void *dtvcc_rust, struct encoder_ctx* encoder);
+#endif
+
 extern int end_of_file;
 
 int ccx_mxf_getmoredata(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata);

--- a/src/rust/src/decoder/mod.rs
+++ b/src/rust/src/decoder/mod.rs
@@ -10,7 +10,10 @@ mod timing;
 mod tv_screen;
 mod window;
 
-use crate::{bindings::*, utils::is_true};
+use crate::{
+    bindings::*,
+    utils::{is_false, is_true},
+};
 
 use log::{debug, warn};
 
@@ -20,6 +23,7 @@ const CCX_DTVCC_SCREENGRID_ROWS: u8 = 75;
 const CCX_DTVCC_SCREENGRID_COLUMNS: u8 = 210;
 const CCX_DTVCC_MAX_ROWS: u8 = 15;
 const CCX_DTVCC_MAX_COLUMNS: u8 = 32 * 2;
+const CCX_DTVCC_MAX_SERVICES: usize = 63;
 
 /// Context required for processing 708 data
 pub struct Dtvcc<'a> {
@@ -28,37 +32,92 @@ pub struct Dtvcc<'a> {
     pub services_active: Vec<i32>,
     pub report_enabled: bool,
     pub report: &'a mut ccx_decoder_dtvcc_report,
-    pub decoders: Vec<&'a mut dtvcc_service_decoder>,
+    pub decoders: [Option<Box<dtvcc_service_decoder>>; CCX_DTVCC_MAX_SERVICES],
     pub packet: Vec<u8>,
     pub packet_length: u8,
     pub is_header_parsed: bool,
     pub last_sequence: i32,
-    pub encoder: &'a mut encoder_ctx,
+    pub encoder: *mut encoder_ctx,
     pub no_rollup: bool,
     pub timing: &'a mut ccx_common_timing_ctx,
 }
 
 impl<'a> Dtvcc<'a> {
     /// Create a new dtvcc context
-    pub fn new(ctx: &'a mut dtvcc_ctx) -> Self {
-        let report = unsafe { &mut *ctx.report };
-        let encoder = unsafe { &mut *(ctx.encoder as *mut encoder_ctx) };
-        let timing = unsafe { &mut *ctx.timing };
+    pub fn new(opts: &ccx_decoder_dtvcc_settings) -> Self {
+        // closely follows `dtvcc_init` at `src/lib_ccx/ccx_dtvcc.c:82`
 
-        Self {
-            is_active: is_true(ctx.is_active),
-            active_services_count: ctx.active_services_count as u8,
-            services_active: ctx.services_active.to_vec(),
-            report_enabled: is_true(ctx.report_enabled),
+        let is_active = false;
+        let active_services_count = opts.active_services_count as u8;
+        let services_active = opts.services_enabled.to_vec();
+        let report_enabled = is_true(opts.print_file_reports);
+
+        let report = unsafe { &mut *opts.report };
+        report.reset_count = 0;
+
+        // `dtvcc_clear_packet` does the following
+        let packet_length = 0;
+        let is_header_parsed = false;
+        let packet = [0; CCX_DTVCC_MAX_SERVICES].to_vec();
+
+        let last_sequence = CCX_DTVCC_NO_LAST_SEQUENCE;
+        let timing = unsafe { &mut *opts.timing };
+
+        let no_rollup = is_true(opts.no_rollup);
+
+        // unlike C, here the decoders are allocated on the stack as an array.
+        let decoders = {
+            const INIT: Option<Box<dtvcc_service_decoder>> = None;
+            let mut decoders = [INIT; CCX_DTVCC_MAX_SERVICES];
+
+            decoders
+                .iter_mut()
+                .zip(opts.services_enabled)
+                .enumerate()
+                .for_each(|(i, (d, se))| {
+                    if is_false(se) {
+                        return;
+                    }
+
+                    let mut decoder = Box::new(dtvcc_service_decoder {
+                        // we cannot allocate this on the stack as `dtvcc_service_decoder` is a C
+                        // struct cannot be changed trivially
+                        tv: Box::into_raw(Box::new(dtvcc_tv_screen {
+                            cc_count: 0,
+                            service_number: i as i32 + 1,
+                            ..dtvcc_tv_screen::default()
+                        })),
+                        ..dtvcc_service_decoder::default()
+                    });
+
+                    decoder.windows.iter_mut().for_each(|w| {
+                        w.memory_reserved = 0;
+                    });
+
+                    unsafe { dtvcc_windows_reset(decoder.as_mut()) };
+
+                    *d = Some(decoder);
+                });
+
+            decoders
+        };
+
+        let encoder = std::ptr::null_mut();
+
+        Dtvcc {
+            is_active,
+            active_services_count,
+            services_active,
+            report_enabled,
             report,
-            decoders: ctx.decoders.iter_mut().collect(),
-            packet: ctx.current_packet.to_vec(),
-            packet_length: ctx.current_packet_length as u8,
-            is_header_parsed: is_true(ctx.is_current_packet_header_parsed),
-            last_sequence: ctx.last_sequence,
-            encoder,
-            no_rollup: is_true(ctx.no_rollup),
+            packet,
+            packet_length,
+            is_header_parsed,
+            last_sequence,
+            no_rollup,
             timing,
+            encoder,
+            decoders,
         }
     }
     /// Process cc data and add it to the dtvcc packet
@@ -171,7 +230,9 @@ impl<'a> Dtvcc<'a> {
             }
 
             if service_number > 0 && is_true(self.services_active[(service_number - 1) as usize]) {
-                let decoder = &mut self.decoders[(service_number - 1) as usize];
+                let decoder = &mut self.decoders[(service_number - 1) as usize]
+                    .as_mut()
+                    .unwrap();
                 decoder.process_service_block(
                     &self.packet[pos as usize..(pos + block_length) as usize],
                     self.encoder,

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -95,6 +95,11 @@ extern "C" fn ccxr_dtvcc_free(dtvcc_rust: *mut Dtvcc) {
     }
 }
 
+#[no_mangle]
+extern "C" fn ccxr_dtvcc_set_encoder(dtvcc_rust: *mut Dtvcc, encoder: *mut encoder_ctx) {
+    unsafe { (*dtvcc_rust).encoder = encoder };
+}
+
 /// Process cc_data
 ///
 /// # Safety

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -44,6 +44,57 @@ pub extern "C" fn ccxr_init_logger() {
         .init();
 }
 
+/// Create a `dtvcc_rust`
+///
+/// SAFETY:
+/// The following should not be `NULL`:
+///     - opts
+///     - opts.report
+///     - opts.timing
+#[no_mangle]
+extern "C" fn ccxr_dtvcc_init<'a>(opts_ptr: *const ccx_decoder_dtvcc_settings) -> *mut Dtvcc<'a> {
+    let opts = unsafe { opts_ptr.as_ref() }.unwrap();
+    Box::into_raw(Box::new(Dtvcc::new(opts)))
+}
+
+/// Frees `dtvcc_rust`
+///
+/// SAFETY:
+/// The following should not be `NULL`:
+///     - dtvcc_rust
+///     - dtvcc_rust.decoders[i] if dtvcc_rust.services_active[i] is true
+///     - dtvcc_rust.decoders[i].windows[j].rows[k] if
+///         dtvcc_rust.decoders[i].windows[j].memory_reserved is true
+///     - dtvcc_rust.decoders[i].tv
+#[no_mangle]
+extern "C" fn ccxr_dtvcc_free(dtvcc_rust: *mut Dtvcc) {
+    let dtvcc = unsafe { dtvcc_rust.read() };
+
+    // closely follows `dtvcc_free` at `src/lib_ccx/ccx_dtvcc.c:126`
+    for i in 0..decoder::CCX_DTVCC_MAX_SERVICES {
+        if utils::is_false(dtvcc.services_active[i]) {
+            continue;
+        }
+
+        let decoder = unsafe { &mut dtvcc.decoders[i].read() };
+
+        decoder.windows.iter_mut().for_each(|window| {
+            if utils::is_false(window.memory_reserved) {
+                return;
+            }
+
+            // Drop all windows row
+            window.rows.iter().for_each(|symbol_ptr| unsafe {
+                symbol_ptr.drop_in_place();
+            });
+
+            window.memory_reserved = 0;
+        });
+
+        unsafe { decoder.tv.drop_in_place() };
+    }
+}
+
 /// Process cc_data
 ///
 /// # Safety
@@ -60,13 +111,11 @@ extern "C" fn ccxr_process_cc_data(
         .map(|x| unsafe { *data.add(x as usize) })
         .collect();
     let dec_ctx = unsafe { &mut *dec_ctx };
-    let dtvcc_ctx = unsafe { &mut *dec_ctx.dtvcc };
-    let mut dtvcc = Dtvcc::new(dtvcc_ctx);
     for cc_block in cc_data.chunks_exact_mut(3) {
         if !validate_cc_pair(cc_block) {
             continue;
         }
-        let success = do_cb(dec_ctx, &mut dtvcc, cc_block);
+        let success = do_cb(dec_ctx, cc_block);
         if success {
             ret = 0;
         }
@@ -110,7 +159,8 @@ pub fn verify_parity(data: u8) -> bool {
 }
 
 /// Process CC data according to its type
-pub fn do_cb(ctx: &mut lib_cc_decode, dtvcc: &mut Dtvcc, cc_block: &[u8]) -> bool {
+pub fn do_cb(ctx: &mut lib_cc_decode, cc_block: &[u8]) -> bool {
+    let dtvcc = unsafe { &mut *(ctx.dtvcc_rust as *mut Dtvcc) };
     let cc_valid = (cc_block[0] & 4) >> 2;
     let cc_type = cc_block[0] & 3;
     let mut timeok = true;


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**
- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**
- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

Closes #1499 

Work to be done in this PR:
- [x] Change Dtvcc::new() to create Dtvcc using ccx_decoder_dtvcc_settings as done [here]( https://github.com/CCExtractor/ccextractor/blob/master/src/lib_ccx/ccx_dtvcc.c#L76-L124)
- [x] Create a new extern C fn `ccxr_dtvcc_init()` in [lib.rs](https://github.com/CCExtractor/ccextractor/blob/master/src/rust/src/lib.rs) and use this at all places where `dtvcc_init()` is being called. (Probably add a new struct field to lib_cc_decode like `dtvcc_rust` and store Dtvcc there instead of using the dtvcc field)
- [ ] Similar for `dtvcc_free()`
- [ ] Change [ccxr_process_cc_data](https://github.com/CCExtractor/ccextractor/blob/master/src/rust/src/lib.rs#L53-L75) to use Dtvcc from `dec_ctx` instead of creating a new one

Additionally to fix mp4 code flow:-
- [ ] Call the corresponding rust function [here](https://github.com/CCExtractor/ccextractor/blob/master/src/lib_ccx/mp4.c#L398) and pass Dtvcc as done in the above steps