### PR TITLE
fix: replace iconv with encoding_rs

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -157,8 +157,8 @@ dependencies = [
  "bindgen 0.64.0",
  "cfg-if",
  "clap",
+ "encoding_rs",
  "env_logger",
- "iconv",
  "leptonica-sys",
  "lib_ccxr",
  "log",
@@ -294,16 +294,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "dyn_buf"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c57ab96715773d9cb9789b38eb7cbf04b3c6f5624a9d98f51761603376767c"
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "env_logger"
@@ -399,16 +402,6 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "iconv"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e6a7db0df823ef299ef75b6951975c7a1f9019910b3665614bac4161bab1a9"
-dependencies = [
- "dyn_buf",
- "libc",
-]
 
 [[package]]
 name = "icu_collections"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -13,7 +13,6 @@ crate-type = ["staticlib"]
 [dependencies]
 log = "0.4.26"
 env_logger = "0.8.4"
-iconv = "0.1.1"
 palette = "0.6.1"
 rsmpeg = { version = "0.14.2", optional = true, features = [
     "link_system_ffmpeg",
@@ -28,6 +27,7 @@ cfg-if = "1.0.0"
 num-integer = "0.1.46"
 lib_ccxr = { path = "lib_ccxr" }
 url = "2.5.4"
+encoding_rs = "0.8.5"
 
 [build-dependencies]
 bindgen = "0.64.0"


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---
Closes #1697 

The iconv [crate](https://github.com/andelf/rust-iconv) is currently unmaintained and broken on the latest version of rust (see this [issue](https://github.com/andelf/rust-iconv/issues/10)). This PR migrates the encoding from iconv to the well maintained [encoding_rs](https://crates.io/crates/encoding_rs) library.

Note that the rust implementation for this particular case was and still is buggy, regression tests 142, 147 and 149 all of which test this specific scenario have historically had empty output files (see [here](https://sampleplatform.ccextractor.org/regression/test/142/view) for eg), which is why the tests were passing. The C builds however, produce the proper outputs.