### PR TITLE
[FIX] Fixed Unit Test Rust based on the new changes on Rust 1.86.0

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -40,6 +40,7 @@
 - New: Add tesseract page segmentation modes control with `--psm` flag
 - Fix: Resolve compile-time error about implicit declarations (#1646)
 - Fix: fatal out of memory error extracting from a VOB PS
+- Fix: Unit Test Rust failing due to changes in Rust Version 1.86.0
 
 0.94 (2021-12-14)
 -----------------

--- a/src/rust/src/decoder/mod.rs
+++ b/src/rust/src/decoder/mod.rs
@@ -44,24 +44,35 @@ pub struct Dtvcc<'a> {
 impl<'a> Dtvcc<'a> {
     /// Create a new dtvcc context
     pub fn new(ctx: &'a mut dtvcc_ctx) -> Self {
-        let report = unsafe { &mut *ctx.report };
-        let encoder = unsafe { &mut *(ctx.encoder as *mut encoder_ctx) };
-        let timing = unsafe { &mut *ctx.timing };
-
+        let report = if !ctx.report.is_null() {
+            unsafe { Box::new(*(ctx.report)) }
+        } else {
+            Box::new(ccx_decoder_dtvcc_report::default())
+        };
+        let encoder = if !ctx.encoder.is_null() {
+            unsafe { Box::new(*(ctx.encoder as *mut encoder_ctx)) }
+        } else {
+            Box::new(encoder_ctx::default())
+        };
+        let timing = if !ctx.timing.is_null() {
+            unsafe { Box::new(*(ctx.timing)) }
+        } else {
+            Box::new(ccx_common_timing_ctx::default())
+        };
         Self {
             is_active: is_true(ctx.is_active),
             active_services_count: ctx.active_services_count as u8,
             services_active: ctx.services_active.to_vec(),
             report_enabled: is_true(ctx.report_enabled),
-            report,
+            report: Box::leak(report),
             decoders: ctx.decoders.iter_mut().collect(),
             packet: ctx.current_packet.to_vec(),
             packet_length: ctx.current_packet_length as u8,
             is_header_parsed: is_true(ctx.is_current_packet_header_parsed),
             last_sequence: ctx.last_sequence,
-            encoder,
+            encoder: Box::leak(encoder),
             no_rollup: is_true(ctx.no_rollup),
-            timing,
+            timing: Box::leak(timing),
         }
     }
     /// Process cc data and add it to the dtvcc packet

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -173,7 +173,11 @@ pub fn do_cb(ctx: &mut lib_cc_decode, dtvcc: &mut Dtvcc, cc_block: &[u8]) -> boo
             0 | 1 => {}
             // Type 2 and 3 are for CEA-708 data.
             2 | 3 => {
-                let current_time = unsafe { (*ctx.timing).get_fts(ctx.current_field as u8) };
+                let current_time = if ctx.timing.is_null() {
+                    0
+                } else {
+                    unsafe { (*ctx.timing).get_fts(ctx.current_field as u8) }
+                };
                 ctx.current_field = 3;
 
                 // Check whether current time is within start and end bounds


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

While working on the `share` module, I came across the problem that on the main branch, [the Unit Test Rust(test_rust.yml) was failing](https://github.com/CCExtractor/ccextractor/actions/runs/14557403272/job/40836138898). Reverting commits didn't help, later I found out that the problem was due to Rust being upgraded to 1.86.0.
[The New Changes to check for Null pointer De-referencing](https://github.com/rust-lang/rust/pull/134424)
This triggered a panic on 3 tests

- `test_do_cb` in `src/rust/src/lib.rs`
- `test_process_cc_data` in `src/rust/src/decoder.rs`
- `test_process_current_packet` in `src/rust/src/decoder.rs`

The errors were fixed by checking for null pointers and reverting to a fallback value when true. I have used Box::leak in `decoder.rs` for now, it may be changed to a safer alternative later.

## How to replicate the errors for the main branch

- `git clone https://github.com/CCExtractor/ccextractor && cd ccextractor `
- `cd src/rust`
- `rustup update`
- `rustup run 1.86.0 cargo test`