### PR TITLE
Fix `--ocrlang` argument on rust

### DIFF
--- a/src/rust/lib_ccxr/src/common/options.rs
+++ b/src/rust/lib_ccxr/src/common/options.rs
@@ -452,7 +452,7 @@ pub struct Options {
     /// The name of the language stream for DVB
     pub dvblang: Option<Language>,
     /// The name of the .traineddata file to be loaded with tesseract
-    pub ocrlang: PathBuf,
+    pub ocrlang: Option<Language>,
     /// The Tesseract OEM mode, could be 0 (default), 1 or 2
     pub ocr_oem: i8,
     /// The Tesseract PSM mode, could be between 0 and 13. 3 is tesseract default

--- a/src/rust/src/common.rs
+++ b/src/rust/src/common.rs
@@ -150,8 +150,8 @@ pub unsafe fn copy_from_rust(ccx_s_options: *mut ccx_s_options, options: Options
     if let Some(dvblang) = options.dvblang {
         (*ccx_s_options).dvblang = string_to_c_char(dvblang.to_ctype().as_str());
     }
-    if options.ocrlang.try_exists().unwrap_or_default() {
-        (*ccx_s_options).ocrlang = string_to_c_char(options.ocrlang.to_str().unwrap());
+    if let Some(ocrlang) = options.ocrlang {
+        (*ccx_s_options).ocrlang = string_to_c_char(ocrlang.to_ctype().as_str());
     }
     (*ccx_s_options).ocr_oem = options.ocr_oem as _;
     (*ccx_s_options).ocr_quantmode = options.ocr_quantmode as _;

--- a/src/rust/src/parser.rs
+++ b/src/rust/src/parser.rs
@@ -767,7 +767,7 @@ impl OptionsExt for Options {
         }
 
         if let Some(ref ocrlang) = args.ocrlang {
-            self.ocrlang = PathBuf::from_str(ocrlang.as_str()).unwrap_or_default();
+            self.ocrlang = Some(Language::from_str(ocrlang.as_str()).unwrap());
         }
 
         if let Some(ref quant) = args.quant {


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---
The `--ocrlang` argument currently doesn't work as expected as it expects to be passed a file path on Rust but the rest of the codebase expects it to be language code of the `.traineddata` file