### PR TITLE
[FIX] Replaced deprecated module `std::intrinsics` with `std::ptr`

### DIFF
--- a/src/rust/src/decoder/window.rs
+++ b/src/rust/src/decoder/window.rs
@@ -12,7 +12,7 @@
 
 use std::{
     alloc::{alloc_zeroed, dealloc, Layout},
-    intrinsics::copy_nonoverlapping,
+    ptr::copy_nonoverlapping,
 };
 
 use super::timing::get_time_str;


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [x] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [x] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---
This PR resolves the warning posed by depreciated module `std::intrinsics` by replacing the same with `std::mem` module
```
error: use of deprecated module `std::intrinsics`: import this function via `std::mem` instead
  --> src/decoder/window.rs:15:17
   |
15 |     intrinsics::copy_nonoverlapping,
   |                 ^^^^^^^^^^^^^^^^^^^
   |
```