### PR TITLE
 [FIX] Initialize data structures for the rust CEA-708 decoder and correct Dtvcc-issue1499

### DIFF
--- a/linux/build
+++ b/linux/build
@@ -31,7 +31,7 @@ done
 
 BLD_FLAGS="$BLD_FLAGS -std=gnu99 -Wno-write-strings -Wno-pointer-sign -D_FILE_OFFSET_BITS=64 -DVERSION_FILE_PRESENT -DENABLE_OCR -DFT2_BUILD_LIBRARY -DGPAC_DISABLE_VTT -DGPAC_DISABLE_OD_DUMP -DGPAC_DISABLE_REMOTERY -DNO_GZIP"
 bit_os=$(getconf LONG_BIT)
-if [ "$bit_os"=="64" ]
+if [ "$bit_os" == "64" ]
 then
     BLD_FLAGS="$BLD_FLAGS -DGPAC_64_BITS"
 fi

--- a/src/lib_ccx/ccx_decoders_common.h
+++ b/src/lib_ccx/ccx_decoders_common.h
@@ -32,4 +32,10 @@ struct cc_subtitle* copy_subtitle(struct cc_subtitle *sub);
 void free_encoder_context(struct encoder_ctx *ctx);
 void free_decoder_context(struct lib_cc_decode *ctx);
 void free_subtitle(struct cc_subtitle* sub);
+
+extern int ccxr_process_cc_data(struct lib_cc_decode *dec_ctx, unsigned char *cc_data, int cc_count);
+extern void ccxr_flush_decoder(struct dtvcc_ctx *dtvcc, struct dtvcc_service_decoder *decoder);
+extern int ccxr_dtvcc_init(struct lib_cc_decode *ctx);
+extern void ccxr_dtvcc_free(struct lib_cc_decode *ctx);
+
 #endif

--- a/src/lib_ccx/ccx_decoders_structs.h
+++ b/src/lib_ccx/ccx_decoders_structs.h
@@ -209,6 +209,7 @@ struct lib_cc_decode
     int false_pict_header;
 
 	dtvcc_ctx *dtvcc;
+	void *dtvcc_rust; // Rust Dtvcc instance
 	int current_field;
 	// Analyse/use the picture information
 	int maxtref; // Use to remember the temporal reference number


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [x] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

### Summary of Changes Made

#### 1. In `src/rust/src/lib.rs`:
- Added a new `lib_cc_decode` struct with a `dtvcc_rust` field to store the Rust `Dtvcc` instance.
- Created `ccxr_dtvcc_init()` function to initialize the `Dtvcc` struct only once.
- Created `ccxr_dtvcc_free()` function to free the `Dtvcc` struct.
- Modified `ccxr_process_cc_data()` to use the stored `Dtvcc` instance instead of creating a new one each time.
- Added a fallback to the old method if initialization fails.

#### 2. In `src/lib_ccx/ccx_decoders_structs.h`:
- Added the `dtvcc_rust` field to the existing `lib_cc_decode` struct definition.

#### 3. In `src/lib_ccx/ccx_decoders_common.h`:
- Added `extern` declarations for `ccxr_dtvcc_init` and `ccxr_dtvcc_free` functions.

#### 4. In `src/lib_ccx/ccx_decoders_common.c`:
- Added function declarations for the Rust functions.
- Added a call to `ccxr_dtvcc_init()` after `dtvcc_init` is called.
- Added a call to `ccxr_dtvcc_free()` before `dtvcc_free` is called.
- Initialized `dtvcc_rust` to `NULL` in the `init_cc_decode` function.
- Added `NULL` initialization for `dtvcc_rust` in the `copy_decoder_context` function.

#### 5. In `src/lib_ccx/mp4.c`:
- Fixed a conflict between multiple `MEDIA_TYPE` defines.
- Confirmed that the `extern` declarations for the Rust functions were already in place.
- Added code in the `process_clcp` function to use the Rust implementation of Dtvcc:
  - Checks if `dtvcc_rust` is `NULL` and initializes it if needed.
  - Creates a proper `cc_block` for the Rust implementation.
  - Calls `ccxr_process_cc_data()` with the block.
  - Falls back to the C implementation if Rust isn't available.

---

This implementation ensures that the `Dtvcc` struct is initialized only once at the start of the program and then reused for all subsequent function calls. This fixes the issue where data was being reset each time `ccxr_process_cc_data()` was called. The changes also integrate this approach into the MP4 code path.
