### PR TITLE
Fix vcpkg baseline

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -31,7 +31,7 @@ encoding_rs = "0.8.5"
 rsmpeg = { version = "0.14.2", default-features = false, features = ["ffmpeg6", "link_system_ffmpeg"], optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-rsmpeg = { version = "0.14.2", default-features = false, features = ["ffmpeg6", "link_system_ffmpeg"], optional = true }
+rsmpeg = "0.12.0"
 
 # Fallback for other platforms (FreeBSD, etc.)
 [target.'cfg(not(any(target_os = "linux", target_os = "windows")))'.dependencies]


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

{pull request content here}
