### PR TITLE
fix(encoders): replace sprintf/strcpy with bounds-checked versions

### DIFF
--- a/src/lib_ccx/ccx_encoders_sami.c
+++ b/src/lib_ccx/ccx_encoders_sami.c
@@ -15,7 +15,7 @@ int write_stringz_as_sami(char *string, struct encoder_ctx *context, LLONG ms_st
 	unsigned char *el = NULL;
 	char str[1024];
 
-	sprintf(str, "<SYNC start=%llu><P class=\"UNKNOWNCC\">\r\n", (unsigned long long)ms_start);
+	snprintf(str, sizeof(str), "<SYNC start=%llu><P class=\"UNKNOWNCC\">\r\n", (unsigned long long)ms_start);
 	if (context->encoding != CCX_ENC_UNICODE)
 	{
 		dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
@@ -85,7 +85,7 @@ int write_stringz_as_sami(char *string, struct encoder_ctx *context, LLONG ms_st
 		begin += strlen((const char *)begin) + 1;
 	}
 
-	sprintf((char *)str, "</P></SYNC>\r\n");
+	snprintf(str, sizeof(str), "</P></SYNC>\r\n");
 	if (context->encoding != CCX_ENC_UNICODE)
 	{
 		dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
@@ -94,9 +94,9 @@ int write_stringz_as_sami(char *string, struct encoder_ctx *context, LLONG ms_st
 	ret = write(context->out->fh, context->buffer, used);
 	if (ret != used)
 		goto end;
-	sprintf((char *)str,
-		"<SYNC start=%llu><P class=\"UNKNOWNCC\">&nbsp;</P></SYNC>\r\n\r\n",
-		(unsigned long long)ms_end);
+	snprintf(str, sizeof(str),
+		 "<SYNC start=%llu><P class=\"UNKNOWNCC\">&nbsp;</P></SYNC>\r\n\r\n",
+		 (unsigned long long)ms_end);
 	if (context->encoding != CCX_ENC_UNICODE)
 	{
 		dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
@@ -127,8 +127,8 @@ int write_cc_bitmap_as_sami(struct cc_subtitle *sub, struct encoder_ctx *context
 
 	if (sub->data != NULL) // then we should write the sub
 	{
-		sprintf(buf,
-			"<SYNC start=%llu><P class=\"UNKNOWNCC\">\r\n", (unsigned long long)sub->start_time);
+		snprintf(buf, context->capacity,
+			 "<SYNC start=%llu><P class=\"UNKNOWNCC\">\r\n", (unsigned long long)sub->start_time);
 		write_wrapped(context->out->fh, buf, strlen(buf));
 		for (int i = sub->nb_data - 1; i >= 0; i--)
 		{
@@ -137,7 +137,7 @@ int write_cc_bitmap_as_sami(struct cc_subtitle *sub, struct encoder_ctx *context
 				if (context->prev_start != -1 || !(sub->flags & SUB_EOD_MARKER))
 				{
 					token = strtok(rect[i].ocr_text, "\r\n");
-					sprintf(buf, "%s", token);
+					snprintf(buf, context->capacity, "%s", token);
 					token = strtok(NULL, "\r\n");
 					write_wrapped(context->out->fh, buf, strlen(buf));
 					if (i != 0)
@@ -146,13 +146,13 @@ int write_cc_bitmap_as_sami(struct cc_subtitle *sub, struct encoder_ctx *context
 				}
 			}
 		}
-		sprintf(buf, "</P></SYNC>\r\n");
+		snprintf(buf, context->capacity, "</P></SYNC>\r\n");
 		write_wrapped(context->out->fh, buf, strlen(buf));
 	}
 	else // we write an empty subtitle to clear the old one
 	{
-		sprintf(buf,
-			"<SYNC start=%llu><P class=\"UNKNOWNCC\">&nbsp;</P></SYNC>\r\n\r\n", (unsigned long long)sub->start_time);
+		snprintf(buf, context->capacity,
+			 "<SYNC start=%llu><P class=\"UNKNOWNCC\">&nbsp;</P></SYNC>\r\n\r\n", (unsigned long long)sub->start_time);
 		write_wrapped(context->out->fh, buf, strlen(buf));
 	}
 #endif
@@ -194,8 +194,8 @@ int write_cc_buffer_as_sami(struct eia608_screen *data, struct encoder_ctx *cont
 	int wrote_something = 0;
 	char str[1024];
 
-	sprintf(str, "<SYNC start=%llu><P class=\"UNKNOWNCC\">\r\n",
-		(unsigned long long)data->start_time);
+	snprintf(str, sizeof(str), "<SYNC start=%llu><P class=\"UNKNOWNCC\">\r\n",
+		 (unsigned long long)data->start_time);
 	if (context->encoding != CCX_ENC_UNICODE)
 	{
 		dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
@@ -219,16 +219,16 @@ int write_cc_buffer_as_sami(struct eia608_screen *data, struct encoder_ctx *cont
 			write_wrapped(context->out->fh, context->encoded_crlf, context->encoded_crlf_length);
 		}
 	}
-	sprintf((char *)str, "</P></SYNC>\r\n");
+	snprintf(str, sizeof(str), "</P></SYNC>\r\n");
 	if (context->encoding != CCX_ENC_UNICODE)
 	{
 		dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);
 	}
 	used = encode_line(context, context->buffer, (unsigned char *)str);
 	write_wrapped(context->out->fh, context->buffer, used);
-	sprintf((char *)str,
-		"<SYNC start=%llu><P class=\"UNKNOWNCC\">&nbsp;</P></SYNC>\r\n\r\n",
-		(unsigned long long)data->end_time - 1); // - 1 to prevent overlap
+	snprintf(str, sizeof(str),
+		 "<SYNC start=%llu><P class=\"UNKNOWNCC\">&nbsp;</P></SYNC>\r\n\r\n",
+		 (unsigned long long)data->end_time - 1); // - 1 to prevent overlap
 	if (context->encoding != CCX_ENC_UNICODE)
 	{
 		dbg_print(CCX_DMT_DECODER_608, "\r%s\n", str);

--- a/src/lib_ccx/ccx_encoders_srt.c
+++ b/src/lib_ccx/ccx_encoders_srt.c
@@ -21,11 +21,11 @@ int write_stringz_as_srt(char *string, struct encoder_ctx *context, LLONG ms_sta
 	millis_to_time(ms_start, &h1, &m1, &s1, &ms1);
 	millis_to_time(ms_end - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
 	context->srt_counter++;
-	sprintf(timeline, "%u%s", context->srt_counter, context->encoded_crlf);
+	snprintf(timeline, sizeof(timeline), "%u%s", context->srt_counter, context->encoded_crlf);
 	used = encode_line(context, context->buffer, (unsigned char *)timeline);
 	write_wrapped(context->out->fh, context->buffer, used);
-	sprintf(timeline, "%02u:%02u:%02u,%03u --> %02u:%02u:%02u,%03u%s",
-		h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
+	snprintf(timeline, sizeof(timeline), "%02u:%02u:%02u,%03u --> %02u:%02u:%02u,%03u%s",
+		 h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
 	used = encode_line(context, context->buffer, (unsigned char *)timeline);
 	dbg_print(CCX_DMT_DECODER_608, "\n- - - SRT caption - - -\n");
 	dbg_print(CCX_DMT_DECODER_608, "%s", timeline);
@@ -112,11 +112,11 @@ int write_cc_bitmap_as_srt(struct cc_subtitle *sub, struct encoder_ctx *context)
 				millis_to_time(sub->start_time, &h1, &m1, &s1, &ms1);
 				millis_to_time(sub->end_time - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
 				context->srt_counter++;
-				sprintf(timeline, "%u%s", context->srt_counter, context->encoded_crlf);
+				snprintf(timeline, sizeof(timeline), "%u%s", context->srt_counter, context->encoded_crlf);
 				used = encode_line(context, context->buffer, (unsigned char *)timeline);
 				write_wrapped(context->out->fh, context->buffer, used);
-				sprintf(timeline, "%02u:%02u:%02u,%03u --> %02u:%02u:%02u,%03u%s",
-					h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
+				snprintf(timeline, sizeof(timeline), "%02u:%02u:%02u,%03u --> %02u:%02u:%02u,%03u%s",
+					 h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
 				used = encode_line(context, context->buffer, (unsigned char *)timeline);
 				write_wrapped(context->out->fh, context->buffer, used);
 				len = strlen(str);
@@ -196,12 +196,12 @@ int write_cc_buffer_as_srt(struct eia608_screen *data, struct encoder_ctx *conte
 	char timeline[128];
 
 	++context->srt_counter;
-	sprintf(timeline, "%u%s", context->srt_counter, context->encoded_crlf);
+	snprintf(timeline, sizeof(timeline), "%u%s", context->srt_counter, context->encoded_crlf);
 	used = encode_line(context, context->buffer, (unsigned char *)timeline);
 	write_wrapped(context->out->fh, context->buffer, used);
 
-	sprintf(timeline, "%02u:%02u:%02u,%03u --> %02u:%02u:%02u,%03u%s",
-		h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
+	snprintf(timeline, sizeof(timeline), "%02u:%02u:%02u,%03u --> %02u:%02u:%02u,%03u%s",
+		 h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
 	used = encode_line(context, context->buffer, (unsigned char *)timeline);
 	write_wrapped(context->out->fh, context->buffer, used);
 

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -131,8 +131,8 @@ int write_stringz_as_webvtt(char *string, struct encoder_ctx *context, LLONG ms_
 	millis_to_time(ms_start, &h1, &m1, &s1, &ms1);
 	millis_to_time(ms_end - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
 
-	sprintf(timeline, "%02u:%02u:%02u.%03u --> %02u:%02u:%02u.%03u%s",
-		h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
+	snprintf(timeline, sizeof(timeline), "%02u:%02u:%02u.%03u --> %02u:%02u:%02u.%03u%s",
+		 h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
 	used = encode_line(context, context->buffer, (unsigned char *)timeline);
 	dbg_print(CCX_DMT_DECODER_608, "\n- - - WEBVTT caption - - -\n");
 	dbg_print(CCX_DMT_DECODER_608, "%s", timeline);
@@ -215,9 +215,9 @@ void write_webvtt_header(struct encoder_ctx *context)
 		millis_to_time(context->timing->sync_pts2fts_fts, &h1, &m1, &s1, &ms1);
 
 		// If the user has enabled X-TIMESTAMP-MAP
-		sprintf(header_string, "X-TIMESTAMP-MAP=MPEGTS:%ld,LOCAL:%02u:%02u:%02u.%03u%s",
-			context->timing->sync_pts2fts_pts, h1, m1, s1, ms1,
-			ccx_options.enc_cfg.line_terminator_lf ? "\n\n" : "\r\n\r\n");
+		snprintf(header_string, sizeof(header_string), "X-TIMESTAMP-MAP=MPEGTS:%ld,LOCAL:%02u:%02u:%02u.%03u%s",
+			 context->timing->sync_pts2fts_pts, h1, m1, s1, ms1,
+			 ccx_options.enc_cfg.line_terminator_lf ? "\n\n" : "\r\n\r\n");
 
 		used = encode_line(context, context->buffer, (unsigned char *)header_string);
 		write_wrapped(context->out->fh, context->buffer, used);
@@ -238,21 +238,35 @@ void write_webvtt_header(struct encoder_ctx *context)
 	if (ccx_options.webvtt_create_css)
 	{
 		char *basefilename = get_basename(context->first_input_file);
-		char *css_file_name = (char *)malloc((strlen(basefilename) + 4) * sizeof(char)); // strlen(".css") == 4
-		sprintf(css_file_name, "%s.css", basefilename);
+		size_t css_file_name_size = strlen(basefilename) + 5; // strlen(".css") + 1 for null
+		char *css_file_name = (char *)malloc(css_file_name_size);
+		if (!css_file_name)
+		{
+			fatal(EXIT_NOT_ENOUGH_MEMORY, "In write_webvtt_header: Out of memory allocating css_file_name.");
+		}
+		snprintf(css_file_name, css_file_name_size, "%s.css", basefilename);
 
 		FILE *f = fopen(css_file_name, "wb");
 		if (f == NULL)
 		{
 			mprint("Warning: Error creating the file %s\n", css_file_name);
+			free(css_file_name);
 			return;
 		}
 		fprintf(f, "%s", webvtt_inline_css);
 		fclose(f);
 
-		char *outline_css_file = (char *)malloc((strlen(css_file_name) + strlen(webvtt_outline_css)) * sizeof(char));
-		sprintf(outline_css_file, webvtt_outline_css, css_file_name);
+		size_t outline_css_file_size = strlen(css_file_name) + strlen(webvtt_outline_css) + 1;
+		char *outline_css_file = (char *)malloc(outline_css_file_size);
+		if (!outline_css_file)
+		{
+			free(css_file_name);
+			fatal(EXIT_NOT_ENOUGH_MEMORY, "In write_webvtt_header: Out of memory allocating outline_css_file.");
+		}
+		snprintf(outline_css_file, outline_css_file_size, webvtt_outline_css, css_file_name);
 		write_wrapped(context->out->fh, outline_css_file, strlen(outline_css_file));
+		free(css_file_name);
+		free(outline_css_file);
 	}
 	else if (ccx_options.use_webvtt_styling)
 	{
@@ -301,8 +315,8 @@ int write_cc_bitmap_as_webvtt(struct cc_subtitle *sub, struct encoder_ctx *conte
 			millis_to_time(sub->start_time, &h1, &m1, &s1, &ms1);
 			millis_to_time(sub->end_time - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
 			context->srt_counter++;					// Not needed for WebVTT but let's keep it around for now
-			sprintf(timeline, "%02u:%02u:%02u.%03u --> %02u:%02u:%02u.%03u%s",
-				h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
+			snprintf(timeline, sizeof(timeline), "%02u:%02u:%02u.%03u --> %02u:%02u:%02u.%03u%s",
+				 h1, m1, s1, ms1, h2, m2, s2, ms2, context->encoded_crlf);
 			used = encode_line(context, context->buffer, (unsigned char *)timeline);
 			write_wrapped(context->out->fh, context->buffer, used);
 			len = strlen(str);
@@ -436,8 +450,8 @@ int write_cc_buffer_as_webvtt(struct eia608_screen *data, struct encoder_ctx *co
 		{
 			char timeline[128] = "";
 
-			sprintf(timeline, "%02u:%02u:%02u.%03u --> %02u:%02u:%02u.%03u line:%s%%%s",
-				h1, m1, s1, ms1, h2, m2, s2, ms2, webvtt_pac_row_percent[i], context->encoded_crlf);
+			snprintf(timeline, sizeof(timeline), "%02u:%02u:%02u.%03u --> %02u:%02u:%02u.%03u line:%s%%%s",
+				 h1, m1, s1, ms1, h2, m2, s2, ms2, webvtt_pac_row_percent[i], context->encoded_crlf);
 			used = encode_line(context, context->buffer, (unsigned char *)timeline);
 
 			dbg_print(CCX_DMT_DECODER_608, "\n- - - WEBVTT caption - - -\n");

--- a/src/lib_ccx/mp4.c
+++ b/src/lib_ccx/mp4.c
@@ -223,12 +223,12 @@ static int process_avc_track(struct lib_ccx_ctx *ctx, const char *basename, GF_I
 	return status;
 }
 
-static char *format_duration(u64 dur, u32 timescale, char *szDur)
+static char *format_duration(u64 dur, u32 timescale, char *szDur, size_t szDur_size)
 {
 	u32 h, m, s, ms;
 	if ((dur == (u64)-1) || (dur == (u32)-1))
 	{
-		strcpy(szDur, "Unknown");
+		snprintf(szDur, szDur_size, "Unknown");
 		return szDur;
 	}
 	dur = (u64)((((Double)(s64)dur) / timescale) * 1000);
@@ -238,7 +238,7 @@ static char *format_duration(u64 dur, u32 timescale, char *szDur)
 	ms = (u32)(dur)-h * 3600000 - m * 60000 - s * 1000;
 	if (h <= 24)
 	{
-		sprintf(szDur, "%02d:%02d:%02d.%03d", h, m, s, ms);
+		snprintf(szDur, szDur_size, "%02d:%02d:%02d.%03d", h, m, s, ms);
 	}
 	else
 	{
@@ -246,7 +246,7 @@ static char *format_duration(u64 dur, u32 timescale, char *szDur)
 		h = (u32)(dur / 3600000) - 24 * d;
 		if (d <= 365)
 		{
-			sprintf(szDur, "%d Days, %02d:%02d:%02d.%03d", d, h, m, s, ms);
+			snprintf(szDur, szDur_size, "%d Days, %02d:%02d:%02d.%03d", d, h, m, s, ms);
 		}
 		else
 		{
@@ -258,7 +258,7 @@ static char *format_duration(u64 dur, u32 timescale, char *szDur)
 				if (y % 4)
 					d--;
 			}
-			sprintf(szDur, "%d Years %d Days, %02d:%02d:%02d.%03d", y, d, h, m, s, ms);
+			snprintf(szDur, szDur_size, "%d Years %d Days, %02d:%02d:%02d.%03d", y, d, h, m, s, ms);
 		}
 	}
 	return szDur;
@@ -824,8 +824,7 @@ int dumpchapters(struct lib_ccx_ctx *ctx, struct ccx_s_mp4Cfg *cfg, char *file)
 	{
 		if (file)
 		{
-			strcpy(szName, get_basename(file));
-			strcat(szName, ".txt");
+			snprintf(szName, sizeof(szName), "%s.txt", get_basename(file));
 
 			t = gf_fopen(szName, "wt");
 			if (!t)
@@ -847,9 +846,9 @@ int dumpchapters(struct lib_ccx_ctx *ctx, struct ccx_s_mp4Cfg *cfg, char *file)
 	{
 		u64 chapter_time;
 		const char *name;
-		char szDur[20];
+		char szDur[64];
 		gf_isom_get_chapter(f, 0, i + 1, &chapter_time, &name);
-		fprintf(t, "CHAPTER%02d=%s\n", i + 1, format_duration(chapter_time, 1000, szDur));
+		fprintf(t, "CHAPTER%02d=%s\n", i + 1, format_duration(chapter_time, 1000, szDur, sizeof(szDur)));
 		fprintf(t, "CHAPTER%02dNAME=%s\n", i + 1, name);
 	}
 	if (file)


### PR DESCRIPTION
## Summary

This PR continues the Phase 3 buffer safety work from the bug analysis plan, replacing unsafe string functions with bounds-checked alternatives:

- **ccx_encoders_sami.c**: 10 `sprintf` → `snprintf` conversions
- **ccx_encoders_srt.c**: 6 `sprintf` → `snprintf` conversions  
- **mp4.c**: 6 fixes including:
  - `sprintf`/`strcpy`/`strcat` → `snprintf`
  - **Critical fix**: Buffer overflow in `format_duration()` where 20-byte buffer was too small for long duration strings (e.g., "365 Days, 23:59:59.999" = 22+ chars)
  - Added size parameter to `format_duration()` function
- **ccx_encoders_webvtt.c**: 6 `sprintf` → `snprintf` conversions, plus:
  - Fixed malloc size bug (`+4` instead of `+5` for null terminator)
  - Added OOM checks for `css_file_name` and `outline_css_file`
  - Fixed memory leaks (allocated strings were not freed)

## Test plan

- [x] Build completes successfully
- [ ] Test with SAMI output format
- [ ] Test with SRT output format
- [ ] Test with WebVTT output format (including CSS generation)
- [ ] Test with MP4 files containing chapters

🤖 Generated with [Claude Code](https://claude.com/claude-code)