### PR TITLE
[Rust] Added Encoder Module

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 1.0 (to be released)
 -----------------
+- New: Add Encoder Module to Rust
 - Fix: Segmentation faults on XDS files
 - Fix: Clippy Errors Based on Rust 1.88
 - IMPROVEMENT: Refactor and optimize Dockerfile

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -19,6 +19,10 @@ int fsync(int fd)
 }
 #endif
 
+#ifndef DISABLE_RUST
+int ccxr_get_str_basic(unsigned char *out_buffer, unsigned char *in_buffer, int trim_subs,
+		  enum ccx_encoding_type in_enc, enum ccx_encoding_type out_enc, int max_len);
+#endif
 // These are the default settings for plain transcripts. No times, no CC or caption mode, and no XDS.
 ccx_encoders_transcript_format ccx_encoders_default_transcript_settings =
     {
@@ -293,6 +297,9 @@ int change_ascii_encoding(unsigned char *dest, unsigned char *src, int len, enum
 int get_str_basic(unsigned char *out_buffer, unsigned char *in_buffer, int trim_subs,
 		  enum ccx_encoding_type in_enc, enum ccx_encoding_type out_enc, int max_len)
 {
+#ifndef DISABLE_RUST
+	return ccxr_get_str_basic(out_buffer, in_buffer, trim_subs, in_enc, out_enc, max_len);
+#else
 	int last_non_blank = -1;
 	int first_non_blank = -1;
 	int len = 0;
@@ -305,7 +312,6 @@ int get_str_basic(unsigned char *out_buffer, unsigned char *in_buffer, int trim_
 		*out_buffer = 0;
 		return 0;
 	}
-
 	// change encoding only when required
 	switch (in_enc)
 	{
@@ -331,6 +337,7 @@ int get_str_basic(unsigned char *out_buffer, unsigned char *in_buffer, int trim_
 		return (unsigned)len; // Return length
 
 	return 0; // Return length
+#endif
 }
 
 int write_subtitle_file_footer(struct encoder_ctx *ctx, struct ccx_s_write *out)

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -21,7 +21,7 @@ int fsync(int fd)
 
 #ifndef DISABLE_RUST
 int ccxr_get_str_basic(unsigned char *out_buffer, unsigned char *in_buffer, int trim_subs,
-		  enum ccx_encoding_type in_enc, enum ccx_encoding_type out_enc, int max_len);
+		       enum ccx_encoding_type in_enc, enum ccx_encoding_type out_enc, int max_len);
 #endif
 // These are the default settings for plain transcripts. No times, no CC or caption mode, and no XDS.
 ccx_encoders_transcript_format ccx_encoders_default_transcript_settings =

--- a/src/lib_ccx/ccx_encoders_spupng.c
+++ b/src/lib_ccx/ccx_encoders_spupng.c
@@ -29,18 +29,6 @@ FT_Face face_regular = NULL;
 FT_Face face_italics = NULL;
 FT_Face face = NULL;
 
-struct spupng_t
-{
-	FILE *fpxml;
-	FILE *fppng;
-	char *dirname;
-	char *pngfile;
-	char *relative_path_png;
-	int fileIndex;
-	int xOffset;
-	int yOffset;
-};
-
 #define CCPL (ccfont2_width / CCW * ccfont2_height / CCH)
 
 static int initialized = 0;

--- a/src/lib_ccx/ccx_encoders_structs.h
+++ b/src/lib_ccx/ccx_encoders_structs.h
@@ -29,4 +29,16 @@ struct ccx_s_write
 
 };
 
+struct spupng_t
+{
+	FILE *fpxml;
+	FILE *fppng;
+	char *dirname;
+	char *pngfile;
+	char *relative_path_png;
+	int fileIndex;
+	int xOffset;
+	int yOffset;
+};
+
 #endif

--- a/src/rust/build.rs
+++ b/src/rust/build.rs
@@ -12,6 +12,9 @@ fn main() {
         "writercwtdata",
         "version",
         "set_binary_mode",
+        "net_send_header", // shall be removed after NET
+        "write_spumux_footer",
+        "write_spumux_header",
     ]);
 
     #[cfg(feature = "hardsubx_ocr")]
@@ -39,6 +42,7 @@ fn main() {
         "ccx_encoding_type",
         "ccx_decoder_608_settings",
         "ccx_decoder_608_report",
+        "eia608_screen",
         "uint8_t",
         "word_list",
     ]);

--- a/src/rust/src/encoder/common.rs
+++ b/src/rust/src/encoder/common.rs
@@ -1,0 +1,484 @@
+use lib_ccxr::info;
+use lib_ccxr::util::encoding::*;
+use std::cmp;
+use std::convert::TryFrom;
+
+pub enum EncoderError {
+    Retry = -100,           // CCX_EAGAIN
+    EOF = -101,             // CCX_EOF
+    InvalidArgument = -102, // CCX_EINVAL
+    Unsupported = -103,     // CCX_ENOSUPP
+    OutOfMemory = -104,     // CCX_ENOMEM
+}
+fn find_limit_characters(
+    line: &[u8],
+    first_non_blank: &mut i32,
+    last_non_blank: &mut i32,
+    max_len: usize,
+) {
+    // initialize to -1 (meaning “not found”)
+    *first_non_blank = -1;
+    *last_non_blank = -1;
+
+    // clamp to avoid out‑of‑bounds
+    let limit = cmp::min(line.len(), max_len);
+
+    for (i, &c) in line.iter().take(limit).enumerate() {
+        // detect non‑blank
+        if c != b' ' && c != 0x89 {
+            if *first_non_blank < 0 {
+                *first_non_blank = i as i32;
+            }
+            *last_non_blank = i as i32;
+        }
+        // break on end‑of‑string or newline
+        if c == b'\0' || c == b'\n' || c == b'\r' {
+            break;
+        }
+    }
+}
+fn change_utf8_encoding(dest: &mut [u8], src: &[u8], len: i32, out_enc: Encoding) -> i32 {
+    let mut dest_idx = 0;
+    let mut src_idx = 0;
+    let max = usize::min(src.len(), len as usize);
+
+    while src_idx < max {
+        let c = src[src_idx];
+        let c_len: usize;
+
+        if c < 0x80 {
+            c_len = 1;
+        } else if (c & 0x20) == 0 {
+            c_len = 2;
+        } else if (c & 0x10) == 0 {
+            c_len = 3;
+        } else if (c & 0x08) == 0 {
+            c_len = 4;
+        } else if (c & 0x04) == 0 {
+            c_len = 5;
+        } else {
+            c_len = 1; // Invalid UTF-8, treat as single byte
+        }
+
+        match out_enc {
+            Encoding::Utf8 => {
+                let to_copy = max;
+                if to_copy <= dest.len() {
+                    dest[..to_copy].copy_from_slice(&src[..to_copy]);
+                    return to_copy as i32;
+                } else {
+                    return EncoderError::Unsupported as i32;
+                }
+            }
+            Encoding::Latin1 => {
+                if c_len == 1 {
+                    dest[dest_idx] = src[src_idx];
+                    dest_idx += 1;
+                } else if c_len == 2 {
+                    if (src[src_idx + 1] & 0x40) == 0 {
+                        let cp = utf8_to_latin1_map(
+                            (((src[src_idx] & 0x1F) as u32) << 6)
+                                | ((src[src_idx + 1] & 0x3F) as u32),
+                        ) as u16;
+                        if cp <= 255 {
+                            dest[dest_idx] = cp as u8;
+                        } else {
+                            dest[dest_idx] = b'?';
+                        }
+                        dest_idx += 1;
+                    } else {
+                        dest[dest_idx] = b'?';
+                        dest_idx += 1;
+                    }
+                } else if c_len == 3 {
+                    if (src[src_idx + 1] & 0x40) == 0 && (src[src_idx + 2] & 0x40) == 0 {
+                        let cp = utf8_to_latin1_map(
+                            (((src[src_idx] & 0x0F) as u32) << 12)
+                                | (((src[src_idx + 1] & 0x3F) as u32) << 6)
+                                | ((src[src_idx + 2] & 0x3F) as u32),
+                        ) as u16;
+                        if cp <= 255 {
+                            dest[dest_idx] = cp as u8;
+                        } else {
+                            dest[dest_idx] = b'?';
+                        }
+                        dest_idx += 1;
+                    } else {
+                        dest[dest_idx] = b'?';
+                        dest_idx += 1;
+                    }
+                } else if c_len == 4 {
+                    if (src[src_idx + 1] & 0x40) == 0
+                        && (src[src_idx + 2] & 0x40) == 0
+                        && (src[src_idx + 3] & 0x40) == 0
+                    {
+                        let cp = utf8_to_latin1_map(
+                            (((src[src_idx] & 0x07) as u32) << 18)
+                                | (((src[src_idx + 1] & 0x3F) as u32) << 12)
+                                | (((src[src_idx + 2] & 0x3F) as u32) << 6)
+                                | ((src[src_idx + 3] & 0x3F) as u32),
+                        ) as u16;
+                        if cp <= 255 {
+                            dest[dest_idx] = cp as u8;
+                        } else {
+                            dest[dest_idx] = b'?';
+                        }
+                        dest_idx += 1;
+                    } else {
+                        dest[dest_idx] = b'?';
+                        dest_idx += 1;
+                    }
+                } else if c_len == 5 {
+                    if (src[src_idx + 1] & 0x40) == 0
+                        && (src[src_idx + 2] & 0x40) == 0
+                        && (src[src_idx + 3] & 0x40) == 0
+                        && (src[src_idx + 4] & 0x40) == 0
+                    {
+                        let cp = utf8_to_latin1_map(
+                            (((src[src_idx] & 0x03) as u32) << 24u32)
+                                | (((src[src_idx + 1] & 0x3F) as u32) << 18u32)
+                                | (((src[src_idx + 2] & 0x3F) as u32) << 12u32)
+                                | (((src[src_idx + 3] & 0x3F) as u32) << 6u32)
+                                | ((src[src_idx + 4] & 0x3F) as u32),
+                        ) as u16;
+                        if cp <= 255 {
+                            dest[dest_idx] = cp as u8;
+                        } else {
+                            dest[dest_idx] = b'?';
+                        }
+                        dest_idx += 1;
+                    } else {
+                        dest[dest_idx] = b'?';
+                        dest_idx += 1;
+                    }
+                } else {
+                    dest[dest_idx] = b'?';
+                    dest_idx += 1;
+                }
+            }
+            Encoding::Ucs2 => {
+                return EncoderError::Unsupported as i32;
+            }
+            Encoding::Line21 => {
+                if c_len == 1 {
+                    dest[dest_idx] = src[src_idx];
+                    dest_idx += 1;
+                } else {
+                    dest[dest_idx] = b'?';
+                    dest_idx += 1;
+                }
+            }
+        }
+        src_idx += c_len;
+    }
+
+    if dest_idx < dest.len() {
+        dest[dest_idx] = 0;
+    }
+    dest_idx as i32
+}
+#[allow(unused_variables)]
+fn change_latin1_encoding(dest: &mut [u8], src: &[u8], len: i32, out_enc: Encoding) -> i32 {
+    EncoderError::Unsupported as i32
+}
+
+#[allow(unused_variables)]
+fn change_unicode_encoding(dest: &mut [u8], src: &[u8], len: i32, out_enc: Encoding) -> i32 {
+    EncoderError::Unsupported as i32
+}
+
+pub fn change_ascii_encoding(
+    dest: &mut Vec<u8>,
+    src: &[u8],
+    out_enc: Encoding,
+) -> Result<usize, i32> {
+    dest.clear();
+
+    for &c in src {
+        match out_enc {
+            Encoding::Utf8 => {
+                let (utf8_packed, byte_count) = line21_to_utf8(c);
+
+                // Extract bytes based on count (big-endian storage)
+                match byte_count {
+                    1 => dest.push(utf8_packed as u8),
+                    2 => {
+                        dest.push((utf8_packed >> 8) as u8);
+                        dest.push(utf8_packed as u8);
+                    }
+                    3 => {
+                        dest.push((utf8_packed >> 16) as u8);
+                        dest.push((utf8_packed >> 8) as u8);
+                        dest.push(utf8_packed as u8);
+                    }
+                    _ => return Err(-1), // Invalid byte count
+                }
+            }
+            Encoding::Latin1 => {
+                let latin1_char = line21_to_latin1(c);
+                dest.push(latin1_char);
+            }
+            Encoding::Ucs2 => {
+                let ucs2_char = line21_to_ucs2(c);
+                // UCS-2 is 2 bytes, little-endian
+                dest.extend_from_slice(&ucs2_char.to_le_bytes());
+            }
+            Encoding::Line21 => {
+                dest.extend_from_slice(src);
+                return Ok(src.len());
+            }
+        }
+    }
+
+    // Add null terminator
+    dest.push(0);
+
+    Ok(dest.len() - 1) // Return length without null terminator
+}
+
+fn utf8_to_latin1_map(character: u32) -> Latin1Char {
+    ucs2_to_latin1(char_to_ucs2(char::try_from(character).unwrap()))
+}
+pub fn get_str_basic(
+    out_buffer: &mut Vec<u8>,
+    in_buffer: &[u8],
+    trim_subs: bool,
+    in_enc: Encoding,
+    out_enc: Encoding,
+    max_len: i32,
+) -> i32 {
+    let mut last_non_blank: i32 = -1;
+    let mut first_non_blank: i32 = -1;
+    let len;
+
+    find_limit_characters(
+        in_buffer,
+        &mut first_non_blank,
+        &mut last_non_blank,
+        max_len as usize,
+    );
+
+    if first_non_blank == -1 {
+        // No non-blank characters found, return empty
+        out_buffer.clear();
+        out_buffer.push(0); // null terminator only
+        return 0;
+    }
+
+    // Calculate the actual content length (without trailing spaces)
+    let mut content_length = last_non_blank - first_non_blank + 1;
+
+    if !trim_subs {
+        first_non_blank = 0;
+        // If not trimming, we need to recalculate to include leading content
+        content_length = last_non_blank + 1;
+    }
+
+    if (first_non_blank + content_length) as usize > in_buffer.len() {
+        out_buffer.clear();
+        out_buffer.push(0);
+        return 0;
+    }
+
+    // Clear the output buffer
+    out_buffer.clear();
+
+    // change encoding only when required
+    match in_enc {
+        Encoding::Utf8 => {
+            let mut temp_buffer = vec![0u8; (content_length * 4) as usize]; // Allow extra space for multi-byte encodings
+            len = change_utf8_encoding(
+                &mut temp_buffer,
+                &in_buffer[first_non_blank as usize..],
+                content_length,
+                out_enc,
+            );
+            if len > 0 {
+                out_buffer.extend_from_slice(&temp_buffer[..len as usize]);
+            }
+        }
+        Encoding::Latin1 => {
+            let mut temp_buffer = vec![0u8; (content_length * 4) as usize];
+            len = change_latin1_encoding(
+                &mut temp_buffer,
+                &in_buffer[first_non_blank as usize..],
+                content_length,
+                out_enc,
+            );
+            if len > 0 {
+                out_buffer.extend_from_slice(&temp_buffer[..len as usize]);
+            }
+        }
+        Encoding::Ucs2 => {
+            let mut temp_buffer = vec![0u8; (content_length * 4) as usize];
+            len = change_unicode_encoding(
+                &mut temp_buffer,
+                &in_buffer[first_non_blank as usize..],
+                content_length,
+                out_enc,
+            );
+            if len > 0 {
+                out_buffer.extend_from_slice(&temp_buffer[..len as usize]);
+            }
+        }
+        Encoding::Line21 => {
+            let input_slice =
+                &in_buffer[first_non_blank as usize..(first_non_blank + content_length) as usize];
+            len = change_ascii_encoding(out_buffer, input_slice, out_enc)
+                .unwrap_or(EncoderError::Retry as usize) as i32;
+        }
+    }
+
+    if len < 0 {
+        info!("WARNING: Could not encode in specified format\n");
+        out_buffer.clear();
+        out_buffer.push(0);
+        0
+    } else if len == EncoderError::Unsupported as i32 {
+        info!("WARNING: Encoding is not yet supported\n");
+        out_buffer.clear();
+        out_buffer.push(0);
+        return 0;
+    } else {
+        // Add null terminator
+        out_buffer.push(0);
+        return len; // Return actual content length, not max_len
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_line_with_content() {
+        let line = b"  hello world  \n";
+        let mut first_non_blank = 0;
+        let mut last_non_blank = 0;
+
+        find_limit_characters(line, &mut first_non_blank, &mut last_non_blank, 15);
+
+        assert_eq!(first_non_blank, 2); // 'h' is at index 2
+        assert_eq!(last_non_blank, 12); // 'd' is at index 12
+    }
+
+    #[test]
+    fn test_line_with_special_chars() {
+        let line = b" \x89 abc \x89 def \r";
+        let mut first_non_blank = 0;
+        let mut last_non_blank = 0;
+
+        find_limit_characters(line, &mut first_non_blank, &mut last_non_blank, 20);
+
+        assert_eq!(first_non_blank, 3); // 'a' is at index 3
+    }
+    #[test]
+    fn test_utf8_to_utf8() {
+        let src = b"Hello, \xC3\xA9world!"; // "Hello, éworld!"
+        let mut dest = [0u8; 20];
+
+        let result = change_utf8_encoding(&mut dest, src, src.len() as i32, Encoding::Utf8);
+
+        assert_eq!(result, src.len() as i32);
+        assert_eq!(&dest[..src.len()], src);
+    }
+
+    #[test]
+    fn test_utf8_to_ascii() {
+        let src = b"Hello, \xC3\xA9world!"; // "Hello, éworld!"
+        let mut dest = [0u8; 20];
+
+        let result = change_utf8_encoding(&mut dest, src, src.len() as i32, Encoding::Line21);
+
+        assert_eq!(result, 14); // "Hello, ?world!" (14 chars)
+        assert_eq!(&dest[..14], b"Hello, ?world!");
+    }
+
+    #[test]
+    fn test_unsupported_encoding() {
+        let src = b"Hello";
+        let mut dest = [0u8; 10];
+
+        let result = change_utf8_encoding(&mut dest, src, src.len() as i32, Encoding::Ucs2);
+
+        assert_eq!(result, EncoderError::Unsupported as i32);
+    }
+    #[test]
+    fn test_ascii_to_ascii() {
+        let src = b"Hello World!";
+        let mut dest = Vec::with_capacity(20);
+        let result = change_ascii_encoding(&mut dest, src, Encoding::Line21);
+
+        assert_eq!(result.unwrap(), src.len());
+        assert_eq!(&dest[..src.len()], src);
+    }
+
+    #[test]
+    fn test_ascii_to_utf8() {
+        let src = b"Hello";
+        let mut dest = Vec::with_capacity(20);
+
+        let result = change_ascii_encoding(&mut dest, src, Encoding::Utf8);
+
+        assert_eq!(result.unwrap(), 5); // Each ASCII char becomes 1 UTF-8 byte
+        assert_eq!(&dest[..5], b"Hello");
+        assert_eq!(dest[5], 0); // Null terminator
+    }
+
+    #[test]
+    fn test_ascii_to_latin1() {
+        let src = b"Test";
+        let mut dest = Vec::with_capacity(20);
+
+        let result = change_ascii_encoding(&mut dest, src, Encoding::Latin1);
+
+        assert_eq!(result.unwrap(), 4);
+        assert_eq!(&dest[..4], b"Test");
+        assert_eq!(dest[4], 0); // Null terminator
+    }
+
+    #[test]
+    fn test_ascii_to_unicode() {
+        let src = b"Hi";
+        let mut dest = Vec::with_capacity(20);
+
+        let result = change_ascii_encoding(&mut dest, src, Encoding::Ucs2);
+
+        assert_eq!(result.unwrap(), 4); // Each ASCII char becomes 2 Unicode bytes
+        assert_eq!(dest[4], 0); // Null terminator
+    }
+
+    #[test]
+    fn test_get_str_basic_with_trim() {
+        let in_buffer = b"  Hello  \0";
+        let mut out_buffer = Vec::with_capacity(20);
+
+        let result = get_str_basic(
+            &mut out_buffer,
+            in_buffer,
+            true,
+            Encoding::Line21,
+            Encoding::Line21,
+            10,
+        );
+
+        assert!(result > 0);
+    }
+
+    #[test]
+    fn test_get_str_basic_without_trim() {
+        let in_buffer = b"  Hello  \0";
+        let mut out_buffer = Vec::with_capacity(20);
+
+        let result = get_str_basic(
+            &mut out_buffer,
+            in_buffer,
+            false,
+            Encoding::Line21,
+            Encoding::Line21,
+            10,
+        );
+
+        assert!(result > 0);
+    }
+}

--- a/src/rust/src/encoder/g608.rs
+++ b/src/rust/src/encoder/g608.rs
@@ -1,0 +1,311 @@
+use crate::bindings::{
+    ccx_encoding_type_CCX_ENC_ASCII, ccx_encoding_type_CCX_ENC_LATIN_1,
+    ccx_encoding_type_CCX_ENC_UNICODE, ccx_encoding_type_CCX_ENC_UTF_8, eia608_screen, encoder_ctx,
+    font_bits_FONT_ITALICS, font_bits_FONT_REGULAR, font_bits_FONT_UNDERLINED,
+    font_bits_FONT_UNDERLINED_ITALICS,
+};
+use crate::encoder::headers_and_footers::{encode_line, write_raw};
+use crate::libccxr_exports::time::ccxr_millis_to_time;
+use lib_ccxr::util::encoding::{line21_to_latin1, line21_to_ucs2, line21_to_utf8};
+use std::io;
+use std::os::raw::{c_int, c_uchar, c_uint, c_void};
+
+/// Write data to file descriptor with retry logic
+pub fn write_wrapped(fd: c_int, buf: &[u8]) -> Result<(), io::Error> {
+    let mut remaining = buf.len();
+    let mut current_buf = buf.as_ptr();
+
+    while remaining > 0 {
+        let written = write_raw(fd, current_buf as *const c_void, remaining);
+        if written == -1 {
+            return Err(io::Error::last_os_error());
+        }
+        let bytes_written = written as usize;
+        unsafe {
+            current_buf = current_buf.add(bytes_written);
+        }
+        remaining -= bytes_written;
+    }
+
+    Ok(())
+}
+
+/// Get line characters encoded according to context encoding
+pub fn get_line_encoded(
+    ctx: &encoder_ctx,
+    buffer: &mut [c_uchar],
+    line_num: usize,
+    data: &eia608_screen,
+) -> c_uint {
+    let mut buffer_pos = 0;
+    let line = &data.characters[line_num];
+
+    for i in line.iter().take(33) {
+        let bytes_written = match ctx.encoding {
+            ccx_encoding_type_CCX_ENC_UTF_8 => {
+                let (utf8_packed, byte_count) = line21_to_utf8(*i);
+
+                // Extract bytes based on count (big-endian storage)
+                match byte_count {
+                    1 => {
+                        if buffer_pos < buffer.len() {
+                            buffer[buffer_pos] = utf8_packed as c_uchar;
+                            1
+                        } else {
+                            0
+                        }
+                    }
+                    2 => {
+                        if buffer_pos + 1 < buffer.len() {
+                            buffer[buffer_pos] = (utf8_packed >> 8) as c_uchar;
+                            buffer[buffer_pos + 1] = utf8_packed as c_uchar;
+                            2
+                        } else {
+                            0
+                        }
+                    }
+                    3 => {
+                        if buffer_pos + 2 < buffer.len() {
+                            buffer[buffer_pos] = (utf8_packed >> 16) as c_uchar;
+                            buffer[buffer_pos + 1] = (utf8_packed >> 8) as c_uchar;
+                            buffer[buffer_pos + 2] = utf8_packed as c_uchar;
+                            3
+                        } else {
+                            0
+                        }
+                    }
+                    _ => 0, // Invalid byte count
+                }
+            }
+            ccx_encoding_type_CCX_ENC_LATIN_1 => {
+                if buffer_pos < buffer.len() {
+                    let latin1_char = line21_to_latin1(*i);
+                    buffer[buffer_pos] = latin1_char as c_uchar;
+                    1
+                } else {
+                    0
+                }
+            }
+            ccx_encoding_type_CCX_ENC_UNICODE => {
+                if buffer_pos + 1 < buffer.len() {
+                    let ucs2_char = line21_to_ucs2(*i);
+                    // UCS-2 is 2 bytes, little-endian
+                    let bytes = ucs2_char.to_le_bytes();
+                    buffer[buffer_pos] = bytes[0] as c_uchar;
+                    buffer[buffer_pos + 1] = bytes[1] as c_uchar;
+                    2
+                } else {
+                    0
+                }
+            }
+            ccx_encoding_type_CCX_ENC_ASCII => {
+                if buffer_pos < buffer.len() {
+                    buffer[buffer_pos] = *i;
+                    1
+                } else {
+                    0
+                }
+            }
+            _ => {
+                0 // This should never be reached
+            }
+        };
+
+        buffer_pos += bytes_written;
+
+        // Break if we've run out of buffer space
+        if bytes_written == 0 {
+            break;
+        }
+    }
+
+    buffer_pos as c_uint
+}
+/// Get color information encoded as characters
+pub fn get_color_encoded(
+    _ctx: &encoder_ctx,
+    buffer: &mut [c_uchar],
+    line_num: usize,
+    data: &eia608_screen,
+) -> c_uint {
+    let mut buffer_pos = 0;
+    for i in 0..32 {
+        if buffer_pos >= buffer.len() {
+            break;
+        }
+        let color_val = data.colors[line_num][i] as u8;
+        buffer[buffer_pos] = if color_val < 10 {
+            color_val + b'0'
+        } else {
+            b'E'
+        };
+        buffer_pos += 1;
+    }
+    if buffer_pos < buffer.len() {
+        buffer[buffer_pos] = 0;
+    }
+    buffer_pos as c_uint
+}
+
+/// Get font information encoded as characters
+pub fn get_font_encoded(
+    _ctx: &encoder_ctx,
+    buffer: &mut [c_uchar],
+    line_num: usize,
+    data: &eia608_screen,
+) -> c_uint {
+    let mut buffer_pos = 0;
+
+    for i in 0..32 {
+        if buffer_pos >= buffer.len() {
+            break;
+        }
+
+        let font_val = data.fonts[line_num][i];
+        buffer[buffer_pos] = match font_val {
+            font_bits_FONT_REGULAR => b'R',
+            font_bits_FONT_UNDERLINED_ITALICS => b'B',
+            font_bits_FONT_UNDERLINED => b'U',
+            font_bits_FONT_ITALICS => b'I',
+            _ => b'E',
+        };
+        buffer_pos += 1;
+    }
+
+    buffer_pos as c_uint
+}
+
+/// Write CC buffer in G608 format
+pub fn write_cc_buffer_as_g608(data: &eia608_screen, context: &mut encoder_ctx) -> c_int {
+    let mut wrote_something = 0;
+
+    // Convert start and end times
+    let mut h1: u32 = 0;
+    let mut m1: u32 = 0;
+    let mut s1: u32 = 0;
+    let mut ms1: u32 = 0;
+
+    let mut h2: u32 = 0;
+    let mut m2: u32 = 0;
+    let mut s2: u32 = 0;
+    let mut ms2: u32 = 0;
+
+    unsafe {
+        ccxr_millis_to_time(data.start_time, &mut h1, &mut m1, &mut s1, &mut ms1);
+        ccxr_millis_to_time(data.end_time - 1, &mut h2, &mut m2, &mut s2, &mut ms2);
+    }
+
+    // Increment counter
+    context.srt_counter += 1;
+
+    // Create timeline string for counter
+    let counter_line = format!("{}{}", context.srt_counter, unsafe {
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+            context.encoded_crlf.as_ptr(),
+            context.encoded_crlf_length as usize,
+        ))
+    });
+
+    // Encode and write counter line
+    let buffer_slice =
+        unsafe { std::slice::from_raw_parts_mut(context.buffer, context.capacity as usize) };
+    let used = encode_line(context, buffer_slice, counter_line.as_bytes());
+
+    if write_wrapped(unsafe { (*context.out).fh }, &buffer_slice[..used as usize]).is_err() {
+        return 0;
+    }
+
+    // Create timeline string for timestamps
+    let timestamp_line = format!(
+        "{:02}:{:02}:{:02},{:03} --> {:02}:{:02}:{:02},{:03}{}",
+        h1,
+        m1,
+        s1,
+        ms1,
+        h2,
+        m2,
+        s2,
+        ms2,
+        unsafe {
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+                context.encoded_crlf.as_ptr(),
+                context.encoded_crlf_length as usize,
+            ))
+        }
+    );
+
+    // Encode and write timestamp line
+    let used = encode_line(context, buffer_slice, timestamp_line.as_bytes());
+
+    if write_wrapped(unsafe { (*context.out).fh }, &buffer_slice[..used as usize]).is_err() {
+        return 0;
+    }
+
+    // Write all 15 lines with their encoding information
+    for i in 0..15 {
+        let subline_slice = unsafe {
+            std::slice::from_raw_parts_mut(context.subline, 1024) // temporary, should be inputted after encoder_ctx => EncoderCtx
+        };
+
+        // Get line encoded
+        let length = get_line_encoded(context, subline_slice, i, data);
+        if write_wrapped(
+            unsafe { (*context.out).fh },
+            &subline_slice[..length as usize],
+        )
+        .is_err()
+        {
+            return 0;
+        }
+
+        // Get color encoded
+        let length = get_color_encoded(context, subline_slice, i, data);
+        if write_wrapped(
+            unsafe { (*context.out).fh },
+            &subline_slice[..length as usize],
+        )
+        .is_err()
+        {
+            return 0;
+        }
+
+        // Get font encoded
+        let length = get_font_encoded(context, subline_slice, i, data);
+        if write_wrapped(
+            unsafe { (*context.out).fh },
+            &subline_slice[..length as usize],
+        )
+        .is_err()
+        {
+            return 0;
+        }
+
+        // Write CRLF
+        let crlf_slice = unsafe {
+            std::slice::from_raw_parts(
+                context.encoded_crlf.as_ptr(),
+                context.encoded_crlf_length as usize,
+            )
+        };
+
+        if write_wrapped(unsafe { (*context.out).fh }, crlf_slice).is_err() {
+            return 0;
+        }
+
+        wrote_something = 1;
+    }
+
+    // Write final CRLF
+    let crlf_slice = unsafe {
+        std::slice::from_raw_parts(
+            context.encoded_crlf.as_ptr(),
+            context.encoded_crlf_length as usize,
+        )
+    };
+
+    if write_wrapped(unsafe { (*context.out).fh }, crlf_slice).is_err() {
+        return 0;
+    }
+
+    wrote_something
+}

--- a/src/rust/src/encoder/headers_and_footers.rs
+++ b/src/rust/src/encoder/headers_and_footers.rs
@@ -1,0 +1,539 @@
+#![allow(dead_code)]
+use crate::bindings::{
+    ccx_encoding_type_CCX_ENC_LATIN_1, ccx_encoding_type_CCX_ENC_UNICODE,
+    ccx_encoding_type_CCX_ENC_UTF_8, ccx_output_format, ccx_s_write, encoder_ctx, net_send_header,
+    write_spumux_footer, write_spumux_header,
+};
+use crate::ccx_options;
+use lib_ccxr::common::{BROADCAST_HEADER, LITTLE_ENDIAN_BOM, UTF8_BOM};
+use lib_ccxr::util::log::DebugMessageFlag;
+use lib_ccxr::{debug, info};
+use std::alloc::{alloc, dealloc, Layout};
+use std::fs::File;
+use std::io::Write;
+use std::os::fd::FromRawFd;
+use std::os::raw::{c_int, c_uchar, c_uint, c_void};
+use std::ptr;
+const CCD_HEADER: &[u8] = b"SCC_disassembly V1.2";
+const SCC_HEADER: &[u8] = b"Scenarist_SCC V1.0";
+
+const SSA_HEADER: &str = "[Script Info]\n\
+Title: Default file\n\
+ScriptType: v4.00+\n\
+\n\
+[V4+ Styles]\n\
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding\n\
+Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,1,1,2,10,10,10,0\n\
+\n\
+[Events]\n\
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\n\
+\n";
+const SAMI_HEADER: &str = "<SAMI>\n\
+<HEAD>\n\
+<STYLE TYPE=\"text/css\">\n\
+<!--\n\
+P {margin-left: 16pt; margin-right: 16pt; margin-bottom: 16pt; margin-top: 16pt;\n\
+text-align: center; font-size: 18pt; font-family: arial; font-weight: bold; color: #f0f0f0;}\n\
+.UNKNOWNCC {Name:Unknown; lang:en-US; SAMIType:CC;}\n\
+-->\n\
+</STYLE>\n\
+</HEAD>\n\n\
+<BODY>\n";
+const SMPTETT_HEADER: &str = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?>\n  <tt xmlns=\"http://www.w3.org/ns/ttml\" xmlns:ttp=\"http://www.w3.org/ns/ttml#parameter\" ttp:dropMode=\"dropNTSC\" ttp:frameRate=\"30\" ttp:frameRateMultiplier=\"1000 1001\" ttp:timeBase=\"smpte\" xmlns:m608=\"http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt#cea608\" xmlns:smpte=\"http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt\" xmlns:ttm=\"http://www.w3.org/ns/ttml#metadata\" xmlns:tts=\"http://www.w3.org/ns/ttml#styling\">\n  <head>\n    <styling>\n      <style tts:color=\"white\" tts:fontFamily=\"monospace\" tts:fontWeight=\"normal\" tts:textAlign=\"left\" xml:id=\"basic\"/>\n    </styling>\n    <layout>\n      <region tts:backgroundColor=\"transparent\" xml:id=\"pop1\"/>\n      <region tts:backgroundColor=\"transparent\" xml:id=\"paint\"/>\n      <region tts:backgroundColor=\"transparent\" xml:id=\"rollup2\"/>\n      <region tts:backgroundColor=\"transparent\" xml:id=\"rollup3\"/>\n      <region tts:backgroundColor=\"transparent\" xml:id=\"rollup4\"/>\n    </layout>\n    <metadata/>\n    <smpte:information m608:captionService=\"F1C1CC\" m608:channel=\"cc1\"/>\n  </head>\n  <body>\n    <div>\n";
+const SIMPLE_XML_HEADER: &str = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<captions>\n";
+
+const WEBVTT_HEADER: &[&str] = &["WEBVTT\n", "\n", "\n"];
+
+const RCWT_HEADER: &[u8] = &[0xCC, 0xCC, 0xED, 0xCC, 0x00, 0x50, 0, 1, 0, 0, 0]; // "RCWT" + version
+
+pub fn encode_line(ctx: &mut encoder_ctx, buffer: &mut [c_uchar], text: &[u8]) -> c_uint {
+    if buffer.is_empty() {
+        return 0;
+    }
+
+    let mut bytes: c_uint = 0;
+    let mut buffer_pos = 0;
+    let mut text_pos = 0;
+    let text_len = text.iter().position(|&b| b == 0).unwrap_or(text.len());
+    while text_pos < text_len {
+        let current_byte = text[text_pos];
+
+        match ctx.encoding {
+            ccx_encoding_type_CCX_ENC_UTF_8 | ccx_encoding_type_CCX_ENC_LATIN_1 => {
+                if buffer_pos + 1 >= buffer.len() {
+                    break;
+                }
+
+                buffer[buffer_pos] = current_byte;
+                bytes += 1;
+                buffer_pos += 1;
+            }
+
+            ccx_encoding_type_CCX_ENC_UNICODE => {
+                if buffer_pos + 2 >= buffer.len() {
+                    break;
+                }
+
+                buffer[buffer_pos] = current_byte;
+                buffer[buffer_pos + 1] = 0;
+                bytes += 2;
+                buffer_pos += 2;
+            }
+            _ => {}
+        }
+        text_pos += 1;
+    }
+
+    // Add null terminator if there's space
+    if buffer_pos < buffer.len() {
+        buffer[buffer_pos] = 0;
+    }
+
+    bytes
+}
+pub fn write_subtitle_file_footer(ctx: &mut encoder_ctx, out: &mut ccx_s_write) -> c_int {
+    let mut ret: c_int = 0;
+    let mut str_buffer = [0u8; 1024];
+
+    match ctx.write_format {
+        ccx_output_format::CCX_OF_SAMI => {
+            let footer = b"</BODY></SAMI>\n\0";
+
+            // Bounds check for str_buffer
+            if footer.len() > str_buffer.len() {
+                return -1;
+            }
+
+            str_buffer[..footer.len()].copy_from_slice(footer);
+
+            if ctx.encoding != ccx_encoding_type_CCX_ENC_UNICODE {
+                debug!(msg_type = DebugMessageFlag::DECODER_608; "\r{}\n",
+                    std::str::from_utf8(&str_buffer[..footer.len()-1]).unwrap_or(""));
+            }
+
+            // Create safe slice from buffer pointer and capacity
+            let buffer_slice =
+                unsafe { std::slice::from_raw_parts_mut(ctx.buffer, ctx.capacity as usize) };
+            let text_slice = &str_buffer[..footer.len()];
+            let used = encode_line(ctx, buffer_slice, text_slice);
+
+            // Bounds check for buffer access
+            if used > ctx.capacity {
+                return -1;
+            }
+
+            ret = write_raw(out.fh, ctx.buffer as *const c_void, used as usize) as c_int;
+
+            if ret != used as c_int {
+                info!("WARNING: loss of data\n");
+            }
+        }
+
+        ccx_output_format::CCX_OF_SMPTETT => {
+            let footer = b"    </div>\n  </body>\n</tt>\n\0";
+
+            // Bounds check for str_buffer
+            if footer.len() > str_buffer.len() {
+                return -1;
+            }
+
+            str_buffer[..footer.len()].copy_from_slice(footer);
+
+            if ctx.encoding != ccx_encoding_type_CCX_ENC_UNICODE {
+                debug!(msg_type = DebugMessageFlag::DECODER_608; "\r{}\n",
+                    std::str::from_utf8(&str_buffer[..footer.len()-1]).unwrap_or(""));
+            }
+
+            // Create safe slice from buffer pointer and capacity
+            let buffer_slice =
+                unsafe { std::slice::from_raw_parts_mut(ctx.buffer, ctx.capacity as usize) };
+            let text_slice = &str_buffer[..footer.len()];
+            let used = encode_line(ctx, buffer_slice, text_slice);
+
+            // Bounds check for buffer access
+            if used > ctx.capacity {
+                return -1;
+            }
+
+            ret = write_raw(out.fh, ctx.buffer as *const c_void, used as usize) as c_int;
+
+            if ret != used as c_int {
+                info!("WARNING: loss of data\n");
+            }
+        }
+
+        ccx_output_format::CCX_OF_SPUPNG => unsafe {
+            write_spumux_footer(out);
+        },
+
+        ccx_output_format::CCX_OF_SIMPLE_XML => {
+            let footer = b"</captions>\n\0";
+
+            // Bounds check for str_buffer
+            if footer.len() > str_buffer.len() {
+                return -1;
+            }
+
+            str_buffer[..footer.len()].copy_from_slice(footer);
+
+            if ctx.encoding != ccx_encoding_type_CCX_ENC_UNICODE {
+                debug!(msg_type = DebugMessageFlag::DECODER_608; "\r{}\n",
+                    std::str::from_utf8(&str_buffer[..footer.len()-1]).unwrap_or(""));
+            }
+
+            // Create safe slice from buffer pointer and capacity
+            let buffer_slice =
+                unsafe { std::slice::from_raw_parts_mut(ctx.buffer, ctx.capacity as usize) };
+            let text_slice = &str_buffer[..footer.len()];
+            let used = encode_line(ctx, buffer_slice, text_slice);
+
+            // Bounds check for buffer access
+            if used > ctx.capacity {
+                return -1;
+            }
+
+            ret = write_raw(out.fh, ctx.buffer as *const c_void, used as usize) as c_int;
+
+            if ret != used as c_int {
+                info!("WARNING: loss of data\n");
+            }
+        }
+
+        ccx_output_format::CCX_OF_SCC | ccx_output_format::CCX_OF_CCD => {
+            // Bounds check for encoded_crlf access
+            if ctx.encoded_crlf_length as usize > ctx.encoded_crlf.len() {
+                return -1;
+            }
+
+            ret = write_raw(
+                out.fh,
+                ctx.encoded_crlf.as_ptr() as *const c_void,
+                ctx.encoded_crlf_length as usize,
+            ) as c_int;
+        }
+
+        _ => {
+            // Nothing to do, no footer on this format
+        }
+    }
+
+    ret
+}
+
+pub fn write_raw(fd: c_int, buf: *const c_void, count: usize) -> isize {
+    if buf.is_null() || count == 0 {
+        return 0;
+    }
+    let mut file = unsafe { File::from_raw_fd(fd) };
+    let data = unsafe { std::slice::from_raw_parts(buf as *const u8, count) };
+    let result = match file.write(data) {
+        Ok(bytes_written) => bytes_written as isize,
+        Err(_) => -1,
+    };
+    std::mem::forget(file);
+    result
+}
+
+fn request_buffer_capacity(ctx: &mut encoder_ctx, length: c_uint) -> bool {
+    if length > ctx.capacity {
+        let old_capacity = ctx.capacity;
+        ctx.capacity = length * 2;
+
+        // Allocate new buffer
+        let new_layout = Layout::from_size_align(ctx.capacity as usize, align_of::<u8>()).unwrap();
+
+        let new_buffer = unsafe { alloc(new_layout) };
+
+        if new_buffer.is_null() {
+            // In C this would call: fatal(EXIT_NOT_ENOUGH_MEMORY, "Not enough memory for reallocating buffer, bailing out\n");
+            return false;
+        }
+
+        // Copy old data if buffer existed
+        if !ctx.buffer.is_null() && old_capacity > 0 {
+            unsafe {
+                ptr::copy_nonoverlapping(ctx.buffer, new_buffer, old_capacity as usize);
+            }
+
+            // Deallocate old buffer
+            let old_layout =
+                Layout::from_size_align(old_capacity as usize, std::mem::align_of::<u8>()).unwrap();
+
+            unsafe {
+                dealloc(ctx.buffer, old_layout);
+            }
+        }
+
+        ctx.buffer = new_buffer;
+    }
+
+    true
+}
+pub fn write_bom(ctx: &mut encoder_ctx, out: &mut ccx_s_write) -> c_int {
+    let mut ret: c_int = 0;
+
+    if ctx.no_bom == 0 {
+        match ctx.encoding {
+            ccx_encoding_type_CCX_ENC_UTF_8 => {
+                ret =
+                    write_raw(out.fh, UTF8_BOM.as_ptr() as *const c_void, UTF8_BOM.len()) as c_int;
+                if ret < UTF8_BOM.len() as c_int {
+                    info!("WARNING: Unable to write UTF BOM\n");
+                    return -1;
+                }
+            }
+            ccx_encoding_type_CCX_ENC_UNICODE => {
+                ret = write_raw(
+                    out.fh,
+                    LITTLE_ENDIAN_BOM.as_ptr() as *const c_void,
+                    LITTLE_ENDIAN_BOM.len(),
+                ) as c_int;
+                if ret < LITTLE_ENDIAN_BOM.len() as c_int {
+                    info!("WARNING: Unable to write LITTLE_ENDIAN_BOM\n");
+                    return -1;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    ret
+}
+
+pub fn write_subtitle_file_header(ctx: &mut encoder_ctx, out: &mut ccx_s_write) -> c_int {
+    let mut used: c_uint;
+    let mut header_size: usize = 0;
+
+    match ctx.write_format {
+        ccx_output_format::CCX_OF_CCD => {
+            if write_raw(
+                out.fh,
+                CCD_HEADER.as_ptr() as *const c_void,
+                CCD_HEADER.len() - 1,
+            ) == -1
+                || write_raw(
+                    out.fh,
+                    ctx.encoded_crlf.as_ptr() as *const c_void,
+                    ctx.encoded_crlf_length as usize,
+                ) == -1
+            {
+                info!("Unable to write CCD header to file\n");
+                return -1;
+            }
+        }
+
+        ccx_output_format::CCX_OF_SCC => {
+            if write_raw(
+                out.fh,
+                SCC_HEADER.as_ptr() as *const c_void,
+                SCC_HEADER.len() - 1,
+            ) == -1
+            {
+                info!("Unable to write SCC header to file\n");
+                return -1;
+            }
+        }
+
+        ccx_output_format::CCX_OF_SRT | ccx_output_format::CCX_OF_G608 => {
+            if write_bom(ctx, out) < 0 {
+                return -1;
+            }
+        }
+
+        ccx_output_format::CCX_OF_SSA => {
+            if write_bom(ctx, out) < 0 {
+                return -1;
+            }
+
+            if !request_buffer_capacity(ctx, (SSA_HEADER.len() * 3) as c_uint) {
+                return -1;
+            }
+
+            // Create safe slice from buffer pointer and capacity
+            let buffer_slice =
+                unsafe { std::slice::from_raw_parts_mut(ctx.buffer, ctx.capacity as usize) };
+            let text_slice = SSA_HEADER;
+            used = encode_line(ctx, buffer_slice, text_slice.as_ref());
+
+            if used > ctx.capacity {
+                return -1;
+            }
+
+            if write_raw(out.fh, ctx.buffer as *const c_void, used as usize) < used as isize {
+                info!("WARNING: Unable to write complete Buffer\n");
+                return -1;
+            }
+        }
+
+        ccx_output_format::CCX_OF_WEBVTT => {
+            if write_bom(ctx, out) < 0 {
+                return -1;
+            }
+
+            // Calculate total header size
+            for header_line in WEBVTT_HEADER {
+                header_size += header_line.len();
+            }
+
+            if !request_buffer_capacity(ctx, (header_size * 3) as c_uint) {
+                return -1;
+            }
+
+            for header_line in WEBVTT_HEADER {
+                let line_to_write = unsafe {
+                    if ccx_options.enc_cfg.line_terminator_lf == 1 && *header_line == "\r\n" {
+                        "\n"
+                    } else {
+                        header_line
+                    }
+                };
+
+                // Create safe slice from buffer pointer and capacity
+                let buffer_slice =
+                    unsafe { std::slice::from_raw_parts_mut(ctx.buffer, ctx.capacity as usize) };
+                let text_slice = line_to_write.as_bytes();
+                used = encode_line(ctx, buffer_slice, text_slice);
+
+                if used > ctx.capacity {
+                    return -1;
+                }
+
+                if write_raw(out.fh, ctx.buffer as *const c_void, used as usize) < used as isize {
+                    info!("WARNING: Unable to write complete Buffer\n");
+                    return -1;
+                }
+            }
+        }
+
+        ccx_output_format::CCX_OF_SAMI => {
+            if write_bom(ctx, out) < 0 {
+                return -1;
+            }
+
+            if !request_buffer_capacity(ctx, (SAMI_HEADER.len() * 3) as c_uint) {
+                return -1;
+            }
+
+            // Create safe slice from buffer pointer and capacity
+            let buffer_slice =
+                unsafe { std::slice::from_raw_parts_mut(ctx.buffer, ctx.capacity as usize) };
+            let text_slice = SAMI_HEADER;
+            used = encode_line(ctx, buffer_slice, text_slice.as_ref());
+
+            if used > ctx.capacity {
+                return -1;
+            }
+
+            if write_raw(out.fh, ctx.buffer as *const c_void, used as usize) < used as isize {
+                info!("WARNING: Unable to write complete Buffer\n");
+                return -1;
+            }
+        }
+
+        ccx_output_format::CCX_OF_SMPTETT => {
+            if write_bom(ctx, out) < 0 {
+                return -1;
+            }
+
+            if !request_buffer_capacity(ctx, (SMPTETT_HEADER.len() * 3) as c_uint) {
+                return -1;
+            }
+
+            // Create safe slice from buffer pointer and capacity
+            let buffer_slice =
+                unsafe { std::slice::from_raw_parts_mut(ctx.buffer, ctx.capacity as usize) };
+            let text_slice = SMPTETT_HEADER;
+            used = encode_line(ctx, buffer_slice, text_slice.as_ref());
+
+            if used > ctx.capacity {
+                return -1;
+            }
+
+            if write_raw(out.fh, ctx.buffer as *const c_void, used as usize) < used as isize {
+                info!("WARNING: Unable to write complete Buffer\n");
+                return -1;
+            }
+        }
+
+        ccx_output_format::CCX_OF_RCWT => {
+            let mut rcwt_header = RCWT_HEADER.to_vec();
+            rcwt_header[7] = ctx.in_fileformat as u8; // sets file format version
+
+            if ctx.send_to_srv != 0 {
+                unsafe {
+                    net_send_header(rcwt_header.as_ptr(), rcwt_header.len());
+                }
+            } else if write_raw(
+                out.fh,
+                rcwt_header.as_ptr() as *const c_void,
+                rcwt_header.len(),
+            ) < 0
+            {
+                info!("Unable to write rcwt header\n");
+                return -1;
+            }
+        }
+
+        ccx_output_format::CCX_OF_RAW => {
+            if write_raw(
+                out.fh,
+                BROADCAST_HEADER.as_ptr() as *const c_void,
+                BROADCAST_HEADER.len(),
+            ) < BROADCAST_HEADER.len() as isize
+            {
+                info!("Unable to write Raw header\n");
+                return -1;
+            }
+        }
+
+        ccx_output_format::CCX_OF_SPUPNG => {
+            if write_bom(ctx, out) < 0 {
+                return -1;
+            }
+            unsafe {
+                write_spumux_header(ctx, out);
+            }
+        }
+
+        ccx_output_format::CCX_OF_TRANSCRIPT => {
+            if write_bom(ctx, out) < 0 {
+                return -1;
+            }
+        }
+
+        ccx_output_format::CCX_OF_SIMPLE_XML => {
+            if write_bom(ctx, out) < 0 {
+                return -1;
+            }
+
+            if !request_buffer_capacity(ctx, (SIMPLE_XML_HEADER.len() * 3) as c_uint) {
+                return -1;
+            }
+
+            // Create safe slice from buffer pointer and capacity
+            let buffer_slice =
+                unsafe { std::slice::from_raw_parts_mut(ctx.buffer, ctx.capacity as usize) };
+            let text_slice = SIMPLE_XML_HEADER;
+            used = encode_line(ctx, buffer_slice, text_slice.as_ref());
+
+            if used > ctx.capacity {
+                return -1;
+            }
+
+            if write_raw(out.fh, ctx.buffer as *const c_void, used as usize) < used as isize {
+                info!("WARNING: Unable to write complete Buffer\n");
+                return -1;
+            }
+        }
+
+        ccx_output_format::CCX_OF_MCC => {
+            ctx.header_printed_flag = 0;
+        }
+
+        _ => {
+            // Default case - do nothing
+        }
+    }
+
+    0
+}

--- a/src/rust/src/encoder/headers_and_footers.rs
+++ b/src/rust/src/encoder/headers_and_footers.rs
@@ -11,8 +11,11 @@ use lib_ccxr::{debug, info};
 use std::alloc::{alloc, dealloc, Layout};
 use std::fs::File;
 use std::io::Write;
+#[cfg(unix)]
 use std::os::fd::FromRawFd;
 use std::os::raw::{c_int, c_uchar, c_uint, c_void};
+#[cfg(windows)]
+use std::os::windows::io::FromRawHandle;
 use std::ptr;
 const CCD_HEADER: &[u8] = b"SCC_disassembly V1.2";
 const SCC_HEADER: &[u8] = b"Scenarist_SCC V1.0";
@@ -224,7 +227,10 @@ pub fn write_raw(fd: c_int, buf: *const c_void, count: usize) -> isize {
     if buf.is_null() || count == 0 {
         return 0;
     }
+    #[cfg(unix)]
     let mut file = unsafe { File::from_raw_fd(fd) };
+    #[cfg(windows)]
+    let mut file = unsafe { File::from_raw_handle(fd as _) };
     let data = unsafe { std::slice::from_raw_parts(buf as *const u8, count) };
     let result = match file.write(data) {
         Ok(bytes_written) => bytes_written as isize,

--- a/src/rust/src/encoder/mod.rs
+++ b/src/rust/src/encoder/mod.rs
@@ -1,0 +1,76 @@
+use crate::bindings::ccx_encoding_type;
+use crate::encoder::common::get_str_basic;
+use lib_ccxr::util::encoding::Encoding;
+use std::os::raw::{c_int, c_uchar};
+
+pub mod common;
+pub mod g608;
+pub mod headers_and_footers;
+pub mod simplexml;
+/// # Safety
+/// This function is unsafe because it deferences to raw pointers and performs operations on pointer slices.
+#[no_mangle]
+pub unsafe fn ccxr_get_str_basic(
+    out_buffer: *mut c_uchar,
+    in_buffer: *mut c_uchar,
+    trim_subs: c_int,
+    in_enc: ccx_encoding_type,
+    out_enc: ccx_encoding_type,
+    max_len: c_int,
+) -> c_int {
+    let trim_subs_bool = trim_subs != 0;
+    let in_encoding = match Encoding::from_ctype(in_enc) {
+        Some(enc) => enc,
+        None => return 0,
+    };
+    let out_encoding = match Encoding::from_ctype(out_enc) {
+        Some(enc) => enc,
+        None => return 0,
+    };
+    let in_buffer_slice = if in_buffer.is_null() || max_len <= 0 {
+        return 0;
+    } else {
+        std::slice::from_raw_parts(in_buffer, max_len as usize)
+    };
+    let mut out_buffer_vec = Vec::with_capacity(max_len as usize * 4); // UTF-8 can be up to 4 bytes per character
+    let result = get_str_basic(
+        &mut out_buffer_vec,
+        in_buffer_slice,
+        trim_subs_bool,
+        in_encoding,
+        out_encoding,
+        max_len,
+    );
+    if result > 0 && !out_buffer.is_null() {
+        let copy_len = std::cmp::min(result as usize, out_buffer_vec.len());
+        if copy_len > 0 {
+            std::ptr::copy_nonoverlapping(out_buffer_vec.as_ptr(), out_buffer, copy_len);
+        }
+        if copy_len < max_len as usize {
+            *out_buffer.add(copy_len) = 0;
+        }
+    } else if !out_buffer.is_null() {
+        *out_buffer = 0;
+    }
+    result
+}
+pub trait FromCType<T> {
+    // Remove after demuxer, just import from ctorust
+    /// # Safety
+    /// This function is unsafe because it uses raw pointers to get data from C types.
+    unsafe fn from_ctype(c_value: T) -> Option<Self>
+    where
+        Self: Sized;
+}
+impl FromCType<ccx_encoding_type> for Encoding {
+    // Remove after demuxer, just import from ctorust
+    unsafe fn from_ctype(encoding: ccx_encoding_type) -> Option<Self> {
+        Some(match encoding {
+            0 => Encoding::Ucs2,   // CCX_ENC_UNICODE
+            1 => Encoding::Latin1, // CCX_ENC_LATIN_1
+            2 => Encoding::Utf8,   // CCX_ENC_UTF_8
+            3 => Encoding::Line21, // CCX_ENC_ASCII
+            _ => Encoding::Utf8,   // Default to UTF-8 if unknown
+        })
+    }
+}

--- a/src/rust/src/encoder/simplexml.rs
+++ b/src/rust/src/encoder/simplexml.rs
@@ -1,0 +1,89 @@
+use crate::bindings::{cc_subtitle, ccx_encoding_type_CCX_ENC_ASCII, eia608_screen, encoder_ctx};
+use crate::encoder::ccxr_get_str_basic;
+use crate::encoder::headers_and_footers::write_raw;
+use lib_ccxr::common::CCX_DECODER_608_SCREEN_WIDTH;
+use lib_ccxr::info;
+use std::os::raw::{c_int, c_void};
+use std::ptr;
+
+pub fn write_cc_line_as_simplexml(
+    data: &mut eia608_screen,
+    context: &mut encoder_ctx,
+    line_number: usize,
+) {
+    let cap = b"<caption>";
+    let cap1 = b"</caption>";
+
+    let length = unsafe {
+        ccxr_get_str_basic(
+            // change to get_str_basic after encoder_ctx is replaced with EncoderCtx
+            context.subline,
+            data.characters[line_number].as_mut_ptr(),
+            context.trim_subs,
+            ccx_encoding_type_CCX_ENC_ASCII,
+            context.encoding,
+            CCX_DECODER_608_SCREEN_WIDTH as i32,
+        )
+    };
+
+    // Write opening caption tag
+    let _ret = unsafe { write_raw((*context.out).fh, cap.as_ptr() as *const c_void, cap.len()) };
+
+    // Write the subtitle content
+    let ret = unsafe {
+        write_raw(
+            (*context.out).fh,
+            context.subline as *const c_void,
+            length as usize,
+        )
+    };
+
+    if ret < length as isize {
+        info!("Warning:Loss of data\n");
+    }
+
+    // Write closing caption tag
+    let _ret = unsafe {
+        write_raw(
+            (*context.out).fh,
+            cap1.as_ptr() as *const c_void,
+            cap1.len(),
+        )
+    };
+
+    // Write CRLF
+    let _ret = unsafe {
+        write_raw(
+            (*context.out).fh,
+            context.encoded_crlf.as_ptr() as *const c_void,
+            context.encoded_crlf_length as usize,
+        )
+    };
+}
+
+pub fn write_cc_buffer_as_simplexml(data: &mut eia608_screen, context: &mut encoder_ctx) -> c_int {
+    let mut wrote_something = 0;
+
+    for i in 0..15 {
+        if data.row_used[i] != 0 {
+            write_cc_line_as_simplexml(data, context, i);
+            wrote_something = 1;
+        }
+    }
+
+    wrote_something
+}
+
+pub fn write_cc_bitmap_as_simplexml(sub: &mut cc_subtitle, _context: &mut encoder_ctx) -> c_int {
+    sub.nb_data = 0;
+
+    if !sub.data.is_null() {
+        unsafe {
+            let data_box = Box::from_raw(sub.data as *mut u8);
+            drop(data_box);
+        }
+        sub.data = ptr::null_mut();
+    }
+
+    0
+}

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -16,6 +16,7 @@ pub mod bindings {
 pub mod args;
 pub mod common;
 pub mod decoder;
+pub mod encoder;
 #[cfg(feature = "hardsubx_ocr")]
 pub mod hardsubx;
 pub mod libccxr_exports;


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---
In this PR, I have migrated a large part of `ccx_encoders_common.c` and the library `ccx_encoders_g608.c` alongside it's helper functions. I have also fixed some issues(wrong functions) in the `encoding` module which were caught during regression testing. After this PR all the writing that is done on txt files is done by Rust.