### PR TITLE
[IMPROVEMENT]: Ensure WebVTT output includes minimal X-TIMESTAMP-MAP for HLS compatibility

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 1.0 (to be released)
 -----------------
+- IMPROVEMENT: Add default X-TIMESTAMP-MAP header for empty subtitle files in WebVTT for better compatibility of HLS streaming (#1743)
 - Fix: HardSubX OCR on Rust
 - Removed the Share Module
 - Fix: Regression failures on DVD files

--- a/src/lib_ccx/ccx_common_option.h
+++ b/src/lib_ccx/ccx_common_option.h
@@ -198,6 +198,17 @@ struct ccx_s_options // Options from user parameters
 #ifdef WITH_LIBCURL
 	char *curlposturl;
 #endif
+
+
+#ifdef ENABLE_SHARING
+	//CC sharing
+	int sharing_enabled;
+	char *sharing_url;
+	//Translating
+	int translate_enabled;
+	char *translate_langs;
+	char *translate_key;
+#endif
 };
 
 extern struct ccx_s_options ccx_options;

--- a/src/lib_ccx/ccx_encoders_helpers.h
+++ b/src/lib_ccx/ccx_encoders_helpers.h
@@ -49,4 +49,6 @@ void shell_sort(void *base, int nb, size_t size, int (*compar)(const void *p1, c
 
 void ccx_encoders_helpers_perform_shellsort_words(void);
 void ccx_encoders_helpers_setup(enum ccx_encoding_type encoding, int no_font_color, int no_type_setting, int trim_subs);
+
+void webvtt_write_minimal_header(void);
 #endif


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [X] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

**SUMMARY**

This PR ensures that when `--timestamp-map` & `--out=webvtt` is used and no captions are detected, CCExtractor still writes a minimal header containing : `X-TIMESTAMP-MAP=MPEGTS:0,LOCAL:00:00:00.000`
 This makes the generated .vtt file valid for HLS players, which often require this header even in empty subtitle files.

**IMPLEMENTATION DETAILS**

1. `CHANGES.TXT`

 -Added entry under Unreleased: 1.0
 IMPROVEMENT: Add default X-TIMESTAMP-MAP header for empty subtitle files in WebVTT for better compatibility
 of HLS streaming (#1743)

2. `src/ccextractor.c`

 -Call `webvtt_write_minimal_header()` in `start_ccx()` when no captions are found and `--out=webvtt` is set.

3. `src/lib_ccx/ccx_encoders_helpers.c`

 -Added new helper function `webvtt_write_minimal_header()`
 -Which:
     Initializes encoder context for WebVTT.
     Writes a default `X-TIMESTAMP-MAP=MPEGTS:0,LOCAL:00:00:00.000` line.
     Ensures line terminator respects user config (LF vs CRLF).
     Cleans up encoder context properly.

4. `src/lib_ccx/ccx_encoders_helpers.h`

 -Declared the new function: `void webvtt_write_minimal_header(void);`