### PR TITLE
fix: debugdvb arg typo

### DIFF
--- a/src/rust/src/args.rs
+++ b/src/rust/src/args.rs
@@ -162,7 +162,7 @@ pub struct Args {
     pub pesheader: bool,
     /// Write the DVB subtitle debug traces to console.
     #[arg(long, help_heading=FILE_NAME_RELATED_OPTIONS)]
-    pub debugdvdsub: bool,
+    pub debugdvbsub: bool,
     /// Ignore PTS jumps (default).
     #[arg(long, help_heading=FILE_NAME_RELATED_OPTIONS)]
     pub ignoreptsjumps: bool,

--- a/src/rust/src/parser.rs
+++ b/src/rust/src/parser.rs
@@ -1024,7 +1024,7 @@ impl OptionsExt for Options {
             self.pes_header_to_stdout = true;
         }
 
-        if args.debugdvdsub {
+        if args.debugdvbsub {
             self.debug_mask =
                 DebugMessageMask::new(DebugMessageFlag::DVB, DebugMessageFlag::VERBOSE);
         }


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---
Came across this issue while trying to debug #985, passing `--debugdvbsub` to a ccextractor build built with rust would error citing an unknown argument. Turned out to be a simple typo in the rust arg parser.

Here is the entry on `ccextractor --help`:
```
--debugdvbsub
          Write the DVB subtitle debug traces to console
```
