### PR TITLE
[FIX] Corrected bitness check for 64-bit systems

### DIFF
--- a/linux/build
+++ b/linux/build
@@ -31,7 +31,7 @@ done
 
 BLD_FLAGS="$BLD_FLAGS -std=gnu99 -Wno-write-strings -Wno-pointer-sign -D_FILE_OFFSET_BITS=64 -DVERSION_FILE_PRESENT -DENABLE_OCR -DFT2_BUILD_LIBRARY -DGPAC_DISABLE_VTT -DGPAC_DISABLE_OD_DUMP -DGPAC_DISABLE_REMOTERY -DNO_GZIP"
 bit_os=$(getconf LONG_BIT)
-if [ "$bit_os"=="64" ]
+if [ "$bit_os" == "64" ]
 then
     BLD_FLAGS="$BLD_FLAGS -DGPAC_64_BITS"
 fi


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->
**[FIX]** Corrected bitness check and added help option to build script

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [x] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

## Description of Changes
Fixed an issue in the bitness check in `linux/build.sh`:
```bash
   if [ "$bit_os"=="64" ]
```
Fixed missing spaces around `==` in bitness check. Without the spaces, the condition always evaluated to true, causing `-DGPAC_64_BITS` to be added even on non-64-bit systems.