### PR TITLE
FIX: ARM64 build: c_char initialization

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 1.0 (to be released)
 -----------------
+- Fix: ARM64/aarch64 build failure due to c_char type mismatch in nal.rs
 - Fix: HardSubX OCR on Rust
 - Removed the Share Module
 - Fix: Regression failures on DVD files

--- a/src/rust/src/avc/nal.rs
+++ b/src/rust/src/avc/nal.rs
@@ -596,7 +596,7 @@ pub unsafe fn slice_header(
            pic_order_cnt_lsb, (*dec_ctx.timing).current_tref,
            current_index, (*dec_ctx.avc_ctx).currref, (*dec_ctx.avc_ctx).lastmaxidx, (*dec_ctx.avc_ctx).maxtref);
 
-    let mut buf = [c_char::from(0i8); 64];
+    let mut buf = [0 as c_char; 64];
     debug!(
         msg_type = DebugMessageFlag::TIME;
         "  sync_pts:{} ({:8})",


### PR DESCRIPTION
## Description
Fixes #1755 

This PR fixes a compilation failure on ARM64/AArch64 Linux systems. The build was failing with: 

```
error[E0277]: the trait bound `u8: From<i8>` is not satisfied
  --> src/avc/nal.rs:599:20
```
## Problem

The `c_char` type in Rust is platform-dependent:
- On x86_64: `c_char` is `i8` (signed)
- On ARM64/AArch64: `c_char` is `u8` (unsigned)

The original code used `c_char::from(0i8)` which worked on x86_64 but failed on ARM64 because Rust doesn't implement `From<i8>` for `u8`.

## Solution

Changed line 599 in `src/rust/src/avc/nal.rs`:

**Before:**
```rust
let mut buf = [c_char::from(0i8); 64];
```

**After:**
```rust
let mut buf = [0 as c_char; 64];
```

Using `0 as c_char` works on all architectures because zero is valid for both signed and unsigned char types.

## Testing

Verified the fix on both architectures:

| Platform | OS | Arch | Result |
|----------|----|----- |--------|
| VM | Ubuntu 25.04 | aarch64 | ✅ Builds successfully |
| Laptop | Ubuntu 24.04 | x86_64 | ✅ Builds successfully |

## References

- Rust `c_char` docs: https://doc.rust-lang.org/stable/std/os/raw/type.c_char.html
- C Standard Section 6.2.5: Plain `char` signedness is implementation-defined

## Impact

- Fixes builds on all ARM64/AArch64 Linux distributions
- No functional changes - still initializes buffer to null bytes
- No performance impact
- Maintains compatibility with x86_64
---

**In raising this pull request, I confirm the following (please check boxes):**
- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**
- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [x] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.
