### PR TITLE
[FIX] Rust: fix setting PSM

### DIFF
--- a/src/rust/src/common.rs
+++ b/src/rust/src/common.rs
@@ -154,6 +154,7 @@ pub unsafe fn copy_from_rust(ccx_s_options: *mut ccx_s_options, options: Options
         (*ccx_s_options).ocrlang = string_to_c_char(ocrlang.to_ctype().as_str());
     }
     (*ccx_s_options).ocr_oem = options.ocr_oem as _;
+    (*ccx_s_options).psm = options.psm as _;
     (*ccx_s_options).ocr_quantmode = options.ocr_quantmode as _;
     if let Some(mkvlang) = options.mkvlang {
         (*ccx_s_options).mkvlang = string_to_c_char(mkvlang.to_ctype().as_str());


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Fix passing PSM option from Rust to CCX
