### PR TITLE
fix: elementary stream regressions

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 1.0 (to be released)
 -----------------
+- Fix: Elementary stream regressions
 - Fix: Segmentation faults on XDS files
 - Fix: Clippy Errors Based on Rust 1.88
 - IMPROVEMENT: Refactor and optimize Dockerfile

--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -183,11 +183,11 @@ int api_start(struct ccx_s_options api_options)
 		----------------------------------------------------------------- */
 		switch (stream_mode)
 		{
+			// Note: This case is meant to fall through
 			case CCX_SM_ELEMENTARY_OR_NOT_FOUND:
 				if (!api_options.use_gop_as_pts)	// If !0 then the user selected something
 					api_options.use_gop_as_pts = 1; // Force GOP timing for ES
 				ccx_common_timing_settings.is_elementary_stream = 1;
-				break;
 			case CCX_SM_TRANSPORT:
 			case CCX_SM_PROGRAM:
 			case CCX_SM_ASF:


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

CCextractor currently fails when an elementary stream is passed or `--in=es` is specified. This is caused by the addition of a break statement in a switch case that was meant to fall through and start the general loop.
