### PR TITLE
fix: unicode encoding regression

### DIFF
--- a/src/rust/lib_ccxr/src/util/encoding.rs
+++ b/src/rust/lib_ccxr/src/util/encoding.rs
@@ -41,11 +41,11 @@
 /// Represents the different kinds of encoding that [`EncodedString`] can take.
 #[derive(Default, Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Encoding {
-    Line21, // Same as `CCX_ENC_ASCII` in C
+    UCS2,   // Same as `CCX_ENC_UNICODE` in C
     Latin1, // Same as `CCX_ENC_LATIN_1` in C
     #[default]
     UTF8, // Same as `CCX_ENC_UTF_8` in C
-    UCS2,   // Same as `CCX_ENC_UNICODE` in C
+    Line21, // Same as `CCX_ENC_ASCII` in C
 }
 
 /// Represents a character in Line 21 encoding.


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

CCextractor does not currently produce the correct output when we try to encode the subtitles in unicode (by passing `--unicode`). This is a regression currently reported by the sample platform under the options category. 
 
The problem seems to be caused by order differences between the C and Rust enums. The C [enum](https://github.com/CCExtractor/ccextractor/blob/master/src/lib_ccx/ccx_common_constants.h#L222) has the unicode entry at position 0 but the Rust [enum](https://github.com/CCExtractor/ccextractor/blob/master/src/rust/lib_ccxr/src/util/encoding.rs#L43) has it at position 3.

I'm not exactly sure *why* this fixes the issue because we are using explicit match by value statements when converting between Rust and C so this shouldn't make a difference but it does yield the correct output nonetheless. 