### PR TITLE
refactor: remove api structures

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 1.0 (to be released)
 -----------------
+- Refactor: Remove API structures from ccextractor
 - Fix: Elementary stream regressions
 - Fix: Segmentation faults on XDS files
 - Fix: Clippy Errors Based on Rust 1.88

--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -38,7 +38,7 @@ void print_end_msg(void)
 	mprint("https://github.com/CCExtractor/ccextractor/issues\n");
 }
 
-int api_start(struct ccx_s_options api_options)
+int start_ccx()
 {
 	struct lib_ccx_ctx *ctx = NULL;	      // Context for libs
 	struct lib_cc_decode *dec_ctx = NULL; // Context for decoder
@@ -49,7 +49,7 @@ int api_start(struct ccx_s_options api_options)
 	setMsgSeverity(LEPT_MSG_SEVERITY);
 #endif
 	// Initialize CCExtractor libraries
-	ctx = init_libraries(&api_options);
+	ctx = init_libraries(&ccx_options);
 
 	if (!ctx)
 	{
@@ -66,10 +66,10 @@ int api_start(struct ccx_s_options api_options)
 	}
 
 #ifdef ENABLE_HARDSUBX
-	if (api_options.hardsubx)
+	if (ccx_options.hardsubx)
 	{
 		// Perform burned in subtitle extraction
-		hardsubx(&api_options, ctx);
+		hardsubx(&ccx_options, ctx);
 		return 0;
 	}
 #endif
@@ -97,11 +97,11 @@ int api_start(struct ccx_s_options api_options)
 		tlt_config.page = ((tlt_config.page / 100) << 8) | (((tlt_config.page / 10) % 10) << 4) | (tlt_config.page % 10);
 	}
 
-	if (api_options.transcript_settings.xds)
+	if (ccx_options.transcript_settings.xds)
 	{
-		if (api_options.write_format != CCX_OF_TRANSCRIPT)
+		if (ccx_options.write_format != CCX_OF_TRANSCRIPT)
 		{
-			api_options.transcript_settings.xds = 0;
+			ccx_options.transcript_settings.xds = 0;
 			mprint("Warning: -xds ignored, XDS can only be exported to transcripts at this time.\n");
 		}
 	}
@@ -109,7 +109,7 @@ int api_start(struct ccx_s_options api_options)
 	time_t start, final;
 	time(&start);
 
-	if (api_options.binary_concat)
+	if (ccx_options.binary_concat)
 	{
 		ctx->total_inputsize = get_total_file_size(ctx);
 		if (ctx->total_inputsize < 0)
@@ -139,16 +139,16 @@ int api_start(struct ccx_s_options api_options)
 	terminate_asap = 0;
 
 #ifdef ENABLE_SHARING
-	if (api_options.translate_enabled && ctx->num_input_files > 1)
+	if (ccx_options.translate_enabled && ctx->num_input_files > 1)
 	{
 		mprint("[share] WARNING: simultaneous translation of several input files is not supported yet\n");
-		api_options.translate_enabled = 0;
-		api_options.sharing_enabled = 0;
+		ccx_options.translate_enabled = 0;
+		ccx_options.sharing_enabled = 0;
 	}
-	if (api_options.translate_enabled)
+	if (ccx_options.translate_enabled)
 	{
 		mprint("[share] launching translate service\n");
-		ccx_share_launch_translator(api_options.translate_langs, api_options.translate_key);
+		ccx_share_launch_translator(ccx_options.translate_langs, ccx_options.translate_key);
 	}
 #endif // ENABLE_SHARING
 	ret = 0;
@@ -156,7 +156,7 @@ int api_start(struct ccx_s_options api_options)
 	{
 		prepare_for_new_file(ctx);
 #ifdef ENABLE_SHARING
-		if (api_options.sharing_enabled)
+		if (ccx_options.sharing_enabled)
 			ccx_share_start(ctx->basefilename);
 #endif // ENABLE_SHARING
 
@@ -185,8 +185,8 @@ int api_start(struct ccx_s_options api_options)
 		{
 			// Note: This case is meant to fall through
 			case CCX_SM_ELEMENTARY_OR_NOT_FOUND:
-				if (!api_options.use_gop_as_pts)	// If !0 then the user selected something
-					api_options.use_gop_as_pts = 1; // Force GOP timing for ES
+				if (!ccx_options.use_gop_as_pts)	// If !0 then the user selected something
+					ccx_options.use_gop_as_pts = 1; // Force GOP timing for ES
 				ccx_common_timing_settings.is_elementary_stream = 1;
 			case CCX_SM_TRANSPORT:
 			case CCX_SM_PROGRAM:
@@ -197,9 +197,9 @@ int api_start(struct ccx_s_options api_options)
 #ifdef ENABLE_FFMPEG
 			case CCX_SM_FFMPEG:
 #endif
-				if (!api_options.use_gop_as_pts) // If !0 then the user selected something
-					api_options.use_gop_as_pts = 0;
-				if (api_options.ignore_pts_jumps)
+				if (!ccx_options.use_gop_as_pts) // If !0 then the user selected something
+					ccx_options.use_gop_as_pts = 0;
+				if (ccx_options.ignore_pts_jumps)
 					ccx_common_timing_settings.disable_sync_check = 1;
 				mprint("\rAnalyzing data in general mode\n");
 				tmp = general_loop(ctx);
@@ -232,7 +232,7 @@ int api_start(struct ccx_s_options api_options)
 				{
 					fatal(EXIT_INCOMPATIBLE_PARAMETERS, "MP4 requires an actual file, it's not possible to read from a stream, including stdin.\n");
 				}
-				if (api_options.extract_chapters)
+				if (ccx_options.extract_chapters)
 				{
 					tmp = dumpchapters(ctx, &ctx->mp4_cfg, ctx->inputfile[ctx->current_file]);
 				}
@@ -240,7 +240,7 @@ int api_start(struct ccx_s_options api_options)
 				{
 					tmp = processmp4(ctx, &ctx->mp4_cfg, ctx->inputfile[ctx->current_file]);
 				}
-				if (api_options.print_file_reports)
+				if (ccx_options.print_file_reports)
 					print_file_report(ctx);
 				if (!ret)
 					ret = tmp;
@@ -311,7 +311,7 @@ int api_start(struct ccx_s_options api_options)
 			dec_ctx->timing->fts_max = 0;
 
 #ifdef ENABLE_SHARING
-			if (api_options.sharing_enabled)
+			if (ccx_options.sharing_enabled)
 			{
 				ccx_share_stream_done(ctx->basefilename);
 				ccx_share_stop();
@@ -430,12 +430,6 @@ int api_start(struct ccx_s_options api_options)
 	return ret ? EXIT_OK : EXIT_NO_CAPTIONS;
 }
 
-struct ccx_s_options *api_init_options()
-{
-	init_options(&ccx_options);
-	return &ccx_options;
-}
-
 int main(int argc, char *argv[])
 {
 	setlocale(LC_ALL, ""); // Supports non-English CCs
@@ -443,10 +437,11 @@ int main(int argc, char *argv[])
 			       // thousands' groupoing instead of what the locale might say
 	setlocale(LC_NUMERIC, "POSIX");
 
-	struct ccx_s_options *api_options = api_init_options();
-	parse_configuration(api_options);
+	init_options(&ccx_options);
+
 	// If "ccextractor.cnf" is present, takes options from it.
 	// See docs/ccextractor.cnf.sample for more info.
+	parse_configuration(&ccx_options);
 
 #ifndef DISABLE_RUST
 	ccxr_init_basic_logger();
@@ -455,7 +450,7 @@ int main(int argc, char *argv[])
 #ifndef DISABLE_RUST
 	int compile_ret = ccxr_parse_parameters(argc, argv);
 #else
-	int compile_ret = parse_parameters(api_options, argc, argv);
+	int compile_ret = parse_parameters(&ccx_options, argc, argv);
 #endif
 
 	if (compile_ret == EXIT_NO_INPUT_FILES)
@@ -472,6 +467,6 @@ int main(int argc, char *argv[])
 		exit(compile_ret);
 	}
 
-	int start_ret = api_start(*api_options);
+	int start_ret = start_ccx();
 	return start_ret;
 }


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---
Removes the API structures from `ccextractor.c`. This was causing a regression due to mismatch between the options maintained by `api_options` and `ccx_options`. 
