### PR TITLE
[FEAT] Add log module in lib_ccxr

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 0.95 (to be released)
 -----------------
+- New: Add log module in lib_ccxr (#1622)
 - New: Create `lib_ccxr` and `libccxr_exports` (#1621)
 - Fix: Unexpected behavior of get_write_interval (#1609)
 - Update: Bump rsmpeg to latest version for ffmpeg bindings (#1600)

--- a/src/lib_ccx/activity.c
+++ b/src/lib_ccx/activity.c
@@ -4,7 +4,6 @@ relevant events. */
 #include "lib_ccx.h"
 #include "ccx_common_option.h"
 
-static int credits_shown = 0;
 unsigned long net_activity_gui = 0;
 
 /* Print current progress. For percentage, -1 -> streaming mode */
@@ -129,11 +128,7 @@ void activity_report_data_read(void)
 
 void activity_header(void)
 {
-	if (!credits_shown)
-	{
-		credits_shown = 1;
-		mprint("CCExtractor %s, Carlos Fernandez Sanz, Volker Quetschke.\n", VERSION);
-		mprint("Teletext portions taken from Petr Kutalek's telxcc\n");
-		mprint("--------------------------------------------------------------------------\n");
-	}
+	mprint("CCExtractor %s, Carlos Fernandez Sanz, Volker Quetschke.\n", VERSION);
+	mprint("Teletext portions taken from Petr Kutalek's telxcc\n");
+	mprint("--------------------------------------------------------------------------\n");
 }

--- a/src/lib_ccx/lib_ccx.c
+++ b/src/lib_ccx/lib_ccx.c
@@ -93,6 +93,8 @@ struct lib_ccx_ctx *init_libraries(struct ccx_s_options *opt)
 {
 	int ret = 0;
 
+	activity_header(); // Brag about writing it :-)
+
 	// Set logging functions for libraries
 	ccx_common_logging.debug_ftn = &dbg_print;
 	ccx_common_logging.debug_mask = opt->debug_mask;

--- a/src/lib_ccx/lib_ccx.c
+++ b/src/lib_ccx/lib_ccx.c
@@ -100,6 +100,10 @@ struct lib_ccx_ctx *init_libraries(struct ccx_s_options *opt)
 	ccx_common_logging.log_ftn = &mprint;
 	ccx_common_logging.gui_ftn = &activity_library_process;
 
+#ifndef DISABLE_RUST
+	ccxr_init_basic_logger(opt);
+#endif
+
 	struct lib_ccx_ctx *ctx = malloc(sizeof(struct lib_ccx_ctx));
 	if (!ctx)
 		ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "init_libraries: Not enough memory allocating lib_ccx_ctx context.");

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -153,6 +153,10 @@ struct lib_ccx_ctx
 struct lib_ccx_ctx *init_libraries(struct ccx_s_options *opt);
 void dinit_libraries( struct lib_ccx_ctx **ctx);
 
+#ifndef DISABLE_RUST
+extern void ccxr_init_basic_logger(struct ccx_s_options *opts);
+#endif
+
 //ccextractor.c
 void print_end_msg(void);
 

--- a/src/lib_ccx/utility.c
+++ b/src/lib_ccx/utility.c
@@ -288,7 +288,6 @@ void mprint(const char *fmt, ...)
 	va_list args;
 	if (!ccx_options.messages_target)
 		return;
-	activity_header(); // Brag about writing it :-)
 	va_start(args, fmt);
 	if (ccx_options.messages_target == CCX_MESSAGES_STDOUT)
 	{

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -65,7 +65,7 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -90,9 +90,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "camino"
@@ -280,6 +280,9 @@ dependencies = [
 [[package]]
 name = "lib_ccxr"
 version = "0.1.0"
+dependencies = [
+ "bitflags 2.6.0",
+]
 
 [[package]]
 name = "libc"
@@ -526,7 +529,7 @@ version = "0.38.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",

--- a/src/rust/build.rs
+++ b/src/rust/build.rs
@@ -26,6 +26,7 @@ fn main() {
         "lib_cc_decode",
         "cc_subtitle",
         "ccx_output_format",
+        "ccx_s_options",
     ]);
 
     #[cfg(feature = "hardsubx_ocr")]

--- a/src/rust/lib_ccxr/Cargo.lock
+++ b/src/rust/lib_ccxr/Cargo.lock
@@ -3,5 +3,14 @@
 version = 3
 
 [[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
 name = "lib_ccxr"
 version = "0.1.0"
+dependencies = [
+ "bitflags",
+]

--- a/src/rust/lib_ccxr/Cargo.toml
+++ b/src/rust/lib_ccxr/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bitflags = "2.6.0"
 
 [features]
 default = ["enable_sharing", "wtv_debug", "enable_ffmpeg", "debug", "with_libcurl"]

--- a/src/rust/lib_ccxr/src/util/log.rs
+++ b/src/rust/lib_ccxr/src/util/log.rs
@@ -28,7 +28,7 @@
 //! | `mprint`, `ccx_common_logging.log_ftn`                                                                                                   | [`info!`]                   |
 //! | `dbg_print`, `ccx_common_logging.debug_ftn`                                                                                              | [`debug!`]                  |
 //! | `activity_library_process`, `ccx_common_logging.gui_ftn`                                                                                 | [`send_gui`]                |
-//! | `ccx_common_logging_gui`                                                                                                                 | [`GuiXdsMessage`]                |
+//! | `ccx_common_logging_gui`                                                                                                                 | [`GuiXdsMessage`]           |
 //! | `dump`                                                                                                                                   | [`hex_dump`]                |
 //! | `dump`                                                                                                                                   | [`hex_dump_with_start_idx`] |
 

--- a/src/rust/lib_ccxr/src/util/log.rs
+++ b/src/rust/lib_ccxr/src/util/log.rs
@@ -34,13 +34,9 @@
 
 use bitflags::bitflags;
 use std::fmt::Arguments;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-use crate::util::VERSION;
-
 static LOGGER: OnceLock<RwLock<CCExtractorLogger>> = OnceLock::new();
-static mut CREDITS_SHOWN: AtomicBool = AtomicBool::new(false);
 
 /// The possible targets for logging messages.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -310,8 +306,6 @@ impl<'a> CCExtractorLogger {
             return;
         }
 
-        activity_header();
-
         self.print(args);
     }
 
@@ -576,17 +570,4 @@ pub fn send_gui(message: GuiXdsMessage) {
     logger()
         .expect("Logger is not yet initialized")
         .send_gui(message)
-}
-
-fn activity_header() {
-    if !unsafe { CREDITS_SHOWN.load(Ordering::Relaxed) } {
-        unsafe { CREDITS_SHOWN.store(true, Ordering::Relaxed) };
-
-        println!(
-            "CCExtractor {}, Carlos Fernandez Sanz, Volker Quetschke.",
-            VERSION
-        );
-        println!("Teletext portions taken from Petr Kutalek's telxcc");
-        println!("--------------------------------------------------------------------------");
-    }
 }

--- a/src/rust/lib_ccxr/src/util/log.rs
+++ b/src/rust/lib_ccxr/src/util/log.rs
@@ -1,0 +1,592 @@
+//!
+//! The interface of this module is highly inspired by the famous log crate of rust.
+//!
+//! The first step before using any of the logging functionality is to setup a logger. This can be
+//! done by creating a [`CCExtractorLogger`] and calling [`set_logger`] with it. To gain access to
+//! the instance of [`CCExtractorLogger`], [`logger`] or [`logger_mut`] can be used.
+//!
+//! There are 4 types of logging messages based on its importance and severity denoted by their
+//! respective macros.
+//! - [`fatal!`]
+//! - [`error!`]
+//! - [`info!`]
+//! - [`debug!`]
+//!
+//! Hex dumps can be logged for debugging by [`hex_dump`] and [`hex_dump_with_start_idx`]. Communication
+//! with the GUI is possible through [`send_gui`].
+//!
+//! # Conversion Guide
+//!
+//! | From                                                                                                                                     | To                          |
+//! |------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|
+//! | `EXIT_*`, `CCX_COMMON_EXIT_*`                                                                                                            | [`ExitCause`]               |
+//! | `CCX_MESSAGES_*`                                                                                                                         | [`OutputTarget`]            |
+//! | `CCX_DMT_*`, `ccx_debug_message_types`                                                                                                   | [`DebugMessageFlag`]        |
+//! | `temp_debug`, `ccx_options.debug_mask`, `ccx_options.debug_mask_on_debug`                                                                | [`DebugMessageMask`]        |
+//! | `ccx_options.messages_target`, `temp_debug`, `ccx_options.debug_mask`, `ccx_options.debug_mask_on_debug`, `ccx_options.gui_mode_reports` | [`CCExtractorLogger`]       |
+//! | `fatal`, `ccx_common_logging.fatal_ftn`                                                                                                  | [`fatal!`]                  |
+//! | `mprint`, `ccx_common_logging.log_ftn`                                                                                                   | [`info!`]                   |
+//! | `dbg_print`, `ccx_common_logging.debug_ftn`                                                                                              | [`debug!`]                  |
+//! | `activity_library_process`, `ccx_common_logging.gui_ftn`                                                                                 | [`send_gui`]                |
+//! | `ccx_common_logging_gui`                                                                                                                 | [`GuiXdsMessage`]                |
+//! | `dump`                                                                                                                                   | [`hex_dump`]                |
+//! | `dump`                                                                                                                                   | [`hex_dump_with_start_idx`] |
+
+use bitflags::bitflags;
+use std::fmt::Arguments;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+use crate::util::VERSION;
+
+static LOGGER: OnceLock<RwLock<CCExtractorLogger>> = OnceLock::new();
+static mut CREDITS_SHOWN: AtomicBool = AtomicBool::new(false);
+
+/// The possible targets for logging messages.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OutputTarget {
+    Stdout,
+    Stderr,
+    Quiet,
+}
+
+bitflags! {
+    /// A bitflag for the types of a Debug Message.
+    ///
+    /// Each debug message can belong to one or more of these types. The
+    /// constants of this struct can be used as bitflags for one message to
+    /// belong to more than one type.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    pub struct DebugMessageFlag: u16 {
+        /// Show information related to parsing the container
+        const PARSE          = 0x1;
+        /// Show video stream related information
+        const VIDEO_STREAM   = 0x2;
+        /// Show GOP and PTS timing information
+        const TIME           = 0x4;
+        /// Show lots of debugging output
+        const VERBOSE        = 0x8;
+        /// Show CC-608 decoder debug
+        const DECODER_608    = 0x10;
+        /// Show CC-708 decoder debug
+        const DECODER_708    = 0x20;
+        /// Show XDS decoder debug
+        const DECODER_XDS    = 0x40;
+        /// Show Caption blocks with FTS timing
+        const CB_RAW         = 0x80;
+        /// Generic, always displayed even if no debug is selected
+        const GENERIC_NOTICE = 0x100;
+        /// Show teletext debug
+        const TELETEXT       = 0x200;
+        /// Show Program Allocation Table dump
+        const PAT            = 0x400;
+        /// Show Program Map Table dump
+        const PMT            = 0x800;
+        /// Show Levenshtein distance calculations
+        const LEVENSHTEIN    = 0x1000;
+        /// Show DVB debug
+        const DVB            = 0x2000;
+        /// Dump defective TS packets
+        const DUMP_DEF       = 0x4000;
+        /// Extracted captions sharing service
+        #[cfg(feature = "enable_sharing")]
+        const SHARE          = 0x8000;
+    }
+}
+
+/// All possible causes for crashing the program instantly. Used in `cause` key of [`fatal!`] macro.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExitCause {
+    Ok,
+    Failure,
+    NoInputFiles,
+    TooManyInputFiles,
+    IncompatibleParameters,
+    UnableToDetermineFileSize,
+    MalformedParameter,
+    ReadError,
+    NoCaptions,
+    WithHelp,
+    NotClassified,
+    ErrorInCapitalizationFile,
+    BufferFull,
+    MissingAsfHeader,
+    MissingRcwtHeader,
+
+    FileCreationFailed,
+    Unsupported,
+    NotEnoughMemory,
+    Bug,
+}
+
+/// A message to be sent to GUI for XDS. Used in [`send_gui`].
+pub enum GuiXdsMessage<'a> {
+    ProgramName(&'a str),
+    ProgramIdNr {
+        minute: u8,
+        hour: u8,
+        date: u8,
+        month: u8,
+    },
+    ProgramDescription {
+        line_num: i32,
+        desc: &'a str,
+    },
+    CallLetters(&'a str),
+}
+
+/// A mask to filter the debug messages based on its type specified by [`DebugMessageFlag`].
+///
+/// This operates on one of the two modes: Normal Mode and Debug Mode. The mask used when in Debug Mode is a superset
+/// of the mask used when in Normal Mode. One can switch between the two modes by [`DebugMessageMask::set_debug_mode`].
+#[derive(Debug)]
+pub struct DebugMessageMask {
+    debug_mode: bool,
+    mask_on_normal: DebugMessageFlag,
+    mask_on_debug: DebugMessageFlag,
+}
+
+/// A global logger used throughout CCExtractor and stores the settings related to logging.
+///
+/// A global logger can be setup up initially using [`set_logger`]. Use the following convenience
+/// macros for logging: [`fatal!`], [`error!`], [`info!`] and [`debug!`].
+#[derive(Debug)]
+pub struct CCExtractorLogger {
+    target: OutputTarget,
+    debug_mask: DebugMessageMask,
+    gui_mode: bool,
+}
+
+impl DebugMessageMask {
+    /// Creates a new [`DebugMessageFlag`] given a mask to be used for Normal Mode and an additional mask to be
+    /// used in Debug Mode.
+    ///
+    /// Note that while in Debug Mode, the mask for Normal Mode will still be valid.
+    /// `extra_mask_on_debug` only specifies additional flags to be set on Debug Mode.
+    pub const fn new(
+        mask_on_normal: DebugMessageFlag,
+        extra_mask_on_debug: DebugMessageFlag,
+    ) -> DebugMessageMask {
+        DebugMessageMask {
+            debug_mode: false,
+            mask_on_normal,
+            mask_on_debug: extra_mask_on_debug.union(mask_on_normal),
+        }
+    }
+
+    /// Set the mode to Normal or Debug Mode based on `false` or `true` respectively.
+    pub fn set_debug_mode(&mut self, mode: bool) {
+        self.debug_mode = mode;
+    }
+
+    /// Check if the current mode is set to Debug Mode.
+    pub fn is_debug_mode(&self) -> bool {
+        self.debug_mode
+    }
+
+    /// Return the mask according to its mode.
+    pub fn mask(&self) -> DebugMessageFlag {
+        if self.debug_mode {
+            self.mask_on_debug
+        } else {
+            self.mask_on_normal
+        }
+    }
+}
+
+impl ExitCause {
+    /// Returns the exit code associated with the cause of the error.
+    ///
+    /// The GUI depends on these exit codes.
+    /// Exit code of 0 means OK as usual.
+    /// Exit code below 100 means display whatever was output to stderr as a warning.
+    /// Exit code above or equal to 100 means display whatever was output to stdout as an error.
+    pub fn exit_code(&self) -> i32 {
+        match self {
+            ExitCause::Ok => 0,
+            ExitCause::Failure => 1,
+            ExitCause::NoInputFiles => 2,
+            ExitCause::TooManyInputFiles => 3,
+            ExitCause::IncompatibleParameters => 4,
+            ExitCause::UnableToDetermineFileSize => 6,
+            ExitCause::MalformedParameter => 7,
+            ExitCause::ReadError => 8,
+            ExitCause::NoCaptions => 10,
+            ExitCause::WithHelp => 11,
+            ExitCause::NotClassified => 300,
+            ExitCause::ErrorInCapitalizationFile => 501,
+            ExitCause::BufferFull => 502,
+            ExitCause::MissingAsfHeader => 1001,
+            ExitCause::MissingRcwtHeader => 1002,
+
+            ExitCause::FileCreationFailed => 5,
+            ExitCause::Unsupported => 9,
+            ExitCause::NotEnoughMemory => 500,
+            ExitCause::Bug => 1000,
+        }
+    }
+}
+
+impl<'a> CCExtractorLogger {
+    /// Returns a new instance of CCExtractorLogger with the provided settings.
+    ///
+    /// `gui_mode` is used to determine if the log massages are intercepted by a GUI.
+    /// `target` specifies the location for printing the log messages.
+    /// `debug_mask` is used to filter debug messages based on its type.
+    pub const fn new(
+        target: OutputTarget,
+        debug_mask: DebugMessageMask,
+        gui_mode: bool,
+    ) -> CCExtractorLogger {
+        CCExtractorLogger {
+            target,
+            debug_mask,
+            gui_mode,
+        }
+    }
+
+    /// Set the mode to Normal or Debug Mode based on `false` or `true` respectively for the
+    /// underlying [`DebugMessageMask`].
+    ///
+    /// This method switches the mask used for filtering debug messages.
+    /// Similar to [`DebugMessageMask::set_debug_mode`].
+    pub fn set_debug_mode(&mut self, mode: bool) {
+        self.debug_mask.set_debug_mode(mode)
+    }
+
+    /// Check if the current mode is set to Debug Mode.
+    ///
+    /// Similar to [`DebugMessageMask::is_debug_mode`].
+    pub fn is_debug_mode(&self) -> bool {
+        self.debug_mask.is_debug_mode()
+    }
+
+    /// Returns the currently set target for logging messages.
+    pub fn target(&self) -> OutputTarget {
+        self.target
+    }
+
+    /// Check if the messages are intercepted by GUI.
+    pub fn is_gui_mode(&self) -> bool {
+        self.gui_mode
+    }
+
+    fn print(&self, args: &Arguments<'a>) {
+        match &self.target {
+            OutputTarget::Stdout => print!("{}", args),
+            OutputTarget::Stderr => eprint!("{}", args),
+            OutputTarget::Quiet => {}
+        }
+    }
+
+    /// Log a fatal error message. Use [`fatal!`] instead.
+    ///
+    /// Used for logging errors dangerous enough to crash the program instantly.
+    pub fn log_fatal(&self, exit_cause: ExitCause, args: &Arguments<'a>) -> ! {
+        self.log_error(args);
+        info!("Issues? Open a ticket here");
+        info!("https://github.com/CCExtractor/ccextractor/issues");
+        std::process::exit(exit_cause.exit_code())
+    }
+
+    /// Log an error message. Use [`error!`] instead.
+    ///
+    /// Used for logging general errors occuring in the program.
+    pub fn log_error(&self, args: &Arguments<'a>) {
+        if self.gui_mode {
+            eprint!("###MESSAGE#")
+        } else {
+            eprint!("\rError: ")
+        }
+
+        eprintln!("{}", args);
+    }
+
+    /// Log an informational message. Use [`info!`] instead.
+    ///
+    /// Used for logging extra information about the execution of the program.
+    pub fn log_info(&self, args: &Arguments<'a>) {
+        if self.target == OutputTarget::Quiet {
+            return;
+        }
+
+        activity_header();
+
+        self.print(args);
+    }
+
+    /// Log a debug message. Use [`debug!`] instead.
+    ///
+    /// Used for logging debug messages throughout the program.
+    pub fn log_debug(&self, message_type: DebugMessageFlag, args: &Arguments<'a>) {
+        if self.debug_mask.mask().intersects(message_type) {
+            self.print(args);
+        }
+    }
+
+    /// Send a message to GUI. Use [`send_gui`] instead.
+    ///
+    /// Used for sending information related to XDS to the GUI.
+    pub fn send_gui(&self, message_type: GuiXdsMessage) {
+        if self.gui_mode {
+            match message_type {
+                GuiXdsMessage::ProgramName(program_name) => {
+                    eprintln!("###XDSPROGRAMNAME#{}", program_name)
+                }
+                GuiXdsMessage::ProgramIdNr {
+                    minute,
+                    hour,
+                    date,
+                    month,
+                } => eprintln!(
+                    "###XDSPROGRAMIDENTIFICATIONNUMBER#{}#{}#{}#{}",
+                    minute, hour, date, month
+                ),
+                GuiXdsMessage::ProgramDescription { line_num, desc } => {
+                    eprintln!("###XDSPROGRAMDESC#{}#{}", line_num, desc)
+                }
+                GuiXdsMessage::CallLetters(current_letters) => {
+                    eprintln!("###XDSNETWORKCALLLETTERS#{}", current_letters)
+                }
+            }
+        }
+    }
+
+    /// Log a hex dump which is helpful for debugging purposes.
+    /// Use [`hex_dump`] or [`hex_dump_with_start_idx`] instead.
+    ///
+    /// Setting `clear_high_bit` to true will ignore the highest bit whien displaying the
+    /// characters. This makes visual CC inspection easier since the highest bit is usually used
+    /// as a parity bit.
+    ///
+    /// The output will contain byte numbers which can be made to start from any number using
+    /// `start_idx`. This is usually `0`.
+    pub fn log_hex_dump(
+        &self,
+        message_type: DebugMessageFlag,
+        data: &[u8],
+        clear_high_bit: bool,
+        start_idx: usize,
+    ) {
+        if !self.debug_mask.mask().intersects(message_type) {
+            return;
+        }
+        println!("In if statement");
+        let chunked_data = data.chunks(16);
+
+        for (id, chunk) in chunked_data.enumerate() {
+            self.print(&format_args!("{:05} | ", id * 16 + start_idx));
+            for x in chunk {
+                self.print(&format_args!("{:02X} ", x));
+            }
+
+            for _ in 0..(16 - chunk.len()) {
+                self.print(&format_args!("   "));
+            }
+
+            self.print(&format_args!(" | "));
+
+            for x in chunk {
+                let c = if x >= &b' ' {
+                    // 0x7F < remove high bit, convenient for visual CC inspection
+                    x & if clear_high_bit { 0x7F } else { 0xFF }
+                } else {
+                    b' '
+                };
+
+                self.print(&format_args!("{}", c as char));
+            }
+
+            self.print(&format_args!("\n"));
+        }
+    }
+}
+
+/// Setup the global logger.
+///
+/// This function can only be called once throught the execution of program. The logger can then be
+/// accessed by [`logger`] and [`logger_mut`].
+pub fn set_logger(logger: CCExtractorLogger) -> Result<(), CCExtractorLogger> {
+    LOGGER
+        .set(logger.into())
+        .map_err(|x| x.into_inner().unwrap())
+}
+
+/// Get an immutable instance of the global logger.
+///
+/// This function will return [`None`] if the logger is not setup initially by [`set_logger`] or if
+/// the underlying RwLock fails to generate a read lock.
+///
+/// Use [`logger_mut`] to get a mutable instance.
+pub fn logger() -> Option<RwLockReadGuard<'static, CCExtractorLogger>> {
+    LOGGER.get()?.read().ok()
+}
+
+/// Get a mutable instance of the global logger.
+///
+/// This function will return [`None`] if the logger is not setup initially by [`set_logger`] or if
+/// the underlying RwLock fails to generate a write lock.
+///
+/// Use [`logger`] to get an immutable instance.
+pub fn logger_mut() -> Option<RwLockWriteGuard<'static, CCExtractorLogger>> {
+    LOGGER.get()?.write().ok()
+}
+
+/// Log a fatal error message.
+///
+/// Used for logging errors dangerous enough to crash the program instantly. This macro does not
+/// return (i.e. it returns `!`). A logger needs to be setup initially by [`set_logger`].
+///
+/// # Usage
+/// This macro requires an [`ExitCause`] which provides the appropriate exit codes for shutting
+/// down program. This is provided using a key called `cause` which comes before the `;`. After
+/// `;`, the arguments works the same as a [`println!`] macro.
+///
+/// # Examples
+/// ```no_run
+/// # use lib_ccxr::util::log::*;
+/// # let actual = 2;
+/// # let required = 1;
+/// fatal!(
+///     cause = ExitCause::TooManyInputFiles;
+///     "{} input files were provided but only {} were needed", actual, required
+/// );
+/// ```
+#[macro_export]
+macro_rules! fatal {
+    (cause = $exit_cause:expr; $($args:expr),*) => {
+        $crate::util::log::logger().expect("Logger is not yet initialized")
+            .log_fatal($exit_cause, &format_args!($($args),*))
+    };
+}
+
+/// Log an error message.
+///
+/// Used for logging general errors occuring in the program. A logger needs to be setup
+/// initially by [`set_logger`].
+///
+/// # Usage
+/// The arguments works the same as a [`println!`] macro.
+///
+/// # Examples
+/// ```no_run
+/// # use lib_ccxr::util::log::*;
+/// # let missing_blocks = 2;
+/// error!("missing {} additional blocks", missing_blocks);
+/// ```
+#[macro_export]
+macro_rules! error {
+    ($($args:expr),*) => {
+        $crate::util::log::logger().expect("Logger is not yet initialized")
+            .log_error(&format_args!($($args),*))
+    }
+}
+
+/// Log an informational message.
+///
+/// Used for logging extra information about the execution of the program. A logger needs to be
+/// setup initially by [`set_logger`].
+///
+/// # Usage
+/// The arguments works the same as a [`println!`] macro.
+///
+/// # Examples
+/// ```no_run
+/// # use lib_ccxr::util::log::*;
+/// info!("Processing the header section");
+/// ```
+#[macro_export]
+macro_rules! info {
+    ($($args:expr),*) => {
+        $crate::util::log::logger().expect("Logger is not yet initialized")
+            .log_info(&format_args!($($args),*))
+    };
+}
+
+/// Log a debug message.
+///
+/// Used for logging debug messages throughout the program. A logger needs to be setup initially
+/// by [`set_logger`].
+///
+/// # Usage
+/// This macro requires an [`DebugMessageFlag`] which represents the type of debug message. It is
+/// used for filtering the messages. This is provided using a key called `msg_type` which comes
+/// before the `;`. After `;`, the arguments works the same as a [`println!`] macro.
+///
+/// # Examples
+/// ```no_run
+/// # use lib_ccxr::util::log::*;
+/// # let byte1 = 23u8;
+/// # let byte2 = 45u8;
+/// debug!(
+///     msg_type = DebugMessageFlag::DECODER_708;
+///     "Packet Start with contents {} {}", byte1, byte2
+/// );
+/// ```
+#[macro_export]
+macro_rules! debug {
+    (msg_type = $msg_flag:expr; $($args:expr),*) => {
+        $crate::util::log::logger().expect("Logger is not yet initialized")
+            .log_debug($msg_flag, &format_args!($($args),*))
+    };
+}
+
+pub use debug;
+pub use error;
+pub use fatal;
+pub use info;
+
+/// Log a hex dump which is helpful for debugging purposes.
+///
+/// Setting `clear_high_bit` to true will ignore the highest bit whien displaying the
+/// characters. This makes visual CC inspection easier since the highest bit is usually used
+/// as a parity bit.
+///
+/// The byte numbers start from `0` by default. Use [`hex_dump_with_start_idx`] if a
+/// different starting index is required.
+pub fn hex_dump(message_type: DebugMessageFlag, data: &[u8], clear_high_bit: bool) {
+    logger()
+        .expect("Logger is not yet initialized")
+        .log_hex_dump(message_type, data, clear_high_bit, 0)
+}
+
+/// Log a hex dump which is helpful for debugging purposes.
+///
+/// Setting `clear_high_bit` to true will ignore the highest bit whien displaying the
+/// characters. This makes visual CC inspection easier since the highest bit is usually used
+/// as a parity bit.
+///
+/// The output will contain byte numbers which can be made to start from any number using
+/// `start_idx`. This is usually `0`.
+pub fn hex_dump_with_start_idx(
+    message_type: DebugMessageFlag,
+    data: &[u8],
+    clear_high_bit: bool,
+    start_idx: usize,
+) {
+    logger()
+        .expect("Logger is not yet initialized")
+        .log_hex_dump(message_type, data, clear_high_bit, start_idx)
+}
+
+/// Send a message to GUI.
+///
+/// Used for sending information related to XDS to the GUI.
+pub fn send_gui(message: GuiXdsMessage) {
+    logger()
+        .expect("Logger is not yet initialized")
+        .send_gui(message)
+}
+
+fn activity_header() {
+    if !unsafe { CREDITS_SHOWN.load(Ordering::Relaxed) } {
+        unsafe { CREDITS_SHOWN.store(true, Ordering::Relaxed) };
+
+        println!(
+            "CCExtractor {}, Carlos Fernandez Sanz, Volker Quetschke.",
+            VERSION
+        );
+        println!("Teletext portions taken from Petr Kutalek's telxcc");
+        println!("--------------------------------------------------------------------------");
+    }
+}

--- a/src/rust/lib_ccxr/src/util/log.rs
+++ b/src/rust/lib_ccxr/src/util/log.rs
@@ -365,7 +365,6 @@ impl<'a> CCExtractorLogger {
         if !self.debug_mask.mask().intersects(message_type) {
             return;
         }
-        println!("In if statement");
         let chunked_data = data.chunks(16);
 
         for (id, chunk) in chunked_data.enumerate() {

--- a/src/rust/lib_ccxr/src/util/log.rs
+++ b/src/rust/lib_ccxr/src/util/log.rs
@@ -280,8 +280,8 @@ impl<'a> CCExtractorLogger {
     /// Used for logging errors dangerous enough to crash the program instantly.
     pub fn log_fatal(&self, exit_cause: ExitCause, args: &Arguments<'a>) -> ! {
         self.log_error(args);
-        info!("Issues? Open a ticket here");
-        info!("https://github.com/CCExtractor/ccextractor/issues");
+        info!("Issues? Open a ticket here\n");
+        info!("https://github.com/CCExtractor/ccextractor/issues\n");
         std::process::exit(exit_cause.exit_code())
     }
 
@@ -486,7 +486,7 @@ macro_rules! error {
 /// # Examples
 /// ```no_run
 /// # use lib_ccxr::util::log::*;
-/// info!("Processing the header section");
+/// info!("Processing the header section\n");
 /// ```
 #[macro_export]
 macro_rules! info {

--- a/src/rust/lib_ccxr/src/util/mod.rs
+++ b/src/rust/lib_ccxr/src/util/mod.rs
@@ -1,1 +1,5 @@
 //! Provides basic utilities used throughout the program.
+
+pub mod log;
+
+static VERSION: &'static str = "0.94";

--- a/src/rust/lib_ccxr/src/util/mod.rs
+++ b/src/rust/lib_ccxr/src/util/mod.rs
@@ -1,5 +1,3 @@
 //! Provides basic utilities used throughout the program.
 
 pub mod log;
-
-static VERSION: &str = "0.94";

--- a/src/rust/lib_ccxr/src/util/mod.rs
+++ b/src/rust/lib_ccxr/src/util/mod.rs
@@ -2,4 +2,4 @@
 
 pub mod log;
 
-static VERSION: &'static str = "0.94";
+static VERSION: &str = "0.94";

--- a/src/rust/src/libccxr_exports/mod.rs
+++ b/src/rust/src/libccxr_exports/mod.rs
@@ -11,13 +11,13 @@ use std::convert::TryInto;
 ///
 /// `ccx_options` must not be null and must initialized properly before calling this function.
 #[no_mangle]
-pub extern "C" fn ccxr_init_basic_logger(ccx_options: *const ccx_s_options) {
+pub unsafe extern "C" fn ccxr_init_basic_logger(ccx_options: *const ccx_s_options) {
     if ccx_options.is_null() {
         panic!("ccx_s_options must not be null");
     }
 
     let debug_mask = DebugMessageFlag::from_bits(
-        unsafe { *ccx_options }
+        (*ccx_options)
             .debug_mask
             .try_into()
             .expect("Failed to convert debug_mask to an unsigned integer"),
@@ -25,7 +25,7 @@ pub extern "C" fn ccxr_init_basic_logger(ccx_options: *const ccx_s_options) {
     .expect("Failed to convert debug_mask to a DebugMessageFlag");
 
     let debug_mask_on_debug = DebugMessageFlag::from_bits(
-        unsafe { *ccx_options }
+        (*ccx_options)
             .debug_mask_on_debug
             .try_into()
             .expect("Failed to convert debug_mask_on_debug to an unsigned integer"),

--- a/src/rust/src/libccxr_exports/mod.rs
+++ b/src/rust/src/libccxr_exports/mod.rs
@@ -1,1 +1,50 @@
 //! Provides C-FFI functions that are direct equivalent of functions available in C.
+
+use crate::ccx_s_options;
+use core::panic;
+use lib_ccxr::util::log::*;
+use std::convert::TryInto;
+
+/// Initializes the logger at the rust side.
+///
+/// # Safety
+///
+/// `ccx_options` must not be null and must initialized properly before calling this function.
+#[no_mangle]
+pub extern "C" fn ccxr_init_basic_logger(ccx_options: *const ccx_s_options) {
+    if ccx_options.is_null() {
+        panic!("ccx_s_options must not be null");
+    }
+
+    let debug_mask = DebugMessageFlag::from_bits(
+        unsafe { *ccx_options }
+            .debug_mask
+            .try_into()
+            .expect("Failed to convert debug_mask to an unsigned integer"),
+    )
+    .expect("Failed to convert debug_mask to a DebugMessageFlag");
+
+    let debug_mask_on_debug = DebugMessageFlag::from_bits(
+        unsafe { *ccx_options }
+            .debug_mask_on_debug
+            .try_into()
+            .expect("Failed to convert debug_mask_on_debug to an unsigned integer"),
+    )
+    .expect("Failed to convert debug_mask_on_debug to a DebugMessageFlag");
+
+    let mask = DebugMessageMask::new(debug_mask, debug_mask_on_debug);
+    let gui_mode_reports = unsafe { *ccx_options }.gui_mode_reports != 0;
+    let messages_target = match unsafe { *ccx_options }.messages_target {
+        0 => OutputTarget::Stdout,
+        1 => OutputTarget::Stderr,
+        2 => OutputTarget::Quiet,
+        _ => panic!("incorrect value for messages_target"),
+    };
+
+    set_logger(CCExtractorLogger::new(
+        messages_target,
+        mask,
+        gui_mode_reports,
+    ))
+    .expect("Failed to initialize and setup the logger");
+}


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---
Closes #1553 

This PR adds functions and macros used for logging operations. The functions of this PR have not been integrated into the C codebase since there is no safe or easy way to pass variable number of arguments (as used in printf) from C to Rust. But the code for initializing the logger from C to Rust is included.

After this PR merge, anybody can use macros like `info!`, `fata!`, `error!`, `debug!` (Just like `mprint`, `fatal`, etc in C) for logging purposes after initializing logger using `ccxr_init_basic_logger` 