### PR TITLE
Fix: Sanitize XML comment to prevent invalid token errors

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -36,6 +36,7 @@
 - Improvement: Use Corrosion to build Rust code
 - Improvement: Ignore MXF Caption Essence Container version byte to enhance SRT subtitle extraction compatibility
 - New: Add tesseract page segmentation modes control with `--psm` flag
+-Fix : Sanitize XML comment to prevent invalid token errors
 
 0.94 (2021-12-14)
 -----------------


### PR DESCRIPTION
# Fix Issue#1235: Sanitize XML comment to prevent invalid token errors

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows :**

- [ ] I absolutely love CCExtractor, but have not contributed previously.

---
## Pull Request Description:

- Added logic to detect and replace any occurrence of "--" in comments with a single "-" to ensure valid XML.
- Used a bulk write ('fwrite') to efficiently handle portions of the string that don't contain invalid sequences.
- Ensured that comments are written correctly without altering the original structure of the code.
- Updated function 'write_spucomment' to handle the sanitization process efficiently.
