### PR TITLE
fix(rust): remove unused assignments in tv_screen.rs

### DIFF
--- a/src/rust/src/decoder/tv_screen.rs
+++ b/src/rust/src/decoder/tv_screen.rs
@@ -454,7 +454,6 @@ impl dtvcc_tv_screen {
                 // Correct the frame delay
                 time_show.time_in_ms -= 1000 / 29.97 as i64;
                 buf.push_str(&(get_scc_time_str(time_show) + "\t942c 942c ").to_owned());
-                time_show.time_in_ms += 1000 / 29.97 as i64;
                 // Clear the buffer and start pop on caption
                 buf.push_str("94ae 94ae 9420 9420");
             }
@@ -466,14 +465,12 @@ impl dtvcc_tv_screen {
                 time_show.time_in_ms -= 1000 / 29.97 as i64;
                 // Clear the buffer and start pop on caption in new time
                 buf.push_str(&(get_scc_time_str(time_show) + "\t94ae 94ae 9420 9420").to_owned());
-                time_show.time_in_ms += 1000 / 29.97 as i64;
             }
             Ordering::Equal => {
                 time_show.time_in_ms -= 1000 / 29.97 as i64;
                 buf.push_str(
                     &(get_scc_time_str(time_show) + "\t942c 942c 94ae 94ae 9420 9420").to_owned(),
                 );
-                time_show.time_in_ms += 1000 / 29.97 as i64;
             }
         }
 


### PR DESCRIPTION
## Summary

Remove three unused assignments to `time_show.time_in_ms` in `src/rust/src/decoder/tv_screen.rs` that were flagged by Clippy as "value assigned is never read".

### Issue

Clippy reported warnings:
```
warning: value assigned to `time_show` is never read
   --> src/decoder/tv_screen.rs:457:17
warning: value assigned to `time_show` is never read
   --> src/decoder/tv_screen.rs:469:17
warning: value assigned to `time_show` is never read
   --> src/decoder/tv_screen.rs:476:17
```

### Root Cause

The code pattern was:
1. Subtract frame delay from `time_show.time_in_ms`
2. Use the modified value in `get_scc_time_str(time_show)`
3. Add frame delay back (restore original value)

However, since `time_show` is not used after the match statement ends, the restoration assignments (step 3) were unnecessary dead code.

### Changes

Removed the three unnecessary `+= 1000 / 29.97 as i64` assignments at the end of each match branch.

## Test plan

- [x] Code compiles without errors
- [x] Clippy warnings for tv_screen.rs are resolved
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)