### PR TITLE
[FIX] Fix compilation on silicon mac

### DIFF
--- a/docs/COMPILATION.MD
+++ b/docs/COMPILATION.MD
@@ -133,6 +133,7 @@ Dependencies can be installed via Homebrew as:
 ```bash
 brew install pkg-config
 brew install autoconf automake libtool
+brew install cmake gpac
 # optional if you want OCR:
 brew install tesseract
 brew install leptonica

--- a/src/thirdparty/libpng/pngpriv.h
+++ b/src/thirdparty/libpng/pngpriv.h
@@ -506,8 +506,7 @@
 #  define png_aligncastconst(type, value) ((const void*)(value))
 #endif /* __cplusplus */
 
-#if defined(PNG_FLOATING_POINT_SUPPORTED) ||\
-    defined(PNG_FLOATING_ARITHMETIC_SUPPORTED)
+#if defined(PNG_FLOATING_POINT_SUPPORTED) || defined(PNG_FLOATING_ARITHMETIC_SUPPORTED)
    /* png.c requires the following ANSI-C constants if the conversion of
     * floating point to ASCII is implemented therein:
     *
@@ -515,10 +514,13 @@
     *  DBL_MIN  Smallest normalized fp number (can be set to an arbitrary value)
     *  DBL_MAX  Maximum floating point number (can be set to an arbitrary value)
     */
+
 #  include <float.h>
 
-#  if (defined(__MWERKS__) && defined(macintosh)) || defined(applec) || \
-    defined(THINK_C) || defined(__SC__) || defined(TARGET_OS_MAC)
+   /* Handle floating-point headers depending on the platform */
+#  if ((defined(__MWERKS__) && defined(macintosh)) || defined(applec) || \
+       defined(THINK_C) || defined(__SC__) || defined(TARGET_OS_MAC)) && \
+      !(defined(__APPLE__) && defined(__MACH__)) // this if block gets executed for older macOS versions
    /* We need to check that <math.h> hasn't already been included earlier
     * as it seems it doesn't agree with <fp.h>, yet we should really use
     * <fp.h> if possible.
@@ -526,15 +528,19 @@
 #    if !defined(__MATH_H__) && !defined(__MATH_H) && !defined(__cmath__)
 #      include <fp.h>
 #    endif
-#  else
+#  else // this if block gets executed for newer macOS versions(Ventura/Sonoma/Sequoia) OR other platforms
+    /* if (defined(__APPLE__) && defined(__MACH__)) or other cases */
+    /* Include math.h for macOS and all other platforms */
 #    include <math.h>
 #  endif
+
 #  if defined(_AMIGA) && defined(__SASC) && defined(_M68881)
    /* Amiga SAS/C: We must include builtin FPU functions when compiling using
     * MATH=68881
     */
 #    include <m68881.h>
 #  endif
+
 #endif
 
 /* This provides the non-ANSI (far) memory allocation routines. */

--- a/src/thirdparty/zlib/zutil.h
+++ b/src/thirdparty/zlib/zutil.h
@@ -130,7 +130,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #  endif
 #endif
 
-#if defined(MACOS) || defined(TARGET_OS_MAC)
+#if defined(MACOS) // for older macOS 
 #  define OS_CODE  7
 #  ifndef Z_SOLO
 #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
@@ -141,6 +141,8 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #      endif
 #    endif
 #  endif
+#elif defined(__MACH__) && defined(__APPLE__) && defined(TARGET_OS_MAC) // for newer macOS(Ventura/Sonoma/Sequoia)
+// do nothing because fdopen is defined already by XCode command-line-tools in these macOS versions
 #endif
 
 #ifdef __acorn


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Recently updated to macOS@15.4 on M1 Mac and CCExtractor compilation started failing for all 3 methods in [src/COMPILATION.MD](https://github.com/CCExtractor/ccextractor/blob/master/docs/COMPILATION.MD).
The issue was due to some update in Xcode command-line-tools which updated clang to `Apple clang version 17.0.0 (clang-1700.0.13.3)`
Updating these preprocessor directives in third party libs solves the issue : 
- src/thirdparty/libpng/pngpriv.h
- src/thirdparty/zlib/zutil.h

Also updated dependencies(`brew install cmake gpac`) in src/docs/COMPILATION.MD
