### PR TITLE
[FIX] CMake builds failing

### DIFF
--- a/src/rust/CMakeLists.txt
+++ b/src/rust/CMakeLists.txt
@@ -2,7 +2,7 @@ include(FetchContent)
 FetchContent_Declare(
     Corrosion
     GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-    GIT_TAG 64289b1d79d6d19cd2e241db515381a086bb8407 # v0.5.0
+    GIT_TAG v0.5.1
     FIND_PACKAGE_ARGS
 )
 FetchContent_MakeAvailable(Corrosion)


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

CMake builds have been failing recently (as seen on GH actions), this is caused due to corrosion v0.5.0 being [incompatible](https://github.com/corrosion-rs/corrosion/issues/590) with the latest [release](https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html) of rustup.

This patch upgrades corrosion to [v0.5.1](https://github.com/corrosion-rs/corrosion/releases/tag/v0.5.1) to enable support.
