### PR TITLE
Fix G608 output extra NULL character (#1777)

### DIFF
--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -1181,7 +1181,7 @@ unsigned int get_line_encoded(struct encoder_ctx *ctx, unsigned char *buffer, in
 {
 	unsigned char *orig = buffer; // Keep for debugging
 	unsigned char *line = data->characters[line_num];
-	for (int i = 0; i < 33; i++)
+	for (int i = 0; i < 32; i++)
 	{
 		int bytes = 0;
 		switch (ctx->encoding)
@@ -1215,7 +1215,6 @@ unsigned int get_color_encoded(struct encoder_ctx *ctx, unsigned char *buffer, i
 		else
 			*buffer++ = 'E';
 	}
-	*buffer = 0;
 	return (unsigned)(buffer - orig); // Return length
 }
 unsigned int get_font_encoded(struct encoder_ctx *ctx, unsigned char *buffer, int line_num, struct eia608_screen *data)


### PR DESCRIPTION
Changes Made:
1. Fixed `get_line_encoded()` in `ccx_encoders_common.c`:
   - Changed loop from `for (int i = 0; i < 33; i++)` to `for (int i = 0; i < 32; i++)`
   - Was reading 33 characters instead of the specified 32

2. Fixed `get_color_encoded()` in `ccx_encoders_common.c`:
   - Removed `*buffer = 0;` line that added a NULL terminator
   - This NULL was being written to the output file

Result:
G608 output now correctly contains:
- 32 characters of text
- 32 characters of color codes  
- 32 characters of font codes
- Total: 96 characters per line (no extra NULL bytes)

Fixes #1777