### PR TITLE
Fix: Rust Clippy failing on 1.90

### DIFF
--- a/src/rust/src/es/pic.rs
+++ b/src/rust/src/es/pic.rs
@@ -249,7 +249,7 @@ pub unsafe fn read_pic_info(
     if dec_ctx.repeat_first_field != 0 {
         dec_ctx.pulldownfields += 1;
         dec_ctx.total_pulldownfields += 1;
-        if dec_ctx.current_progressive_sequence != 0 || (dec_ctx.total_pulldownfields % 2) == 0 {
+        if dec_ctx.current_progressive_sequence != 0 || dec_ctx.total_pulldownfields.is_multiple_of(2) {
             extraframe = 1;
         }
         if dec_ctx.current_progressive_sequence != 0 && dec_ctx.top_field_first != 0 {

--- a/src/rust/src/es/pic.rs
+++ b/src/rust/src/es/pic.rs
@@ -249,7 +249,9 @@ pub unsafe fn read_pic_info(
     if dec_ctx.repeat_first_field != 0 {
         dec_ctx.pulldownfields += 1;
         dec_ctx.total_pulldownfields += 1;
-        if dec_ctx.current_progressive_sequence != 0 || dec_ctx.total_pulldownfields.is_multiple_of(2) {
+        if dec_ctx.current_progressive_sequence != 0
+            || dec_ctx.total_pulldownfields.is_multiple_of(2)
+        {
             extraframe = 1;
         }
         if dec_ctx.current_progressive_sequence != 0 && dec_ctx.top_field_first != 0 {


### PR DESCRIPTION

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

Rust Format SourceCode Fails on 1.90. Minor change to fix it.
