### PR TITLE
Fix DVB Regressions on windows

### DIFF
--- a/src/lib_ccx/ocr.c
+++ b/src/lib_ccx/ocr.c
@@ -106,7 +106,8 @@ char *probe_tessdata_location(const char *lang)
 	    "/usr/share/tesseract-ocr/",
 	    "/usr/share/tesseract-ocr/4.00/",
 	    "/usr/share/tesseract-ocr/5/",
-	    "/usr/share/tesseract/"};
+	    "/usr/share/tesseract/",
+	    "C:\\Program Files\\Tesseract-OCR\\"};
 
 	for (int i = 0; i < sizeof(paths) / sizeof(paths[0]); i++)
 	{


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---
Was caused by CCExtractor not being able to find the location of the tessdata folder on windows.
