### PR TITLE
[FIX] dockerfile: fix gpac version to 2.4.0

### DIFF
--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache --update git curl gcc cmake glew glfw \
   zlib-dev libpng-dev libjpeg-turbo-dev openssl-dev freetype-dev libxml2-dev bash cargo
 
 WORKDIR /root
-RUN git clone https://github.com/gpac/gpac 
+RUN git clone -b v2.4.0 https://github.com/gpac/gpac
 WORKDIR /root/gpac/
 RUN ./configure && make -j$(nproc) && make install-lib
 WORKDIR /root 


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [x] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

GPAC renamed its libraries to `libgpac.so.13` causing image build  to fail:

```
Error: building at STEP "COPY --from=builder /usr/local/lib/libgpac.so.12 /usr/local/lib/": checking on sources under "/home/pszemus/.local/share/containers/storage/overlay/faa4f2b5c39251a5cf42a97234d2d5652336a2388c96a64d85fc1922c4c43a71/merged": copier: stat: "/usr/local/lib/libgpac.so.12": no such file or directory
```
so let's fix the gpac version to the latest release (2.4.0)

