### PR TITLE
[IMPROVEMENT] Clarify CEA-608/708 Subtitle Extraction Behavior #1448

### DIFF
--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -472,17 +472,7 @@ void print_usage(void)
 	mprint("                                 in specified input. Don't produce any file\n");
 	mprint("                                 output\n\n");
 	mprint("       --srt, --dvdraw, --sami, --webvtt, --txt, --ttxt and --null can be used as shorts.\n\n");
-	
-	mprint("\nSubtitle Extraction:\n");
-    
-	mprint("  By default, ccextractor now extracts both CEA-608 and CEA-708 subtitles\n");
-    mprint("  if they are present in the input. This results in two output files: one\n");
-    mprint("  for CEA-608 and one for CEA-708.\n\n");
-    mprint("  To extract only CEA-608 subtitles, use -1, -2, or -12.\n");
-    mprint("  To extract only CEA-708 subtitles, use -svc.\n");
-    mprint("  To extract both CEA-608 and CEA-708 subtitles, use both -1/-2/-12 and -svc.\n");
-    mprint("\n");
-	
+
 	mprint("Options that affect how input files will be processed.\n");
 
 	mprint("       --goptime: Use GOP for timing instead of PTS. This only applies\n");
@@ -979,17 +969,17 @@ void print_usage(void)
 	mprint("  You can adjust, or disable, the algorithm settings with the following\n");
 	mprint("  parameters.\n");
 	mprint("\n");
-	mprint("Notes on times:\n"
-	       "  --startat and --endat times are used first, then -delay.\n");
+	mprint("Notes on times:\n");
+	mprint("  --startat and --endat times are used first, then -delay.\n");
 	mprint("  So if you use --srt -startat 3:00 --endat 5:00 --delay 120000, ccextractor will\n");
 	mprint("  generate a .srt file, with only data from 3:00 to 5:00 in the input file(s)\n");
 	mprint("  and then add that (huge) delay, which would make the final file start at\n");
 	mprint("  5:00 and end at 7:00.\n");
 	mprint("\n");
 	mprint("Notes on codec options:\n");
-	mprint("  If codec type is not selected then first elementary stream suitable for \n"
-	       "  subtitle is selected, please consider --teletext -noteletext override this\n"
-	       "  option.\n");
+	mprint("  If codec type is not selected then first elementary stream suitable for\n");
+	mprint("  subtitle is selected, please consider --teletext --noteletext override this\n");
+	mprint("  option.\n");
 	mprint("  no-codec and codec parameter must not be same if found to be same \n"
 	       "  then parameter of no-codec is ignored, this flag should be passed \n"
 	       "  once, more then one are not supported yet and last parameter would \n"
@@ -1002,8 +992,14 @@ void print_usage(void)
 	mprint("  The start window must be between the times given and must have enough time\n");
 	mprint("  to display the message for at least the specified time.\n");
 	mprint("\n");
-	mprint("Notes on the CEA-708 decoder:\n"
-	       "  While it is starting to be useful, it's\n");
+	mprint("Notes on the CEA-708 decoder:\n");
+	mprint("  By default, ccextractor now extracts both CEA-608 and CEA-708 subtitles\n");
+	mprint("  if they are present in the input. This results in two output files: one\n");
+	mprint("  for CEA-608 and one for CEA-708.\n");
+	mprint("  To extract only CEA-608 subtitles, use -1, -2, or -12.\n");
+	mprint("  To extract only CEA-708 subtitles, use -svc.\n");
+	mprint("  To extract both CEA-608 and CEA-708 subtitles, use both -1/-2/-12 and -svc.\n\n");
+	mprint("  While it is starting to be useful, it's\n");
 	mprint("  a work in progress. A number of things don't work yet in the decoder\n");
 	mprint("  itself, and many of the auxiliary tools (case conversion to name one)\n");
 	mprint("  won't do anything yet. Feel free to submit samples that cause problems\n");

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -472,7 +472,17 @@ void print_usage(void)
 	mprint("                                 in specified input. Don't produce any file\n");
 	mprint("                                 output\n\n");
 	mprint("       --srt, --dvdraw, --sami, --webvtt, --txt, --ttxt and --null can be used as shorts.\n\n");
-
+	
+	mprint("\nSubtitle Extraction:\n");
+    
+	mprint("  By default, ccextractor now extracts both CEA-608 and CEA-708 subtitles\n");
+    mprint("  if they are present in the input. This results in two output files: one\n");
+    mprint("  for CEA-608 and one for CEA-708.\n\n");
+    mprint("  To extract only CEA-608 subtitles, use -1, -2, or -12.\n");
+    mprint("  To extract only CEA-708 subtitles, use -svc.\n");
+    mprint("  To extract both CEA-608 and CEA-708 subtitles, use both -1/-2/-12 and -svc.\n");
+    mprint("\n");
+	
 	mprint("Options that affect how input files will be processed.\n");
 
 	mprint("       --goptime: Use GOP for timing instead of PTS. This only applies\n");

--- a/src/rust/src/args.rs
+++ b/src/rust/src/args.rs
@@ -104,6 +104,12 @@ Notes on adding credits:
   to display the message for at least the specified time.
 
 Notes on the CEA-708 decoder:
+	By default, ccextractor now extracts both CEA-608 and CEA-708 subtitles
+	if they are present in the input. This results in two output files: one
+	for CEA-608 and one for CEA-708.
+	To extract only CEA-608 subtitles, use -1, -2, or -12.
+	To extract only CEA-708 subtitles, use -svc.
+	To extract both CEA-608 and CEA-708 subtitles, use both -1/-2/-12 and -svc.
   While it is starting to be useful, it's
   a work in progress. A number of things don't work yet in the decoder
   itself, and many of the auxiliary tools (case conversion to name one)


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->
Referring to issue #1448 

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [x] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

This pull request addresses the issue where the default behavior of ccextractor changed in version 0.94 regarding CEA-608 and CEA-708 subtitle extraction, but this change was not clearly documented.

Changes:
- Added a "Subtitle Extraction" section to the --help output in params.c to explain that ccextractor now extracts both CEA-608 and CEA-708 subtitles by default, resulting in two output files when both are present.  The section also explains how to use the -1, -2, -12, and -svc options to control which subtitle types are extracted.
- Updated CHANGES.TXT to include a more detailed description of the change in subtitle extraction behavior.

This change improves the user experience by providing clear and accessible information about the new default behavior, preventing confusion and ensuring that users can easily control subtitle extraction according to their needs.
