### PR TITLE
Changed Bindgen 0.64.0 -> 0.69.4 in src/Cargo.toml,Cargo.lock (as iss…

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 1.0 (to be released)
 -----------------
+- Improvement: Changed Bindgen 0.64.0 -> 0.69.4 in src/Cargo.toml,Cargo.lock (as issue 1608 proposed)
 - New: Create unit test for rust code (#1615)
 - Breaking: Major argument flags revamp for CCExtractor (#1564 & #1619)
 - New: Create a Docker image to simplify the CCExtractor usage without any environmental hustle (#1611)

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -30,7 +30,7 @@ lib_ccxr = { path = "lib_ccxr" }
 url = "2.5.2"
 
 [build-dependencies]
-bindgen = "0.64.0"
+bindgen = "0.69.4"
 pkg-config = "0.3.30"
 
 [features]


### PR DESCRIPTION

This PR changes bindgen 0.64.0 -> 0.69.4 in src/Cargo.toml,Cargo.lock (as issue 1608 proposed) while maintaining backwards compatibility 

<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

{pull request content here}
