### PR TITLE
[FIX] Fix missing X-TIMESTAMP-MAP header in WebVTT when no subtitles found

### DIFF
--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -176,6 +176,10 @@ int write_subtitle_file_footer(struct encoder_ctx *ctx, struct ccx_s_write *out)
 		case CCX_OF_CCD:
 			ret = write(out->fh, ctx->encoded_crlf, ctx->encoded_crlf_length);
 			break;
+		case CCX_OF_WEBVTT:
+			// Ensure header is written even if no subtitles were found
+			write_webvtt_header(ctx, out);
+			break;
 		default: // Nothing to do, no footer on this format
 			break;
 	}

--- a/src/lib_ccx/ccx_encoders_common.h
+++ b/src/lib_ccx/ccx_encoders_common.h
@@ -237,6 +237,7 @@ int write_cc_bitmap_as_spupng          (struct cc_subtitle *sub, struct encoder_
 int write_cc_bitmap_as_transcript      (struct cc_subtitle *sub, struct encoder_ctx *context);
 int write_cc_bitmap_as_libcurl         (struct cc_subtitle *sub, struct encoder_ctx *context);
 
+void write_webvtt_header(struct encoder_ctx *context, struct ccx_s_write *out);
 void write_spumux_header(struct encoder_ctx *ctx, struct ccx_s_write *out);
 void write_spumux_footer(struct ccx_s_write *out);
 

--- a/src/lib_ccx/lib_ccx.c
+++ b/src/lib_ccx/lib_ccx.c
@@ -209,6 +209,7 @@ void dinit_libraries(struct lib_ccx_ctx **ctx)
 {
 	struct lib_ccx_ctx *lctx = *ctx;
 	struct encoder_ctx *enc_ctx;
+	struct encoder_ctx *enc_ctx1;
 	struct lib_cc_decode *dec_ctx;
 	struct lib_cc_decode *dec_ctx1;
 	int i;
@@ -237,6 +238,17 @@ void dinit_libraries(struct lib_ccx_ctx **ctx)
 		{
 			list_del(&enc_ctx->list);
 			dinit_encoder(&enc_ctx, cfts);
+		}
+	}
+
+	// Cleanup any remaining encoders that weren't associated with a decoder
+	// (e.g., when no subtitles were found but output file was created)
+	if (!list_empty(&lctx->enc_ctx_head))
+	{
+		list_for_each_entry_safe(enc_ctx, enc_ctx1, &lctx->enc_ctx_head, list, struct encoder_ctx)
+		{
+			list_del(&enc_ctx->list);
+			dinit_encoder(&enc_ctx, 0);
 		}
 	}
 


### PR DESCRIPTION
## Problem

I noticed that when running CCExtractor with the `--timestamp-map` flag on a video file that has no subtitles, the resulting WebVTT file was just empty with only "WEBVTT" at the top. The `X-TIMESTAMP-MAP` header was completely missing, which breaks HLS streaming compatibility.

## What I changed

- Updated `write_webvtt_header()` so it can write to a specific output file
- Added a fallback that writes a default timestamp map (`X-TIMESTAMP-MAP=MPEGTS:0,LOCAL:00:00:00.000`) when there's no timing info available
- Made sure WebVTT files get their header written even when there are no subtitles by handling this in `write_subtitle_file_footer()`
- Fixed a cleanup issue where encoders weren't being properly closed if no subtitles were found

Fixes #1743

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

## Testing

Ran CCExtractor on a `.ts` file with no subtitles using the `--timestamp-map` flag. Before this fix, the output was just "WEBVTT". Now it correctly outputs:
