### PR TITLE
fix: MCC encoder 16-bit sequence

### DIFF
--- a/src/lib_ccx/ccx_encoders_mcc.c
+++ b/src/lib_ccx/ccx_encoders_mcc.c
@@ -323,15 +323,15 @@ static uint8 *add_boilerplate(struct encoder_ctx *ctx, unsigned char *cc_data, i
 	buff_ptr[5] = data_size + 12;
 	buff_ptr[6] = ((cdp_frame_rate << 4) | 0x0F);
 	buff_ptr[7] = 0x43; // Timecode not Present; Service Info not Present; Captions Present
-	buff_ptr[8] = (uint8)((ctx->cdp_hdr_seq & 0xF0) >> 8);
-	buff_ptr[9] = (uint8)(ctx->cdp_hdr_seq & 0x0F);
+	buff_ptr[8] = (uint8)((ctx->cdp_hdr_seq >> 8) & 0xFF);
+	buff_ptr[9] = (uint8)(ctx->cdp_hdr_seq & 0xFF);
 	buff_ptr[10] = CC_DATA_ID;
 	buff_ptr[11] = cc_count | 0xE0;
 	memcpy(&buff_ptr[12], cc_data, data_size);
 	uint8 *data_ptr = &buff_ptr[data_size + 12];
 	data_ptr[0] = CDP_FOOTER_ID;
-	data_ptr[1] = (uint8)((ctx->cdp_hdr_seq & 0xF0) >> 8);
-	data_ptr[2] = (uint8)(ctx->cdp_hdr_seq & 0x0F);
+	data_ptr[1] = (uint8)((ctx->cdp_hdr_seq >> 8) & 0xFF);
+	data_ptr[2] = (uint8)(ctx->cdp_hdr_seq & 0xFF);
 	data_ptr[3] = 0;
 
 	for (int loop = 0; loop < (data_size + 15); loop++)


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->



- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Fix MCC encoder 16-bit sequence counter bit manipulation per SMPTE ST 334-2 spec
Fixes #1709  Thanks to @programmerjake for identifying the issue