### PR TITLE
[FIX] cargo tests failing on windows

### DIFF
--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -27,6 +27,7 @@ use std::os::windows::io::{FromRawHandle, RawHandle};
 
 use args::Args;
 use bindings::*;
+use cfg_if::cfg_if;
 use clap::{error::ErrorKind, Parser};
 use common::{copy_from_rust, CType, CType2};
 use decoder::Dtvcc;
@@ -42,29 +43,48 @@ use std::{
     os::raw::{c_char, c_double, c_int, c_long, c_uint},
 };
 
-#[cfg(test)]
-static mut cb_708: c_int = 0;
-#[cfg(test)]
-static mut cb_field1: c_int = 0;
-#[cfg(test)]
-static mut cb_field2: c_int = 0;
+// Mock data for rust unit tests
+cfg_if! {
+    if #[cfg(test)] {
+        static mut cb_708: c_int = 0;
+        static mut cb_field1: c_int = 0;
+        static mut cb_field2: c_int = 0;
+        static mut current_fps: c_double = 30.0;
+        static mut usercolor_rgb: [c_int; 8] = [0; 8];
+        static mut FILEBUFFERSIZE: c_int = 0;
+        static mut MPEG_CLOCK_FREQ: c_int = 90000;
 
+        static mut frames_since_ref_time: c_int = 0;
+        static mut total_frames_count: c_uint = 0;
+        static mut fts_at_gop_start: c_long = 0;
+        static mut gop_rollover: c_int = 0;
+        static mut pts_big_change: c_uint = 0;
+
+        static mut tlt_config: ccx_s_teletext_config = unsafe { std::mem::zeroed() };
+        static mut ccx_options: ccx_s_options = unsafe { std::mem::zeroed() };
+        static mut gop_time: gop_time_code = unsafe { std::mem::zeroed() };
+        static mut first_gop_time: gop_time_code = unsafe { std::mem::zeroed() };
+        static mut ccx_common_timing_settings: ccx_common_timing_settings_t = unsafe { std::mem::zeroed() };
+        static mut capitalization_list: word_list = unsafe { std::mem::zeroed() };
+        static mut profane: word_list = unsafe { std::mem::zeroed() };
+
+        unsafe extern "C" fn version(_location: *const c_char) {}
+        unsafe extern "C" fn set_binary_mode() {}
+    }
+}
+
+// External C symbols (only when not testing)
 #[cfg(not(test))]
 extern "C" {
     static mut cb_708: c_int;
     static mut cb_field1: c_int;
     static mut cb_field2: c_int;
-}
-
-#[allow(dead_code)]
-extern "C" {
+    static mut current_fps: c_double;
     static mut usercolor_rgb: [c_int; 8];
     static mut FILEBUFFERSIZE: c_int;
     static mut MPEG_CLOCK_FREQ: c_int;
     static mut tlt_config: ccx_s_teletext_config;
     static mut ccx_options: ccx_s_options;
-    static mut pts_big_change: c_uint;
-    static mut current_fps: c_double;
     static mut frames_since_ref_time: c_int;
     static mut total_frames_count: c_uint;
     static mut gop_time: gop_time_code;
@@ -74,6 +94,10 @@ extern "C" {
     static mut ccx_common_timing_settings: ccx_common_timing_settings_t;
     static mut capitalization_list: word_list;
     static mut profane: word_list;
+    static mut pts_big_change: c_uint;
+
+    fn version(location: *const c_char);
+    fn set_binary_mode();
 }
 
 /// Initialize env logger with custom format, using stdout as target
@@ -214,12 +238,6 @@ extern "C" fn ccxr_close_handle(handle: RawHandle) {
         // File will close automatically (due to Drop) once it goes out of scope
         let _file = File::from_raw_handle(handle);
     }
-}
-
-extern "C" {
-    fn version(location: *const c_char);
-    #[allow(dead_code)]
-    fn set_binary_mode();
 }
 
 /// # Safety

--- a/src/rust/src/libccxr_exports/time.rs
+++ b/src/rust/src/libccxr_exports/time.rs
@@ -6,7 +6,7 @@ use std::ffi::{c_char, c_int, c_long, CStr};
 use crate::{
     bindings::*, cb_708, cb_field1, cb_field2, ccx_common_timing_settings as timing_settings,
     current_fps, first_gop_time, frames_since_ref_time, fts_at_gop_start, gop_rollover, gop_time,
-    pts_big_change, total_frames_count,
+    pts_big_change, total_frames_count, MPEG_CLOCK_FREQ,
 };
 
 use lib_ccxr::common::FrameType;
@@ -279,6 +279,7 @@ unsafe fn apply_timing_info() {
     timing_info.timing_settings.disable_sync_check = timing_settings.disable_sync_check != 0;
     timing_info.timing_settings.no_sync = timing_settings.no_sync != 0;
     timing_info.timing_settings.is_elementary_stream = timing_settings.is_elementary_stream != 0;
+    timing_info.mpeg_clock_freq = MPEG_CLOCK_FREQ.into();
 }
 
 /// Write from [`GLOBAL_TIMING_INFO`] to the equivalent static variables in C.

--- a/src/rust/src/parser.rs
+++ b/src/rust/src/parser.rs
@@ -24,13 +24,7 @@ use time::OffsetDateTime;
 use crate::args::CCXCodec;
 use crate::args::{self, InFormat};
 
-cfg_if! {
-    if #[cfg(test)] {
-        use crate::parser::tests::{set_binary_mode, MPEG_CLOCK_FREQ, usercolor_rgb, FILEBUFFERSIZE};
-    } else {
-        use crate::{set_binary_mode, MPEG_CLOCK_FREQ, usercolor_rgb, FILEBUFFERSIZE};
-    }
-}
+use crate::{set_binary_mode, usercolor_rgb, FILEBUFFERSIZE, MPEG_CLOCK_FREQ};
 
 cfg_if! {
     if #[cfg(windows)] {
@@ -1684,9 +1678,6 @@ pub mod tests {
 
     #[no_mangle]
     pub unsafe extern "C" fn set_binary_mode() {}
-    pub static mut MPEG_CLOCK_FREQ: u64 = 0;
-    pub static mut FILEBUFFERSIZE: i32 = 0;
-    pub static mut usercolor_rgb: [i32; 8] = [0; 8];
 
     fn parse_args(args: &[&str]) -> (Options, TeletextConfig) {
         let mut common_args = vec!["./ccextractor", "input_file"];


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---
Cargo tests have been failing on Windows on the master branch for a while now. The primary reason seems to be differences in linking behaviour between the GNU and MSVC ABIs, see [here](https://rust-lang.github.io/rustup/installation/windows.html#:%7E:text=Or%20to%20choose%20the%2064%20bit%20GNU%20toolchain) for more info.

The main issue was that when running unit tests, the linker that MSVC uses couldn't resolve several external C symbols, primarily [these](https://github.com/CCExtractor/ccextractor/blob/407d0f4e93611c5b0ceb14b7fc01d4a4c2e90433/src/rust/src/lib.rs#L60-L77). This makes sense as when running unit tests, the C side of the codebase never comes into play. To address this, I added a `cfg_if` block that provides mock implementations during test runs so that the tests can run without requiring linkage to C symbols.

I also noticed that there was an extern declaration in `lib_ccxr` for `MPEG_CLOCK_FREQUENCY`, after consulting with @steel-bucket I realized that this is was an oversight as the `lib_ccxr` crate is meant to be a clean idiomatic rust layer. To fix this, I added a new field to GLOBAL_TIMING_INFO and ensured the MPEG clock frequency is passed explicitly through FFI.

With these changes, all unit tests now run successfully on Windows. This should help with fixing any windows specific bugs in upcoming PRs.

