### PR TITLE
Fix Hardsubx OCR

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install dependencies
-      run: sudo apt update && sudo apt-get install libgpac-dev libtesseract-dev
+      run: sudo apt update && sudo apt-get install libgpac-dev libtesseract-dev libavcodec-dev libavdevice-dev libx11-dev libxcb1-dev libxcb-shm0-dev
     - uses: actions/checkout@v4
     - name: build
-      run: ./build
+      run: ./build -hardsubx
       working-directory: ./linux
     - name: Display version information
       run: ./ccextractor --version

--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 1.0 (to be released)
 -----------------
+- Fix: HardSubX OCR on Rust
 - Removed the Share Module
 - Fix: Regression failures on DVD files
 - Fix: Segmentation faults on MP4 files with CEA-708 captions

--- a/src/rust/src/hardsubx/decoder.rs
+++ b/src/rust/src/hardsubx/decoder.rs
@@ -41,9 +41,13 @@ pub unsafe fn dispatch_classifier_functions(ctx: *mut lib_hardsubx_ctx, im: *mut
     match (*ctx).ocr_mode {
         0 => {
             let ret_char_arr = get_ocr_text_wordwise_threshold(ctx, im, (*ctx).conf_thresh);
-            ffi::CStr::from_ptr(ret_char_arr)
-                .to_string_lossy()
-                .into_owned()
+            if ret_char_arr.is_null() {
+                "".to_string()
+            } else {
+                ffi::CStr::from_ptr(ret_char_arr)
+                    .to_string_lossy()
+                    .into_owned()
+            }
         }
         1 => {
             let ret_char_arr = get_ocr_text_letterwise_threshold(ctx, im, (*ctx).conf_thresh);

--- a/src/rust/src/hardsubx/decoder.rs
+++ b/src/rust/src/hardsubx/decoder.rs
@@ -40,6 +40,14 @@ pub unsafe fn dispatch_classifier_functions(ctx: *mut lib_hardsubx_ctx, im: *mut
     // function that calls the classifier functions
     match (*ctx).ocr_mode {
         0 => {
+            let ret_char_arr = get_ocr_text_simple_threshold(ctx, im, (*ctx).conf_thresh);
+            let text_out_result = ffi::CString::from_raw(ret_char_arr).into_string();
+            match text_out_result {
+                Ok(T) => T,
+                Err(_E) => "".to_string(),
+            }
+        }
+        1 => {
             let ret_char_arr = get_ocr_text_wordwise_threshold(ctx, im, (*ctx).conf_thresh);
             if ret_char_arr.is_null() {
                 "".to_string()
@@ -49,17 +57,8 @@ pub unsafe fn dispatch_classifier_functions(ctx: *mut lib_hardsubx_ctx, im: *mut
                     .into_owned()
             }
         }
-        1 => {
-            let ret_char_arr = get_ocr_text_letterwise_threshold(ctx, im, (*ctx).conf_thresh);
-            let text_out_result = ffi::CString::from_raw(ret_char_arr).into_string();
-            match text_out_result {
-                Ok(T) => T,
-                Err(_E) => "".to_string(),
-            }
-        }
-
         2 => {
-            let ret_char_arr = get_ocr_text_simple_threshold(ctx, im, (*ctx).conf_thresh);
+            let ret_char_arr = get_ocr_text_letterwise_threshold(ctx, im, (*ctx).conf_thresh);
             let text_out_result = ffi::CString::from_raw(ret_char_arr).into_string();
             match text_out_result {
                 Ok(T) => T,
@@ -70,7 +69,6 @@ pub unsafe fn dispatch_classifier_functions(ctx: *mut lib_hardsubx_ctx, im: *mut
         _ => {
             eprintln!("Invalid OCR Mode");
             exit(EXIT_MALFORMED_PARAMETER);
-            // "".to_string()
         }
     }
 }
@@ -117,7 +115,7 @@ pub unsafe extern "C" fn _process_frame_white_basic(
     let mut gray_im: *mut Pix = pixConvertRGBToGray(im, 0.0, 0.0, 0.0);
     let mut sobel_edge_im: *mut Pix =
         pixSobelEdgeFilter(gray_im, L_VERTICAL_EDGES.try_into().unwrap());
-    let mut dilate_gray_im: *mut Pix = pixDilateGray(sobel_edge_im, 21, 1);
+    let mut dilate_gray_im: *mut Pix = pixDilateGray(sobel_edge_im, 21, 11);
     let mut edge_im: *mut Pix = pixThresholdToBinary(dilate_gray_im, 50);
 
     let mut feat_im: *mut Pix = pixCreate(width, height, 32);

--- a/src/rust/src/hardsubx/imgops.rs
+++ b/src/rust/src/hardsubx/imgops.rs
@@ -13,10 +13,11 @@ pub extern "C" fn rgb_to_hsv(R: f32, G: f32, B: f32, H: &mut f32, S: &mut f32, V
 
 #[no_mangle]
 pub extern "C" fn rgb_to_lab(R: f32, G: f32, B: f32, L: &mut f32, a: &mut f32, b: &mut f32) {
-    let rgb = Srgb::new(R, G, B);
+    // Normalize input RGB from 0-255 to 0.0-1.0
+    let rgb = Srgb::new(R / 255.0, G / 255.0, B / 255.0);
 
-    // This declaration sets the white-point as per the D65 standard
-    let lab_rep = Lab::<palette::white_point::D65, f32>::from_color(rgb);
+    // Convert from sRGB to Lab (D65 white point is default)
+    let lab_rep = Lab::from_color(rgb);
 
     *L = lab_rep.l;
     *a = lab_rep.a;


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---
closes #1723 

Hardsubx is currently broken on the master branch on Rust.

Fixed a segmentation faults on Linux which was caused by a null pointer dereference in `dispatch_classifier_function`, I've added proper error handling to fix this. While here, I also noticed that the values in the match statement for the classifier functions are incorrect, see [here](https://github.com/hrideshmg/ccextractor/blob/97e74447da106ceebf02afb20804c47c21a7d3af/src/lib_ccx/hardsubx.h#L27). The `pixDilateGray()` function also had an incorrect argument, see [here](https://github.com/hrideshmg/ccextractor/blob/hardsubx_fixes/src/lib_ccx/hardsubx_decoder.c#L56).

While CCextractor seemed to run after this, the output seemed to be garbled. On running some tests, I found out that the luminance mask was fully white. This is because the [Srgb::new()](https://docs.rs/palette/latest/palette/type.Srgb.html#fields) function expects values in the range of `0.0-1.0`, however we were passing values from `0.0-255.0`.

I've also enabled hardsubx for the test builds. This is to facilitate adding regression tests on the sample platform.