### PR TITLE
[FIX]Cargo Clippy failing on 1.91

### DIFF
--- a/src/rust/lib_ccxr/src/common/options.rs
+++ b/src/rust/lib_ccxr/src/common/options.rs
@@ -139,13 +139,7 @@ pub struct Decoder608Report {
     pub cc_channels: [u8; 4],
 }
 
-impl Default for Decoder608ColorCode {
-    fn default() -> Self {
-        Self::Userdefined
-    }
-}
-
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 pub enum Decoder608ColorCode {
     White = 0,
     Green = 1,
@@ -154,6 +148,7 @@ pub enum Decoder608ColorCode {
     Red = 4,
     Yellow = 5,
     Magenta = 6,
+    #[default]
     Userdefined = 7,
     Black = 8,
     Transparent = 9,


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---
Minor Fix - Cargo Clippy failing on the latest version of Rust