### PR TITLE
fix: XDS segmentation faults

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 1.0 (to be released)
 -----------------
+- Fix: Segmentation faults on XDS files
 - Fix: Clippy Errors Based on Rust 1.88
 - IMPROVEMENT: Refactor and optimize Dockerfile
 - Fix: Improved handling of IETF language tags in Matroska files (#1665)

--- a/src/rust/src/decoder/service_decoder.rs
+++ b/src/rust/src/decoder/service_decoder.rs
@@ -1136,9 +1136,14 @@ impl dtvcc_service_decoder {
         window.is_empty = 0;
 
         // Add symbol to window
-        unsafe {
-            let ptr: *mut dtvcc_symbol = window.rows[window.pen_row as usize].add(window.pen_column as usize);
-            *ptr = sym;
+        if window.memory_reserved == 1 {
+            unsafe {
+                let ptr: *mut dtvcc_symbol =
+                    window.rows[window.pen_row as usize].add(window.pen_column as usize);
+                *ptr = sym;
+            }
+        } else {
+            return;
         }
 
         // "Painting" char by pen - attribs
@@ -1227,6 +1232,30 @@ extern "C" fn ccxr_flush_decoder(dtvcc: *mut dtvcc_ctx, decoder: *mut dtvcc_serv
 mod test {
     use super::*;
     use crate::utils::get_zero_allocated_obj;
+
+    fn setup_test_decoder_with_memory() -> dtvcc_service_decoder {
+        let mut decoder = get_zero_allocated_obj::<dtvcc_service_decoder>();
+
+        decoder.current_window = 0;
+        decoder.windows[0].is_defined = 1;
+        decoder.windows[0].row_count = 4;
+        decoder.windows[0].col_count = 4;
+        decoder.windows[0].attribs.print_direction =
+            dtvcc_window_pd::DTVCC_WINDOW_PD_LEFT_RIGHT as i32;
+
+        let layout = Layout::array::<dtvcc_symbol>(CCX_DTVCC_MAX_COLUMNS as usize).unwrap();
+        decoder.windows[0].rows[0] = unsafe { alloc(layout) } as *mut dtvcc_symbol;
+        decoder.windows[0].memory_reserved = 1;
+
+        *decoder
+    }
+
+    fn cleanup_test_decoder(decoder: &mut dtvcc_service_decoder) {
+        let layout = Layout::array::<dtvcc_symbol>(CCX_DTVCC_MAX_COLUMNS as usize).unwrap();
+        unsafe {
+            dealloc(decoder.windows[0].rows[0] as *mut u8, layout);
+        }
+    }
 
     // -------------------------- C0 Commands-------------------------
     #[test]
@@ -1381,13 +1410,7 @@ mod test {
 
     #[test]
     fn test_process_p16() {
-        let mut decoder = get_zero_allocated_obj::<dtvcc_service_decoder>();
-        decoder.current_window = 0;
-        decoder.windows[0].is_defined = 1;
-        decoder.windows[0].row_count = 4;
-        decoder.windows[0].col_count = 4;
-        decoder.windows[0].attribs.print_direction =
-            dtvcc_window_pd::DTVCC_WINDOW_PD_LEFT_RIGHT as i32;
+        let mut decoder = setup_test_decoder_with_memory();
         let block = [b'a', b'b'] as [c_uchar; 2];
 
         decoder.process_p16(&block);
@@ -1396,10 +1419,12 @@ mod test {
         assert_eq!(decoder.windows[0].pen_column, 1);
         unsafe {
             assert_eq!(
-                *decoder.windows[0].rows[0],
+                *decoder.windows[0].rows[0].add(0),
                 dtvcc_symbol::new_16(block[0], block[1])
             );
         }
+
+        cleanup_test_decoder(&mut decoder);
     }
 
     // -------------------------- C1 Commands-------------------------
@@ -1643,14 +1668,7 @@ mod test {
     // -------------------------- G0, G1 and extended Commands-------------------------
     #[test]
     fn test_handle_G0() {
-        let mut decoder = get_zero_allocated_obj::<dtvcc_service_decoder>();
-
-        decoder.current_window = 0;
-        decoder.windows[0].is_defined = 1;
-        decoder.windows[0].row_count = 4;
-        decoder.windows[0].col_count = 4;
-        decoder.windows[0].attribs.print_direction =
-            dtvcc_window_pd::DTVCC_WINDOW_PD_LEFT_RIGHT as i32;
+        let mut decoder = setup_test_decoder_with_memory();
 
         // Case: block[0] == 0x7F
         let block = [0x7F, 0x61];
@@ -1660,7 +1678,7 @@ mod test {
         assert_eq!(decoder.windows[0].pen_column, 1);
         unsafe {
             assert_eq!(
-                decoder.windows[0].rows[0].read().sym,
+                decoder.windows[0].rows[0].add(0).read().sym,
                 CCX_DTVCC_MUSICAL_NOTE_CHAR
             );
         }
@@ -1671,20 +1689,15 @@ mod test {
 
         assert_eq!(return_value, 1);
         unsafe {
-            assert_eq!(decoder.windows[0].rows[0].read().sym, 96);
+            assert_eq!(decoder.windows[0].rows[0].add(1).read().sym, 96);
         }
+
+        cleanup_test_decoder(&mut decoder);
     }
 
     #[test]
     fn test_handle_G1() {
-        let mut decoder = get_zero_allocated_obj::<dtvcc_service_decoder>();
-
-        decoder.current_window = 0;
-        decoder.windows[0].is_defined = 1;
-        decoder.windows[0].row_count = 4;
-        decoder.windows[0].col_count = 4;
-        decoder.windows[0].attribs.print_direction =
-            dtvcc_window_pd::DTVCC_WINDOW_PD_LEFT_RIGHT as i32;
+        let mut decoder = setup_test_decoder_with_memory();
 
         let block = [0x7F, 0x61];
         let return_value = decoder.handle_G1(&block);
@@ -1693,20 +1706,15 @@ mod test {
         assert_eq!(decoder.windows[0].pen_row, 0);
         assert_eq!(decoder.windows[0].pen_column, 1);
         unsafe {
-            assert_eq!(decoder.windows[0].rows[0].read().sym, 0x7F);
+            assert_eq!(decoder.windows[0].rows[0].add(0).read().sym, 0x7F);
         }
+
+        cleanup_test_decoder(&mut decoder);
     }
 
     #[test]
     fn test_handle_extended_char() {
-        let mut decoder = get_zero_allocated_obj::<dtvcc_service_decoder>();
-
-        decoder.current_window = 0;
-        decoder.windows[0].is_defined = 1;
-        decoder.windows[0].row_count = 4;
-        decoder.windows[0].col_count = 4;
-        decoder.windows[0].attribs.print_direction =
-            dtvcc_window_pd::DTVCC_WINDOW_PD_LEFT_RIGHT as i32;
+        let mut decoder = setup_test_decoder_with_memory();
 
         // 0..=0x1F
         let return_value = decoder.handle_extended_char(&[0x1A, 0x61]);
@@ -1718,7 +1726,7 @@ mod test {
         assert_eq!(decoder.windows[0].pen_row, 0);
         assert_eq!(decoder.windows[0].pen_column, 1);
         unsafe {
-            assert_eq!(decoder.windows[0].rows[0].read().sym, 0x5);
+            assert_eq!(decoder.windows[0].rows[0].add(0).read().sym, 0x5);
         }
 
         // 0x80..=0x9F
@@ -1731,8 +1739,10 @@ mod test {
         assert_eq!(decoder.windows[0].pen_row, 0);
         assert_eq!(decoder.windows[0].pen_column, 2);
         unsafe {
-            assert_eq!(decoder.windows[0].rows[0].read().sym, 0x20);
+            assert_eq!(decoder.windows[0].rows[0].add(1).read().sym, 0x20);
         }
+
+        cleanup_test_decoder(&mut decoder);
     }
 
     #[test]
@@ -1757,13 +1767,20 @@ mod test {
         decoder.windows[0].attribs.print_direction =
             dtvcc_window_pd::DTVCC_WINDOW_PD_LEFT_RIGHT as i32;
 
+        let layout = Layout::array::<dtvcc_symbol>(CCX_DTVCC_MAX_COLUMNS as usize).unwrap();
+        decoder.windows[0].rows[0] = unsafe { alloc(layout) } as *mut dtvcc_symbol;
+        decoder.windows[0].memory_reserved = 1;
+
         decoder.process_character(sym);
 
         // Check changes
         assert_eq!(decoder.windows[0].pen_row, 0);
         assert_eq!(decoder.windows[0].pen_column, 1);
         unsafe {
-            assert_eq!(decoder.windows[0].rows[0].read(), dtvcc_symbol::new(0x41));
+            assert_eq!(
+                decoder.windows[0].rows[0].add(0).read(),
+                dtvcc_symbol::new(0x41)
+            );
         }
     }
 }

--- a/src/rust/src/decoder/service_decoder.rs
+++ b/src/rust/src/decoder/service_decoder.rs
@@ -1136,7 +1136,10 @@ impl dtvcc_service_decoder {
         window.is_empty = 0;
 
         // Add symbol to window
-        window.rows[window.pen_row as usize] = Box::into_raw(Box::new(sym));
+        unsafe {
+            let ptr: *mut dtvcc_symbol = window.rows[window.pen_row as usize].add(window.pen_column as usize);
+            *ptr = sym;
+        }
 
         // "Painting" char by pen - attribs
         window.pen_attribs[window.pen_row as usize][window.pen_column as usize] =


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

The regression tests under the XDS category have been failing on Windows due to segmentation faults for a while now. The cause for these errors stem from a small mistake that was made when the CEA-708 decoder functions were ported to Rust.

In specific, here is the offending [line](https://github.com/hrideshmg/ccextractor/blob/54dfce4c89245f71b4ffc71e099e6298550a1cd5/src/rust/src/decoder/service_decoder.rs#L1139):
```Rust
// Add symbol to window
window.rows[window.pen_row as usize] = Box::into_raw(Box::new(sym));
```
To contrast, here is the equivalent C [section](https://github.com/hrideshmg/ccextractor/blob/54dfce4c89245f71b4ffc71e099e6298550a1cd5/src/lib_ccx/ccx_decoders_708.c#L799):
```C
window->rows[window->pen_row][window->pen_column] = symbol;
```

`window.rows` has the following definition: 
```C
dtvcc_symbol *rows[15];
rows[i] = (dtvcc_symbol *)malloc(64 * sizeof(dtvcc_symbol));
```

As we can see, it is an array of pointers where each pointer points to a heap allocated row of `dtvcc_symbols`. In rust, this structure is incorrectly assumed to be an array of `dtvcc_symbols`. I've fixed this by using pointer arithmetic in rust to do the proper operation:
```Rust
unsafe {
    let ptr: *mut dtvcc_symbol =
        window.rows[window.pen_row as usize].add(window.pen_column as usize);
    *ptr = sym;
}
```

The unit tests which directly utilize this operation were also leaking memory due to this, and thus I've made helper functions to properly handle those as well.