### PR TITLE
Fix tests on sample platform

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -23,7 +23,7 @@ on:
     - 'src/rust/**'
 jobs:
   build_shell:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Install dependencies
       run: sudo apt update && sudo apt-get install libgpac-dev libtesseract-dev


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [x] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---
Closes CCExtractor/sample-platform#924

Zulip Discussion: [#general > Are the sample platform tests broken?](https://ccextractor.zulipchat.com/#narrow/channel/478694-general/topic/Are.20the.20sample.20platform.20tests.20broken.3F)

## The problem
All of the recent [Linux tests](https://sampleplatform.ccextractor.org/test/#1) have ended in failure. Going through the logs for the Linux tests, it seems that all of them stem from the following error:
```sh
[INFO] Multitest, overriding report folder to: /repository/reports/Testsuite_Report_2025-03-09_235502
[INFO] Starting with entry 1 of 86
[ERROR] /repository/ccextractor: error while loading shared libraries: libtesseract.so.5: cannot open shared object file: No such file or directory
[ERROR] Path is empty
```

## Debugging Summary
1. Downloaded the latest artifact from [GitHub](https://github.com/CCExtractor/ccextractor/actions/runs/13789729245)
2. Ran `objdump` on the artifact:
  ```c-objdump
  Dynamic Section:
    NEEDED               libm.so.6
    NEEDED               libtesseract.so.5
    NEEDED               liblept.so.5
    NEEDED               libgpac.so.12
    NEEDED               libgcc_s.so.1
    NEEDED               libc.so.6
    NEEDED               ld-linux-x86-64.so.2
  ```
3. As we can see, the artifact expects `libtesseract.so.5` but **Ubuntu 22.04 (the version [used](https://github.com/CCExtractor/sample-platform/blob/4e7b2ea4543df2c041356fd0b6bd106dd9e68925/config_sample.py#L36) by Sample Platform) only provides `libtesseract.so.4`** in its package repository.
    - The reason this discrepancy occurs is that the core repository uses `ubuntu-latest` in its workflow file (which defaults to 24.04) This causes the built binary to use newer libraries that are not present on the sample platform.

## The Fix
In my opinion, the ideal fix would be to update the sample platform to Ubuntu 24.04. However, this might introduce new incompatibilities. So for a safer temporary fix, I've opted to make the core repo use 22.04 for building the artifacts.
I've verified that the these [artifacts](https://github.com/hrideshmg/ccextractor/actions/runs/13811824986) work on Ubuntu 22.04.