### PR TITLE
fix: ocr luminance calculation fix

### DIFF
--- a/src/rust/src/hardsubx/imgops.rs
+++ b/src/rust/src/hardsubx/imgops.rs
@@ -1,8 +1,8 @@
-use palette::{FromColor, Hsv, Lab, Srgb};
+use palette::{FromColor, Hsv, Lab, LinSrgb};
 
 #[no_mangle]
 pub extern "C" fn rgb_to_hsv(R: f32, G: f32, B: f32, H: &mut f32, S: &mut f32, V: &mut f32) {
-    let rgb = Srgb::new(R, G, B);
+    let rgb = LinSrgb::new(R, G, B);
 
     let hsv_rep = Hsv::from_color(rgb);
 
@@ -14,7 +14,7 @@ pub extern "C" fn rgb_to_hsv(R: f32, G: f32, B: f32, H: &mut f32, S: &mut f32, V
 #[no_mangle]
 pub extern "C" fn rgb_to_lab(R: f32, G: f32, B: f32, L: &mut f32, a: &mut f32, b: &mut f32) {
     // Normalize input RGB from 0-255 to 0.0-1.0
-    let rgb = Srgb::new(R / 255.0, G / 255.0, B / 255.0);
+    let rgb = LinSrgb::new(R / 255.0, G / 255.0, B / 255.0);
 
     // Convert from sRGB to Lab (D65 white point is default)
     let lab_rep = Lab::from_color(rgb);


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---
Hardsubx in rust currently does not give identical output as the C implementation, often providing inferior results. After debugging for a bit I noticed that there were very slight differences in the luminance masks between both versions. 

In the old C code, the RGB to LAB conversion was done [manually](https://github.com/hrideshmg/ccextractor/blob/ocr_fixes/src/lib_ccx/hardsubx_imgops.c#L69), in rust we [now](https://github.com/hrideshmg/ccextractor/blob/master/src/rust/src/hardsubx/imgops.rs#L15) use the `palette` crate for this purpose. 
The `Srgb` implementation from `palette` we were using till now assumes that the input image is [gamma corrected](https://en.wikipedia.org/wiki/Gamma_correction), and thus performs gamma decoding to make the RGB values linear.

This is unnecessary though, because our input is already linear RGB and was thus causing a faulty conversion. I've modified the code to use [`LinSrgb`](https://docs.rs/palette/latest/palette/type.LinSrgb.html) instead. The Rust implementation now provides identical output to the C code.

Tested on this [sample](https://drive.google.com/file/d/0B_61ywKPmI0TdlRWcVdnajVJUWs/view?resourcekey=0-oCZT9NnDCE9h0jMzcma9wg).