### PR TITLE
Fix compile-time issue involving implicit declaration of mapclut_paletee()

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -36,6 +36,7 @@
 - Improvement: Use Corrosion to build Rust code
 - Improvement: Ignore MXF Caption Essence Container version byte to enhance SRT subtitle extraction compatibility
 - New: Add tesseract page segmentation modes control with `--psm` flag
+- Fix: Resolve compile-time error about implicit declarations (#1646)
 
 0.94 (2021-12-14)
 -----------------

--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -7,6 +7,7 @@
 #include "ccx_common_constants.h"
 #include <dirent.h>
 #include "ccx_encoders_helpers.h"
+#include "ccx_encoders_spupng.h"
 #include "ocr.h"
 #undef OCR_DEBUG
 


### PR DESCRIPTION
This commit fixes a compile-time error regarding an implicit declaration of mapclut_paletee() on some compilers and compiler versions.  Notably, Arch Linux and Ubuntu 24.10 seem to be affected.

The error resolved is:

```
../src/lib_ccx/ocr.c: In function 'ocr_rect':
../src/lib_ccx/ocr.c:922:9: error: implicit declaration of function 'mapclut_paletee' [-Wimplicit-function-declaration]
  922 |         mapclut_paletee(palette, alpha, (uint32_t *)rect->data1, rect->nb_colors);
      |         ^~~~~~~~~~~~~~~
```

This was resolved by `#include`-ing "ccx_encoders_spupng.h" in the file src/lib_ccx/ocr.c.  Thanks to GitHub user @steel-bucket for sharing the fix in this issue's comments.

I was having the same issue, and making this change to that file allowed it to compile on my system (Ubuntu 24.10, GCC 14.2.0-4ubuntu2).

Fixes: #1646

<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [X] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [X] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

{pull request content here}
