### PR TITLE
[FIX] Updated preprocessor directives for macOS

### DIFF
--- a/src/thirdparty/freetype/gzip/ftzconf.h
+++ b/src/thirdparty/freetype/gzip/ftzconf.h
@@ -215,9 +215,14 @@
 #   define FAR
 #endif
 
-#if !defined(MACOS) && !defined(TARGET_OS_MAC)
+#if !defined(__APPLE__) && !defined(__MACH__)
 typedef unsigned char  Byte;  /* 8 bits */
 #endif
+
+#if defined(__APPLE__) && defined(__MACH__)
+typedef char  Byte;  /* 8 bits(1 byte) */
+#endif
+
 typedef unsigned int   uInt;  /* 16 bits or more */
 typedef unsigned long  uLong; /* 32 bits or more */
 

--- a/src/thirdparty/freetype/gzip/zutil.h
+++ b/src/thirdparty/freetype/gzip/zutil.h
@@ -105,7 +105,7 @@ typedef unsigned long  ulg;
 #  define OS_CODE  0x05
 #endif
 
-#if defined(MACOS) || defined(TARGET_OS_MAC)
+#if defined(__APPLE__) || defined(__MACH__)
 #  define OS_CODE  0x07
 #  if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
 #    include <unix.h> /* for fdopen */


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor(hopefully)

---
I tried compiling ccxr on mac and ran into a few problems
1. In [src/thirdparty/freetype/gzip/ftzconf.h], `typedef Byte` was not happening in case the OS was MacOS
2. Updated the prepocessor directives (in [_src/thirdparty/freetype/gzip/ftzconf.h_]) used for identifying if the OS is MacOS to newer standards : `__APPLE__` and `__MACH__`
