### PR TITLE
[FIX] Fixed issue with cross compiling using MINGW-w64

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -46,6 +46,7 @@
 - Fix: Resolve compile-time error about implicit declarations (#1646)
 - Fix: fatal out of memory error extracting from a VOB PS
 - Fix: Unit Test Rust failing due to changes in Rust Version 1.86.0
+- Fix: Support for MINGW-w64 cross compiling
 
 0.94 (2021-12-14)
 -----------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,7 +123,9 @@ set(FREETYPE_SOURCE
         )
 #Windows specific libraries and linker flags
 if(WIN32)
-    include_directories ("${PROJECT_SOURCE_DIR}/thirdparty/win_spec_incld/")
+    if(NOT MINGW)
+        include_directories ("${PROJECT_SOURCE_DIR}/thirdparty/win_spec_incld/")
+    endif()
     include_directories ("${PROJECT_SOURCE_DIR}/thirdparty/win_iconv/")
     aux_source_directory ("${PROJECT_SOURCE_DIR}/thirdparty/win_iconv/" SOURCEFILE)
     set (EXTRA_LIBS ${EXTRA_LIBS} ws2_32 winmm Bcrypt)

--- a/src/lib_ccx/ccx_common_platform.h
+++ b/src/lib_ccx/ccx_common_platform.h
@@ -26,7 +26,9 @@
 		#undef UINT64_MAX
 		#define UINT64_MAX   _UI64_MAX
 		typedef int socklen_t;
-		typedef int ssize_t;
+		#if !defined(__MINGW64__) && !defined(__MINGW32)
+		    typedef int ssize_t;
+		#endif
 		typedef uint32_t in_addr_t;
 		#ifndef IN_CLASSD
 			#define IN_CLASSD(i)       (((INT32)(i) & 0xf0000000) == 0xe0000000)

--- a/src/lib_ccx/ccx_common_platform.h
+++ b/src/lib_ccx/ccx_common_platform.h
@@ -26,7 +26,7 @@
 		#undef UINT64_MAX
 		#define UINT64_MAX   _UI64_MAX
 		typedef int socklen_t;
-		#if !defined(__MINGW64__) && !defined(__MINGW32)
+		#if !defined(__MINGW64__) && !defined(__MINGW32__)
 		    typedef int ssize_t;
 		#endif
 		typedef uint32_t in_addr_t;
@@ -120,3 +120,4 @@
 	typedef uint8_t UBYTE;
 
 #endif // CCX_PLATFORM_H
+

--- a/src/lib_ccx/ccx_encoders_common.h
+++ b/src/lib_ccx/ccx_encoders_common.h
@@ -2,7 +2,7 @@
 #define _CC_ENCODER_COMMON_H
 
 #ifdef WIN32
-	#if defined(__MINGW64__) || defined(__MINGW32)
+	#if defined(__MINGW64__) || defined(__MINGW32__)
 		#include <iconv.h>
 	#else
 		#include "..\\thirdparty\\win_iconv\\iconv.h"

--- a/src/lib_ccx/ccx_encoders_common.h
+++ b/src/lib_ccx/ccx_encoders_common.h
@@ -2,7 +2,11 @@
 #define _CC_ENCODER_COMMON_H
 
 #ifdef WIN32
-	#include "..\\thirdparty\\win_iconv\\iconv.h"
+	#if defined(__MINGW64__) || defined(__MINGW32)
+		#include <iconv.h>
+	#else
+		#include "..\\thirdparty\\win_iconv\\iconv.h"
+	#endif
 #else
 	#include "iconv.h"
 #endif

--- a/src/lib_ccx/ts_tables_epg.c
+++ b/src/lib_ccx/ts_tables_epg.c
@@ -4,13 +4,13 @@
 #include "utility.h"
 #include <stdbool.h>
 #ifdef WIN32
-	#if defined(__MINGW64__) || defined(__MINGW32__)
-		#include <iconv.h>
-	#else
-		#include "..\\thirdparty\\win_iconv\\iconv.h"
-	#endif
+#if defined(__MINGW64__) || defined(__MINGW32__)
+#include <iconv.h>
 #else
-	#include "iconv.h"
+#include "..\\thirdparty\\win_iconv\\iconv.h"
+#endif
+#else
+#include "iconv.h"
 #endif
 
 // Prints a string to a file pointer, escaping XML special chars

--- a/src/lib_ccx/ts_tables_epg.c
+++ b/src/lib_ccx/ts_tables_epg.c
@@ -4,7 +4,7 @@
 #include "utility.h"
 #include <stdbool.h>
 #ifdef WIN32
-	#if defined(__MINGW64__) || defined(__MINGW32)
+	#if defined(__MINGW64__) || defined(__MINGW32__)
 		#include <iconv.h>
 	#else
 		#include "..\\thirdparty\\win_iconv\\iconv.h"

--- a/src/lib_ccx/ts_tables_epg.c
+++ b/src/lib_ccx/ts_tables_epg.c
@@ -4,9 +4,13 @@
 #include "utility.h"
 #include <stdbool.h>
 #ifdef WIN32
-#include "..\\thirdparty\\win_iconv\\iconv.h"
+	#if defined(__MINGW64__) || defined(__MINGW32)
+		#include <iconv.h>
+	#else
+		#include "..\\thirdparty\\win_iconv\\iconv.h"
+	#endif
 #else
-#include "iconv.h"
+	#include "iconv.h"
 #endif
 
 // Prints a string to a file pointer, escaping XML special chars


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [X ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X ] I have checked that another pull request for this purpose does not exist.
- [X ] I have considered, and confirmed that this submission will be valuable to others.
- [X ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X ] I give this submission freely, and claim no ownership to its content.
- [X ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [X ] I am an active contributor to CCExtractor.

---

Fixed build script for cross compiling using MinGW-w64
Some file path's and headers are specific to VS, MinGW provides them natively, updated CMakeFile and source code to differentiate between MS/VS environments and MinGW environments.
