### PR TITLE
[FIX] Handle double-hyphens in XML comments in spupng encoder

### DIFF
--- a/src/lib_ccx/ccx_encoders_spupng.c
+++ b/src/lib_ccx/ccx_encoders_spupng.c
@@ -186,7 +186,38 @@ void write_sputag_close(struct spupng_t *sp)
 }
 void write_spucomment(struct spupng_t *sp, const char *str)
 {
-	fprintf(sp->fpxml, "<!--\n%s\n-->\n", str);
+	fprintf(sp->fpxml, "<!--\n");
+
+	const char *p = str;
+	const char *last_safe_pos = str; // Track the last safe position to flush
+
+	while (*p)
+	{
+
+		if (*p == '-' && *(p + 1) == '-')
+		{
+
+			if (p > last_safe_pos)
+			{
+				fwrite(last_safe_pos, 1, p - last_safe_pos, sp->fpxml);
+			}
+
+			fputc('-', sp->fpxml);
+			p += 2;
+			last_safe_pos = p;
+		}
+		else
+		{
+			p++;
+		}
+	}
+
+	if (p > last_safe_pos)
+	{
+		fwrite(last_safe_pos, 1, p - last_safe_pos, sp->fpxml);
+	}
+
+	fprintf(sp->fpxml, "\n-->\n");
 }
 
 char *get_spupng_filename(void *ctx)


### PR DESCRIPTION
## Summary
- Fixed `write_spucomment` to handle double-hyphens (`--`) which are invalid inside XML comments
- The fix removes one hyphen when encountering `--` sequences to produce valid XML output
- Rebased onto current master
- Applied clang-format

Supersedes #1642

## Test plan
- Generate SPUPNG output with captions containing `--`
- Verify the resulting XML is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)