### PR TITLE
Fix Issue#1235: Sanitize XML comment to prevent invalid token errors

### DIFF
--- a/src/lib_ccx/ccx_encoders_spupng.c
+++ b/src/lib_ccx/ccx_encoders_spupng.c
@@ -198,7 +198,32 @@ void write_sputag_close(struct spupng_t *sp)
 }
 void write_spucomment(struct spupng_t *sp, const char *str)
 {
-	fprintf(sp->fpxml, "<!--\n%s\n-->\n", str);
+	fprintf(sp->fpxml, "<!--\n");
+
+    const char *p = str;
+    const char *last_safe_pos = str; // Track the last safe position to flush
+
+    while (*p) {
+       
+        if (*p == '-' && *(p + 1) == '-') {
+           
+            if (p > last_safe_pos) {
+                fwrite(last_safe_pos, 1, p - last_safe_pos, sp->fpxml);
+            }
+            
+            fputc('-', sp->fpxml);
+            p += 2;  
+            last_safe_pos = p; 
+        } else {
+            p++;  
+        }
+    }
+
+    if (p > last_safe_pos) {
+        fwrite(last_safe_pos, 1, p - last_safe_pos, sp->fpxml);
+    }
+
+    fprintf(sp->fpxml, "\n-->\n");
 }
 
 char *get_spupng_filename(void *ctx)


### PR DESCRIPTION
# Fix Issue#1235: Sanitize XML comment to prevent invalid token errors

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I absolutely love CCExtractor, but have not contributed previously.

---
## Pull Requests Description :

- Added logic to detect and replace any occurrence of "--" in comments with a single "-" to ensure valid XML.
- Used a bulk write ('fwrite') to efficiently handle portions of the string that don't contain invalid sequences.
- Ensured that comments are written correctly without altering the original structure of the code.
- Updated function 'write_spucomment' to handle the sanitization process efficiently.
