### PR TITLE
1034:Update CHANGES.TXT: Improve -out=report to show Teletext subtitle pages

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -112,6 +112,8 @@
 - Fix: CEA-708: Better timing, fixes for missing subtitles
 - Fix: timing for direct rollup
 - Fix: timing for VOB files with multiple chapters
+- Enhanced: -out=report now lists detected Teletext subtitle pages under "Pages With Subtitles" (previously left blank even when pages were detected). Improves analysis for manual page selection use cases.
+
 
 0.88 (2019-05-21)
 -----------------

--- a/src/lib_ccx/cc_bitstream.h
+++ b/src/lib_ccx/cc_bitstream.h
@@ -20,7 +20,7 @@ struct bitstream
 	// This is meant to store high level syntax errors, i.e a function
 	// using the bitstream functions found a syntax error.
 	int error;
-	// Internal (private) variable - used to store the the bitstream
+	// Internal (private) variable - used to store the bitstream
 	// position until it is decided if the bitstream pointer will be
 	// increased by the calling function, or not.
 	unsigned char *_i_pos;

--- a/src/thirdparty/zlib/zlib.h
+++ b/src/thirdparty/zlib/zlib.h
@@ -729,7 +729,7 @@ ZEXTERN int ZEXPORT deflateParams OF((z_streamp strm,
    Then no more input data should be provided before the deflateParams() call.
    If this is done, the old level and strategy will be applied to the data
    compressed before deflateParams(), and the new level and strategy will be
-   applied to the the data compressed after deflateParams().
+   applied to the data compressed after deflateParams().
 
      deflateParams returns Z_OK on success, Z_STREAM_ERROR if the source stream
    state was inconsistent or if a parameter was invalid, or Z_BUF_ERROR if


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ *] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ *] I have checked that another pull request for this purpose does not exist.
- [ *] I have considered, and confirmed that this submission will be valuable to others.
- [* ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ *] I give this submission freely, and claim no ownership to its content.
- [* ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ *] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

{pull request content here}
This pull request improves the -out=report option by including detected Teletext subtitle pages in the report output. Previously, even when pages were detected, the report did not list them, making it difficult to determine which Teletext page to use for extraction based on language or service.


