### PR TITLE
[FIX] Add step to clean libxml2 downloads in build workflow

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -28,42 +28,58 @@ jobs:
   build_release:
     runs-on: windows-2022
     steps:
-      - name: Remove possibly corrupted libxml2 download
-        shell: pwsh
+      - name: Clear all caches (Debug)
         run: |
-          $dl = Join-Path $env:GITHUB_WORKSPACE "vcpkg\downloads\*libxml2*"
-          Write-Host "Removing: $dl"
-          Remove-Item -Path $dl -Force -ErrorAction SilentlyContinue
+          Write-Host "Clearing vcpkg cache directory..."
+          if (Test-Path "C:\vcpkg") {
+            Remove-Item -Path "C:\vcpkg" -Recurse -Force -ErrorAction SilentlyContinue
+            Write-Host "Cleared C:\vcpkg"
+          }
+          if (Test-Path "C:\vcpkg\.cache") {
+            Remove-Item -Path "C:\vcpkg\.cache" -Recurse -Force -ErrorAction SilentlyContinue
+            Write-Host "Cleared C:\vcpkg\.cache"
+          }
+          Write-Host "Cache clearing complete"
+          
       - name: Check out repository
         uses: actions/checkout@v4
+        
       - name: Setup MSBuild.exe
         uses: microsoft/setup-msbuild@v2.0.0
         with:
           msbuild-architecture: x64
+          
       - name: Install gpac
         run: choco install gpac --version 2.4.0
+        
       - name: Setup vcpkg
         run: mkdir C:\vcpkg\.cache
+        
       - name: Cache vcpkg
         id: cache
         uses: actions/cache@v4
         with:
           path: |
             C:\vcpkg\.cache
-          key: vcpkg-${{ runner.os }}-${{ env.VCPKG_COMMIT }}
+          key: vcpkg-${{ runner.os }}-${{ env.VCPKG_COMMIT }}-debug-v1
+          
       - name: Build vcpkg
         run: |
           git clone https://github.com/microsoft/vcpkg
           ./vcpkg/bootstrap-vcpkg.bat
+          
       - name: Install dependencies
         run: ${{ github.workspace }}/vcpkg/vcpkg.exe install --x-install-root ${{ github.workspace }}/vcpkg/installed/
         working-directory: windows
+        
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
+          
       - name: Install Win 10 SDK
         uses: ilammy/msvc-dev-cmd@v1
+        
       - name: build Release-Full
         env:
           LIBCLANG_PATH: "C:\\Program Files\\LLVM\\lib"
@@ -73,48 +89,73 @@ jobs:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
         run: msbuild ccextractor.sln /p:Configuration=Release-Full /p:Platform=x64
         working-directory: ./windows
+        
       - name: Display version information
         run: ./ccextractorwinfull.exe --version
         working-directory: ./windows/x64/Release-Full
+        
       - uses: actions/upload-artifact@v4
         with:
           name: CCExtractor Windows Release build
           path: |
             ./windows/x64/Release-Full/ccextractorwinfull.exe
             ./windows/x64/Release-Full/*.dll
+            
   build_debug:
     runs-on: windows-2022
     steps:
+      - name: Clear all caches (Debug)
+        run: |
+          Write-Host "Clearing vcpkg cache directory..."
+          if (Test-Path "C:\vcpkg") {
+            Remove-Item -Path "C:\vcpkg" -Recurse -Force -ErrorAction SilentlyContinue
+            Write-Host "Cleared C:\vcpkg"
+          }
+          if (Test-Path "C:\vcpkg\.cache") {
+            Remove-Item -Path "C:\vcpkg\.cache" -Recurse -Force -ErrorAction SilentlyContinue
+            Write-Host "Cleared C:\vcpkg\.cache"
+          }
+          Write-Host "Cache clearing complete"
+          
       - name: Check out repository
         uses: actions/checkout@v4
+        
       - name: Setup MSBuild.exe
         uses: microsoft/setup-msbuild@v2.0.0
         with:
           msbuild-architecture: x64
+          
       - name: Install gpac
         run: choco install gpac --version 2.4.0
+        
       - name: Setup vcpkg
         run: mkdir C:\vcpkg\.cache
+        
       - name: Cache vcpkg
         id: cache
         uses: actions/cache@v4
         with:
           path: |
             C:\vcpkg\.cache
-          key: vcpkg-${{ runner.os }}-${{ env.VCPKG_COMMIT }}
+          key: vcpkg-${{ runner.os }}-${{ env.VCPKG_COMMIT }}-debug-v1
+          
       - name: Build vcpkg
         run: |
           git clone https://github.com/microsoft/vcpkg
           ./vcpkg/bootstrap-vcpkg.bat
+          
       - name: Install dependencies
         run: ${{ github.workspace }}/vcpkg/vcpkg.exe install --x-install-root ${{ github.workspace }}/vcpkg/installed/
         working-directory: windows
+        
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
+          
       - name: Install Win 10 SDK
         uses: ilammy/msvc-dev-cmd@v1
+        
       - name: build Debug-Full
         env:
           LIBCLANG_PATH: "C:\\Program Files\\LLVM\\lib"
@@ -124,10 +165,12 @@ jobs:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
         run: msbuild ccextractor.sln /p:Configuration=Debug-Full /p:Platform=x64
         working-directory: ./windows
+        
       - name: Display version information
         continue-on-error: true
         run: ./ccextractorwinfull.exe --version
         working-directory: ./windows/x64/Debug-Full
+        
       - uses: actions/upload-artifact@v4
         with:
           name: CCExtractor Windows Debug build


### PR DESCRIPTION
Added a step to remove potentially corrupted libxml2 downloads before building.

<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---
Currently Testing
