### PR TITLE
Fixed Clippy Errors on 1.88

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 1.0 (to be released)
 -----------------
+- Fix: Clippy Errors Based on Rust 1.88
 - IMPROVEMENT: Refactor and optimize Dockerfile
 - Fix: Improved handling of IETF language tags in Matroska files (#1665)
 - New: Create unit test for rust code (#1615)

--- a/src/rust/lib_ccxr/src/activity.rs
+++ b/src/rust/lib_ccxr/src/activity.rs
@@ -11,7 +11,7 @@ impl ActivityExt for Options {
         if self.gui_mode_reports {
             let mut stderr = io::stderr();
             let version = env!("CARGO_PKG_VERSION");
-            writeln!(stderr, "###VERSION#CCExtractor#{}", version).unwrap();
+            writeln!(stderr, "###VERSION#CCExtractor#{version}").unwrap();
             stderr.flush().unwrap();
         }
     }

--- a/src/rust/lib_ccxr/src/teletext.rs
+++ b/src/rust/lib_ccxr/src/teletext.rs
@@ -519,14 +519,11 @@ impl G0Charset {
                     self.g0_charset[0x00][pos] = ch;
                 }
                 if self.verbose_debug {
-                    eprintln!("- Using G0 Latin National Subset ID {} ({})", subset, s);
+                    eprintln!("- Using G0 Latin National Subset ID {subset} ({s})");
                 }
                 self.primary_charset_current = subset;
             } else {
-                eprintln!(
-                    "- G0 Latin National Subset ID {} is not implemented",
-                    subset
-                );
+                eprintln!("- G0 Latin National Subset ID {subset} is not implemented");
             }
         }
     }
@@ -960,9 +957,9 @@ impl<'a> TeletextContext<'a> {
         #[cfg(feature = "debug")]
         {
             for (index, row) in self.page_buffer.text.iter().enumerate().skip(1) {
-                print!("DEUBG[{:02}]: ", index);
+                print!("DEBUG[{index:02}]: ");
                 for c in row {
-                    print!("{:3x} ", c)
+                    print!("{c:3x} ")
                 }
                 println!();
             }
@@ -1068,10 +1065,7 @@ impl<'a> TeletextContext<'a> {
                     let timecode_show_mmss = &timecode_show[3..8];
                     let timecode_hide_mmss = &timecode_hide[3..8];
                     // Note, only MM:SS here as we need to save space in the preview window
-                    eprint!(
-                        "###TIME###{}-{}\n###SUBTITLES###",
-                        timecode_show_mmss, timecode_hide_mmss
-                    );
+                    eprint!("###TIME###{timecode_show_mmss}-{timecode_hide_mmss}\n###SUBTITLES###",);
                     time_reported = true;
                 } else {
                     eprint!("###SUBTITLE###");
@@ -1152,7 +1146,7 @@ impl<'a> TeletextContext<'a> {
                         self.page_buffer_cur.get_or_insert("".into()).push(u);
                         if logger().expect("could not access logger").is_gui_mode() {
                             // For now we just handle the easy stuff
-                            eprint!("{}", u);
+                            eprint!("{u}");
                         }
                     }
                 }
@@ -1271,7 +1265,7 @@ impl<'a> TeletextContext<'a> {
                 let mut thisp = ((m as u32) << 8)
                     | ((decode_hamming_8_4(packet.data[1]).unwrap() as u32) << 4)
                     | (decode_hamming_8_4(packet.data[0]).unwrap() as u32);
-                let t1 = format!("{:x}", thisp); // Example: 1928 -> 788
+                let t1 = format!("{thisp:x}"); // Example: 1928 -> 788
                 thisp = t1.parse().unwrap();
                 if !self.seen_sub_page[thisp as usize] {
                     self.seen_sub_page[thisp as usize] = true;

--- a/src/rust/lib_ccxr/src/time/units.rs
+++ b/src/rust/lib_ccxr/src/time/units.rs
@@ -231,7 +231,7 @@ impl Timestamp {
         let s = millis / 1000 - 3600 * h - 60 * m;
         let u = millis - 3600000 * h - 60000 * m - 1000 * s;
         if h > 24 {
-            println!("{}", h)
+            println!("{h}")
         }
         Ok((h.try_into()?, m as u8, s as u8, u as u16))
     }
@@ -248,7 +248,7 @@ impl Timestamp {
     /// ```
     pub fn write_srt_time(&self, output: &mut String) -> Result<(), TimestampError> {
         let (h, m, s, u) = self.as_hms_millis()?;
-        write!(output, "{:02}:{:02}:{:02},{:03}", h, m, s, u)?;
+        write!(output, "{h:02}:{m:02}:{s:02},{u:03}")?;
         Ok(())
     }
 
@@ -264,7 +264,7 @@ impl Timestamp {
     /// ```
     pub fn write_vtt_time(&self, output: &mut String) -> Result<(), TimestampError> {
         let (h, m, s, u) = self.as_hms_millis()?;
-        write!(output, "{:02}:{:02}:{:02}.{:03}", h, m, s, u)?;
+        write!(output, "{h:02}:{m:02}:{s:02}.{u:03}")?;
         Ok(())
     }
 
@@ -288,7 +288,7 @@ impl Timestamp {
         let sign = if self.millis < 0 { "-" } else { "" };
         let timestamp = if self.millis < 0 { -*self } else { *self };
         let (h, m, s, u) = timestamp.as_hms_millis()?;
-        write!(output, "{}{:02}:{:02}:{:02}{}{:03}", sign, h, m, s, sep, u)?;
+        write!(output, "{sign}{h:02}:{m:02}:{s:02}{sep}{u:03}")?;
         Ok(())
     }
 
@@ -325,12 +325,12 @@ impl Timestamp {
             TimestampFormat::None => Ok(()),
             TimestampFormat::HHMMSS => {
                 let (h, m, s, _) = self.as_hms_millis()?;
-                write!(output, "{:02}:{:02}:{:02}", h, m, s)?;
+                write!(output, "{h:02}:{m:02}:{s:02}")?;
                 Ok(())
             }
             TimestampFormat::Seconds { millis_separator } => {
                 let (sec, millis) = self.as_sec_millis()?;
-                write!(output, "{}{}{:03}", sec, millis_separator, millis)?;
+                write!(output, "{sec}{millis_separator}{millis:03}")?;
                 Ok(())
             }
             TimestampFormat::Date { millis_separator } => {
@@ -404,7 +404,7 @@ impl Timestamp {
         let (h, m, s, _) = self.as_hms_millis()?;
         let frame = (self.millis - 1000 * (s + 60 * (m + 60 * h)) as i64) as f64 * 29.97 / 1000.0;
 
-        write!(result, "{:02}:{:02}:{:02};{:02}", h, m, s, frame)?;
+        write!(result, "{h:02}:{m:02}:{s:02};{frame:02}")?;
 
         Ok(result)
     }

--- a/src/rust/lib_ccxr/src/util/bits.rs
+++ b/src/rust/lib_ccxr/src/util/bits.rs
@@ -229,10 +229,10 @@ mod tests {
 
     #[test]
     fn test_get_parity() {
-        assert_eq!(get_parity(0), false);
-        assert_eq!(get_parity(1), true);
-        assert_eq!(get_parity(128), true);
-        assert_eq!(get_parity(255), false);
+        assert!(!get_parity(0));
+        assert!(get_parity(1));
+        assert!(get_parity(128));
+        assert!(!get_parity(255));
     }
 
     #[test]

--- a/src/rust/lib_ccxr/src/util/log.rs
+++ b/src/rust/lib_ccxr/src/util/log.rs
@@ -279,8 +279,8 @@ impl<'a> CCExtractorLogger {
 
     fn print(&self, args: &Arguments<'a>) {
         match &self.target {
-            OutputTarget::Stdout => print!("{}", args),
-            OutputTarget::Stderr => eprint!("{}", args),
+            OutputTarget::Stdout => print!("{args}"),
+            OutputTarget::Stderr => eprint!("{args}"),
             OutputTarget::Quiet => {}
         }
     }
@@ -305,7 +305,7 @@ impl<'a> CCExtractorLogger {
             eprint!("\rError: ")
         }
 
-        eprintln!("{}", args);
+        eprintln!("{args}");
     }
 
     /// Log an informational message. Use [`info!`] instead.
@@ -335,22 +335,19 @@ impl<'a> CCExtractorLogger {
         if self.gui_mode {
             match message_type {
                 GuiXdsMessage::ProgramName(program_name) => {
-                    eprintln!("###XDSPROGRAMNAME#{}", program_name)
+                    eprintln!("###XDSPROGRAMNAME#{program_name}")
                 }
                 GuiXdsMessage::ProgramIdNr {
                     minute,
                     hour,
                     date,
                     month,
-                } => eprintln!(
-                    "###XDSPROGRAMIDENTIFICATIONNUMBER#{}#{}#{}#{}",
-                    minute, hour, date, month
-                ),
+                } => eprintln!("###XDSPROGRAMIDENTIFICATIONNUMBER#{minute}#{hour}#{date}#{month}",),
                 GuiXdsMessage::ProgramDescription { line_num, desc } => {
-                    eprintln!("###XDSPROGRAMDESC#{}#{}", line_num, desc)
+                    eprintln!("###XDSPROGRAMDESC#{line_num}#{desc}")
                 }
                 GuiXdsMessage::CallLetters(current_letters) => {
-                    eprintln!("###XDSNETWORKCALLLETTERS#{}", current_letters)
+                    eprintln!("###XDSNETWORKCALLLETTERS#{current_letters}")
                 }
             }
         }
@@ -380,7 +377,7 @@ impl<'a> CCExtractorLogger {
         for (id, chunk) in chunked_data.enumerate() {
             self.print(&format_args!("{:05} | ", id * 16 + start_idx));
             for x in chunk {
-                self.print(&format_args!("{:02X} ", x));
+                self.print(&format_args!("{x:02X} "));
             }
 
             for _ in 0..(16 - chunk.len()) {

--- a/src/rust/src/decoder/timing.rs
+++ b/src/rust/src/decoder/timing.rs
@@ -45,7 +45,7 @@ pub fn get_time_str(time: LLONG) -> String {
     let mm = time / 1000 / 60 - 60 * hh;
     let ss = time / 1000 - 60 * (mm + 60 * hh);
     let ms = time - 1000 * (ss + 60 * (mm + 60 * hh));
-    format!("{:02}:{:02}:{:02},{:03}", hh, mm, ss, ms)
+    format!("{hh:02}:{mm:02}:{ss:02},{ms:03}")
 }
 
 impl ccx_boundary_time {

--- a/src/rust/src/decoder/tv_screen.rs
+++ b/src/rust/src/decoder/tv_screen.rs
@@ -494,7 +494,7 @@ impl dtvcc_tv_screen {
                         buf.push(' ');
                     }
                     let adjusted_val = adjust_odd_parity(self.chars[row_index][i].sym as u8);
-                    buf = format!("{}{:x}", buf, adjusted_val);
+                    buf = format!("{buf}{adjusted_val:x}");
                     bytes_written += 1;
                 }
                 // add 0x80 padding and form byte pair if the last byte pair is not form
@@ -625,7 +625,7 @@ impl dtvcc_tv_screen {
                 red *= 255 / 3;
                 green *= 255 / 3;
                 blue *= 255 / 3;
-                let font_tag = format!("<font color=\"#{:02x}{:02x}{:02x}\">", red, green, blue);
+                let font_tag = format!("<font color=\"#{red:02x}{green:02x}{blue:02x}\">");
                 buf.extend_from_slice(font_tag.as_bytes());
             }
         }

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -251,7 +251,7 @@ pub unsafe extern "C" fn ccxr_parse_parameters(argc: c_int, argv: *mut *mut c_ch
             match e.kind() {
                 ErrorKind::DisplayHelp => {
                     // Print the help string
-                    println!("{}", e);
+                    println!("{e}");
                     return ExitCause::WithHelp.exit_code();
                 }
                 ErrorKind::DisplayVersion => {
@@ -260,11 +260,11 @@ pub unsafe extern "C" fn ccxr_parse_parameters(argc: c_int, argv: *mut *mut c_ch
                 }
                 ErrorKind::UnknownArgument => {
                     println!("Unknown Argument");
-                    println!("{}", e);
+                    println!("{e}");
                     return ExitCause::MalformedParameter.exit_code();
                 }
                 _ => {
-                    println!("{}", e);
+                    println!("{e}");
                     return ExitCause::Failure.exit_code();
                 }
             }

--- a/src/rust/src/parser.rs
+++ b/src/rust/src/parser.rs
@@ -121,8 +121,7 @@ fn process_word_file(filename: &str, list: &mut Vec<String>) -> Result<(), std::
         let new_len = line.trim().len();
         if new_len > CCX_DECODER_608_SCREEN_WIDTH {
             println!(
-                "Word in line {} too long, max = {} characters.",
-                num, CCX_DECODER_608_SCREEN_WIDTH
+                "Word in line {num} too long, max = {CCX_DECODER_608_SCREEN_WIDTH} characters."
             );
             continue;
         }
@@ -1325,7 +1324,7 @@ impl OptionsExt for Options {
                 }
 
                 if !self.transcript_settings.is_final {
-                    let chars = format!("{}", customtxt).chars().collect::<Vec<char>>();
+                    let chars = format!("{customtxt}").chars().collect::<Vec<char>>();
                     self.transcript_settings.show_start_time = chars[0] == '1';
                     self.transcript_settings.show_end_time = chars[1] == '1';
                     self.transcript_settings.show_mode = chars[2] == '1';


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---
Clippy has introduced a new formatting scheme on the New rust version 1.88 which caused clippy to fail.
This PR fixes those issues. I was notified of this from @hrideshmg 's branch [failing CI](https://github.com/CCExtractor/ccextractor/actions/runs/15909554037/job/44873167652)