### PR TITLE
[IMPROVEMENT] Refactor and optimize Dockerfile

### DIFF
--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -4,17 +4,18 @@ FROM base as builder
 
 RUN apk add --no-cache --update git curl gcc cmake glew glfw \
   tesseract-ocr-dev leptonica-dev clang-dev llvm-dev make pkgconfig \
-  zlib-dev libpng-dev libjpeg-turbo-dev openssl-dev freetype-dev libxml2-dev
-
-RUN cd && git clone https://github.com/gpac/gpac 
-WORKDIR root/gpac/
-RUN ./configure && make && make install-lib  && cd && rm -rf /root/gpac
+  zlib-dev libpng-dev libjpeg-turbo-dev openssl-dev freetype-dev libxml2-dev bash cargo
 
 WORKDIR /root
+RUN git clone https://github.com/gpac/gpac 
+WORKDIR /root/gpac/
+RUN ./configure && make -j$(nproc) && make install-lib
+WORKDIR /root 
+RUN rm -rf /root/gpac
+
 RUN git clone https://github.com/CCExtractor/ccextractor.git 
-RUN apk add bash cargo
-RUN export LIB_CLANG_PATH=$(find / -name 'libclang*.so*' 2>/dev/null | grep -v 'No such file' | head -n 1 | xargs dirname)
-RUN cd /root/ccextractor/linux && ./pre-build.sh && ./build
+WORKDIR /root/ccextractor/linux
+RUN ./pre-build.sh && ./build
 
 RUN cp /root/ccextractor/linux/ccextractor /ccextractor && rm -rf ~/ccextractor
 
@@ -43,6 +44,3 @@ COPY --from=builder /usr/lib/libsharpyuv.so.0 /usr/lib/
 COPY --from=builder /ccextractor /
 
 ENTRYPOINT [ "/ccextractor" ]
-
-CMD [ "/ccextractor" ]
-

--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 1.0 (to be released)
 -----------------
+- IMPROVEMENT: Refactor and optimize Dockerfile
 - Fix: Improved handling of IETF language tags in Matroska files (#1665)
 - New: Create unit test for rust code (#1615)
 - Breaking: Major argument flags revamp for CCExtractor (#1564 & #1619)

--- a/linux/build
+++ b/linux/build
@@ -31,7 +31,7 @@ done
 
 BLD_FLAGS="$BLD_FLAGS -std=gnu99 -Wno-write-strings -Wno-pointer-sign -D_FILE_OFFSET_BITS=64 -DVERSION_FILE_PRESENT -DENABLE_OCR -DFT2_BUILD_LIBRARY -DGPAC_DISABLE_VTT -DGPAC_DISABLE_OD_DUMP -DGPAC_DISABLE_REMOTERY -DNO_GZIP"
 bit_os=$(getconf LONG_BIT)
-if [ "$bit_os"=="64" ]
+if [ "$bit_os" == "64" ]
 then
     BLD_FLAGS="$BLD_FLAGS -DGPAC_64_BITS"
 fi


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

**Changes:**

- Replaced `cd` commands with `WORKDIR` instructions to improve clarity and follow Docker best practices.
- Removed the unused RUN export for LIB_CLANG_PATH, which only affected a single build layer (since export does not persist between Docker layers); the library is automatically detected during build.
- Parallelized GPAC build using `make -j$(nproc)`, significantly reducing build time.
- Removed redundant `CMD` instruction since `ENTRYPOINT` already defines the execution command.

This PR improves Dockerfile structure, reduces build time, and eliminates unnecessary instructions for a cleaner and more maintainable setup.

