### PR TITLE
[FIX] DVB OCR: Memory Leak & Quantization Issues

### DIFF
--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -696,23 +696,15 @@ char *ocr_bitmap(void *arg, png_color *palette, png_byte *alpha, unsigned char *
 	return text_out;
 }
 
-void erode(png_color *palette, png_byte *alpha, uint8_t *bitmap, int w, int h, int nb_color)
+void erode(png_color *palette, png_byte *alpha, uint8_t *bitmap, int w, int h, int nb_color, int background_index)
 {
-	int background_index;
-	for (background_index = 0; background_index < nb_color; background_index++)
-	{
-		if (alpha[background_index])
-		{
-			break;
-		}
-	}
 	// we will use a 2*2 kernel for the erosion
 	for (int row = 0; row < h - 1; row++)
 	{
 		for (int col = 0; col < w - 1; col++)
 		{
-			if (alpha[bitmap[row * w + col]] || alpha[bitmap[(row + 1) * w + col]] ||
-			    alpha[bitmap[row * w + (col + 1)]] || alpha[bitmap[(row + 1) * w + (col + 1)]])
+			if (bitmap[row * w + col] == background_index || bitmap[(row + 1) * w + col] == background_index ||
+			    bitmap[row * w + (col + 1)] == background_index || bitmap[(row + 1) * w + (col + 1)] == background_index)
 			{
 				bitmap[row * w + col] = background_index;
 			}
@@ -720,23 +712,15 @@ void erode(png_color *palette, png_byte *alpha, uint8_t *bitmap, int w, int h, i
 	}
 }
 
-void dilate(png_color *palette, png_byte *alpha, uint8_t *bitmap, int w, int h, int nb_color)
+void dilate(png_color *palette, png_byte *alpha, uint8_t *bitmap, int w, int h, int nb_color, int foreground_index)
 {
-	int foreground_index;
-	for (foreground_index = 0; foreground_index < nb_color; foreground_index++)
-	{
-		if (!alpha[foreground_index])
-		{
-			break;
-		}
-	}
 	// we will use a 2*2 kernel for the erosion
 	for (int row = 0; row < h - 1; row++)
 	{
 		for (int col = 0; col < w - 1; col++)
 		{
-			if (!(alpha[bitmap[row * w + col]] && alpha[bitmap[(row + 1) * w + col]] &&
-			      alpha[bitmap[row * w + (col + 1)]] && alpha[bitmap[(row + 1) * w + (col + 1)]]))
+			if ((bitmap[row * w + col] == foreground_index && bitmap[(row + 1) * w + col] == foreground_index &&
+			     bitmap[row * w + (col + 1)] == foreground_index && bitmap[(row + 1) * w + (col + 1)] == foreground_index))
 			{
 				bitmap[row * w + col] = foreground_index;
 			}
@@ -767,6 +751,7 @@ static int quantize_map(png_byte *alpha, png_color *palette,
 	 */
 	uint32_t *mcit = NULL;
 	struct transIntensity ti = {alpha, palette};
+	int text_color, text_bg_color;
 
 	int ret = 0;
 
@@ -833,6 +818,14 @@ static int quantize_map(png_byte *alpha, png_color *palette,
 				max_ind = j;
 			}
 		}
+
+		// Assume second most frequent color to be text background (first is alpha channel)
+		if (i == 1)
+			text_bg_color = iot[max_ind];
+		// Assume third most frequent color to be text color
+		if (i == 2)
+			text_color = iot[max_ind];
+
 		for (j = i; j > 0 && max_ind < mcit[j - 1]; j--)
 		{
 			mcit[j] = mcit[j - 1];
@@ -876,8 +869,8 @@ static int quantize_map(png_byte *alpha, png_color *palette,
 			palette[iot[i]].green = palette[index].green;
 		}
 	}
-	erode(palette, alpha, bitmap, w, h, nb_color);
-	dilate(palette, alpha, bitmap, w, h, nb_color);
+	erode(palette, alpha, bitmap, w, h, nb_color, text_bg_color);
+	dilate(palette, alpha, bitmap, w, h, nb_color, text_color);
 #ifdef OCR_DEBUG
 	ccx_common_logging.log_ftn("Colors present in quantized Image\n");
 	for (int i = 0; i < nb_color; i++)

--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -9,7 +9,6 @@
 #include "ccx_encoders_helpers.h"
 #include "ccx_encoders_spupng.h"
 #include "ocr.h"
-#undef OCR_DEBUG
 
 struct ocrCtx
 {
@@ -686,7 +685,6 @@ char *ocr_bitmap(void *arg, png_color *palette, png_byte *alpha, unsigned char *
 		TessResultIteratorDelete(ri);
 	}
 	// End Color Detection
-	freep(&text_out);
 	boxDestroy(&crop_points);
 
 	pixDestroy(&pix);
@@ -1062,7 +1060,13 @@ char *paraof_ocrtext(struct cc_subtitle *sub, struct encoder_ctx *context)
 			len += strlen(rect->ocr_text);
 	}
 	if (len <= 0)
+	{
+		for (i = 0, rect = sub->data; i < sub->nb_data; i++, rect++)
+		{
+			freep(&rect->ocr_text);
+		}
 		return NULL;
+	}
 	else
 	{
 		str = malloc(len + 1 + 10); // Extra space for possible trailing '/n's at the end of tesseract UTF8 text
@@ -1076,7 +1080,7 @@ char *paraof_ocrtext(struct cc_subtitle *sub, struct encoder_ctx *context)
 		if (!rect->ocr_text)
 			continue;
 		add_ocrtext2str(str, rect->ocr_text, context->encoded_crlf, context->encoded_crlf_length);
-		free(rect->ocr_text);
+		freep(&rect->ocr_text);
 	}
 	return str;
 }


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---
Closes #985

DVB subtitle extraction is currently broken on the latest master build. I've verified this by testing it on the following few files:
- `09-ITV_Red_Heat.ts`  
- `2016-12-15-BBC4.ts`  
- `CHANNEL_4_2016-06-21.ts`  
- `chan7_BBC NEWS.ts`  


I've found two root issues on why this is the case:
1. The first issue is that the ocr'd text in `ocr_bitmap()` is [freed](https://github.com/CCExtractor/ccextractor/blob/a84256da017fa3c8d993262cb8a6436309fc9197/src/lib_ccx/ocr.c#L689) before being returned. Removing this free causes memory leaks (as pointed out by #1511).
2. The second issue lies within the `quantize_map()` function
    - Passing `--quant 0 (or 2)` with the first fix enables proper extraction of DVB subtitles. 

I've spent the past two days trying to understand this function and have narrowed it down to the `erode()` function introduced in [PR 1510](https://github.com/CCExtractor/ccextractor/pull/1510). I believe this is better explained visually, so here are the subtitle bitmaps before and after the `erode()` call for two different video files:

## Before
![before_erosion](https://github.com/user-attachments/assets/c4ba013c-ec31-4886-8133-10ccbebc208b)
![before_erosion_CHANNEL_4_2016-06-21](https://github.com/user-attachments/assets/4619ca1d-3adc-4fcc-92ef-56ca336cea1f)

## After
![after_erosion](https://github.com/user-attachments/assets/3da3c647-ec76-4459-9cc7-05078192eb20)
![after_erosion_CHANNEL_4_2016-06-21](https://github.com/user-attachments/assets/a83ea0c9-0610-40a0-b62e-cd7c7e95bb3d)


## Fixes
1. The memory leaks are caused due to empty strings that were not being freed due to an [if condition](https://github.com/CCExtractor/ccextractor/blob/a84256da017fa3c8d993262cb8a6436309fc9197/src/lib_ccx/ocr.c#L1064-L1065) that was prematurely returning. I've handled this case and tested it on the files mentioned in #1511.
2. After analyzing the [`erode()`](https://github.com/CCExtractor/ccextractor/blob/a84256da017fa3c8d993262cb8a6436309fc9197/src/lib_ccx/ocr.c#L701-L723) function, I noticed that the text was being eroded based on transparency rather than the text background. This method will only work for bitmaps which have their quantized text color be transparent.
```c
if (alpha[bitmap[row * w + col]] || alpha[bitmap[(row + 1) * w + col]] ||
    alpha[bitmap[row * w + (col + 1)]] || alpha[bitmap[(row + 1) * w + (col + 1)]])
```
I've modified erode and dilate so that they now use the text and text background color rather than the alpha.
I'm getting these colors from the loop which populates the mcit variable. This approach has been pretty successful in my limited amount of testing, however it relies on the assumption that the background and text color will always be the second and third most frequently occurring colors respectively.

`channel5-2018-02-12.ts` is one exception though, in it the text color is the fourth most frequently occurring color (black, the bg color is repeated twice for some reason). So erosion succeeds but dilation fails, the result is still better than the raw quantized results but it might be worthwhile to disable quantization by default.