### PR TITLE
Fix #1779: Update COMPILATION.md to reflect correct Linux build flags

### DIFF
--- a/docs/COMPILATION.MD
+++ b/docs/COMPILATION.MD
@@ -66,9 +66,6 @@ cd ccextractor/linux
 # compile without debug flags
 ./build
 
-# compile without rust
-./build -without-rust
-
 # compile with debug info
 ./build -debug            # same as ./builddebug
 
@@ -89,9 +86,6 @@ FFMPEG_VERSION=ffmpeg7 ./build -hardsubx  # force FFmpeg 7 on any platform
 FFMPEG_INCLUDE_DIR=/usr/include 
 FFMPEG_PKG_CONFIG_PATH=/usr/lib/pkgconfig
 
-# compile in debug mode without rust
-./build -debug -without-rust
-
 # test your build
 ./ccextractor
 ```
@@ -102,7 +96,7 @@ FFMPEG_PKG_CONFIG_PATH=/usr/lib/pkgconfig
 sudo apt-get install autoconf  # dependency to generate configuration script
 cd ccextractor/linux
 ./autogen.sh
-./configure                    # OR ./configure --without-rust
+./configure                    # OR ./configure --without-rust (to build without Rust)
 make
 
 # test your build


### PR DESCRIPTION
✅ Problem
The Linux build script (ccextractor/linux/build) does not support the -without-rust flag, yet the documentation suggested it could be used:
     ./build -without-rust
     ./build -debug -without-rust
    
This caused confusion because the build script only supports:
-debug
-hardsubx

Meanwhile, the --without-rust option does exist, but only in the autoconf-based workflow (./configure --without-rust).

🔧 Changes Made

- Removed all incorrect references to ./build -without-rust
- Removed the incorrect combined example ./build -debug -without-rust
- Clarified that --without-rust is a valid option only for autoconf builds
- Updated COMPILATION.md to accurately reflect supported flags