### PR TITLE
[FIX] Fix c formatting issues and fix some rust warnings

### DIFF
--- a/src/lib_ccx/asf_functions.c
+++ b/src/lib_ccx/asf_functions.c
@@ -561,7 +561,7 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 		dbg_print(CCX_DMT_PARSE, "Number of data packets: %ld\n", (long)asf_data_container.TotalDataPackets);
 
 		reentry = 0; // Make sure we read the Data Packet Headers
-	}		     // End of if (firstcall)
+	} // End of if (firstcall)
 	firstcall = 0;
 
 	// Start loop over Data Packets

--- a/src/lib_ccx/ccx_decoders_common.c
+++ b/src/lib_ccx/ccx_decoders_common.c
@@ -219,7 +219,7 @@ int do_cb(struct lib_cc_decode *ctx, unsigned char *cc_block, struct cc_subtitle
 			default:
 				fatal(CCX_COMMON_EXIT_BUG_BUG, "In do_cb: Impossible value for cc_type, Please file a bug report on GitHub.\n");
 		} // switch (cc_type)
-	}	  // cc_valid
+	} // cc_valid
 	else
 	{
 		dbg_print(CCX_DMT_CBRAW, "    ..   ..   ..\n");

--- a/src/lib_ccx/ccx_encoders_spupng.c
+++ b/src/lib_ccx/ccx_encoders_spupng.c
@@ -704,7 +704,7 @@ uint32_t *utf8_to_utf32(char *src)
 }
 
 // Convert big-endian and little-endian
-#define BigtoLittle32(A) ((((uint32_t)(A)&0xff000000) >> 24) | (((uint32_t)(A)&0x00ff0000) >> 8) | (((uint32_t)(A)&0x0000ff00) << 8) | (((uint32_t)(A)&0x000000ff) << 24))
+#define BigtoLittle32(A) ((((uint32_t)(A) & 0xff000000) >> 24) | (((uint32_t)(A) & 0x00ff0000) >> 8) | (((uint32_t)(A) & 0x0000ff00) << 8) | (((uint32_t)(A) & 0x000000ff) << 24))
 
 // Generate PNG file from an UTF-8 string (str)
 // PNG file will be stored at output

--- a/src/lib_ccx/dvb_subtitle_decoder.c
+++ b/src/lib_ccx/dvb_subtitle_decoder.c
@@ -39,20 +39,20 @@
 
 #define YUV_TO_RGB1_CCIR(cb1, cr1)                                                               \
 	{                                                                                        \
-		cb = (cb1)-128;                                                                  \
-		cr = (cr1)-128;                                                                  \
+		cb = (cb1) - 128;                                                                \
+		cr = (cr1) - 128;                                                                \
 		r_add = FIX(1.40200 * 255.0 / 224.0) * cr + ONE_HALF;                            \
 		g_add = -FIX(0.34414 * 255.0 / 224.0) * cb - FIX(0.71414 * 255.0 / 224.0) * cr + \
 			ONE_HALF;                                                                \
 		b_add = FIX(1.77200 * 255.0 / 224.0) * cb + ONE_HALF;                            \
 	}
 
-#define YUV_TO_RGB2_CCIR(r, g, b, y1)               \
-	{                                           \
-		y = ((y1)-16) * FIX(255.0 / 219.0); \
-		r = cm[(y + r_add) >> SCALEBITS];   \
-		g = cm[(y + g_add) >> SCALEBITS];   \
-		b = cm[(y + b_add) >> SCALEBITS];   \
+#define YUV_TO_RGB2_CCIR(r, g, b, y1)                 \
+	{                                             \
+		y = ((y1) - 16) * FIX(255.0 / 219.0); \
+		r = cm[(y + r_add) >> SCALEBITS];     \
+		g = cm[(y + g_add) >> SCALEBITS];     \
+		b = cm[(y + b_add) >> SCALEBITS];     \
 	}
 
 #define times4(x) x, x, x, x

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -993,7 +993,7 @@ int general_loop(struct lib_ccx_ctx *ctx)
 	enum ccx_stream_mode_enum stream_mode;
 	struct demuxer_data *datalist = NULL;
 	struct demuxer_data *data_node = NULL;
-	int (*get_more_data)(struct lib_ccx_ctx * c, struct demuxer_data * *d);
+	int (*get_more_data)(struct lib_ccx_ctx *c, struct demuxer_data **d);
 	int ret;
 	int caps = 0;
 

--- a/src/lib_ccx/hardsubx_decoder.c
+++ b/src/lib_ccx/hardsubx_decoder.c
@@ -552,7 +552,7 @@ void process_hardsubx_linear_frames_and_normal_subs(struct lib_hardsubx_ctx *har
 	enum ccx_stream_mode_enum stream_mode;
 	struct demuxer_data *datalist = NULL;
 	struct demuxer_data *data_node = NULL;
-	int (*get_more_data)(struct lib_ccx_ctx * c, struct demuxer_data * *d);
+	int (*get_more_data)(struct lib_ccx_ctx *c, struct demuxer_data **d);
 	int ret;
 	int caps = 0;
 

--- a/src/rust/lib_ccxr/src/util/bits.rs
+++ b/src/rust/lib_ccxr/src/util/bits.rs
@@ -193,10 +193,10 @@ pub fn decode_hamming_24_18(mut value: u32) -> Option<u32> {
     }
 
     Some(
-        (value & 0x000004) >> 2
-            | (value & 0x000070) >> 3
-            | (value & 0x007f00) >> 4
-            | (value & 0x7f0000) >> 5,
+        ((value & 0x000004) >> 2)
+            | ((value & 0x000070) >> 3)
+            | ((value & 0x007f00) >> 4)
+            | ((value & 0x7f0000) >> 5),
     )
 }
 

--- a/src/rust/src/decoder/encoding.rs
+++ b/src/rust/src/decoder/encoding.rs
@@ -1,14 +1,14 @@
-/// 256 BYTES IS ENOUGH FOR ALL THE SUPPORTED CHARACTERS IN
-/// EIA-708, SO INTERNALLY WE USE THIS TABLE (FOR CONVENIENCE)
-///
-/// 00-1F -> Characters that are in the G2 group in 20-3F,
-///          except for 06, which is used for the closed captions
-///          sign "CC" which is defined in group G3 as 00. (this
-///          is by the article 33).
-/// 20-7F -> Group G0 as is - corresponds to the ASCII code
-/// 80-9F -> Characters that are in the G2 group in 60-7F
-///          (there are several blank characters here, that's OK)
-/// A0-FF -> Group G1 as is - non-English characters and symbols
+//! 256 BYTES IS ENOUGH FOR ALL THE SUPPORTED CHARACTERS IN
+//! EIA-708, SO INTERNALLY WE USE THIS TABLE (FOR CONVENIENCE)
+//!
+//! 00-1F -> Characters that are in the G2 group in 20-3F,
+//!          except for 06, which is used for the closed captions
+//!          sign "CC" which is defined in group G3 as 00. (this
+//!          is by the article 33).
+//! 20-7F -> Group G0 as is - corresponds to the ASCII code
+//! 80-9F -> Characters that are in the G2 group in 60-7F
+//!          (there are several blank characters here, that's OK)
+//! A0-FF -> Group G1 as is - non-English characters and symbols
 
 // NOTE: Same as `lib_ccx/ccx_decoder_708_encoding.c` file
 

--- a/src/rust/src/decoder/mod.rs
+++ b/src/rust/src/decoder/mod.rs
@@ -213,7 +213,7 @@ impl dtvcc_symbol {
     }
     /// Create a new 16 bit symbol
     pub fn new_16(data1: u8, data2: u8) -> Self {
-        let sym = (data1 as u16) << 8 | data2 as u16;
+        let sym = ((data1 as u16) << 8) | data2 as u16;
         Self { init: 1, sym }
     }
     /// Check if symbol is initialized


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).** (Not applicable)

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

Fixes the C formatting issues and fixes all but one clippy warnings that are being triggered on the CI pipelines
