### PR TITLE
fix(parser): use HHMMSSFFF format for ttxt output timestamps

### DIFF
--- a/src/rust/src/parser.rs
+++ b/src/rust/src/parser.rs
@@ -238,7 +238,7 @@ impl OptionsExt for Options {
             OutFormat::Ttxt => {
                 self.write_format = OutputFormat::Transcript;
                 if self.date_format == TimestampFormat::None {
-                    self.date_format = TimestampFormat::HHMMSS;
+                    self.date_format = TimestampFormat::HHMMSSFFF;
                 }
                 // Sets the right things so that timestamps and the mode are printed.
                 if !self.transcript_settings.is_final {


### PR DESCRIPTION
## Summary

Fixes a regression in ttxt output where timestamps were missing milliseconds.

The Rust parser was incorrectly setting `date_format` to `TimestampFormat::HHMMSS` (no milliseconds) instead of `TimestampFormat::HHMMSSFFF` (with milliseconds) for `--out=ttxt`.

This bug was introduced in PR #1619 when porting the parser to Rust. The original C code correctly used `ODF_HHMMSSMS` which includes milliseconds in the timestamp format (`HH:MM:SS,mmm`).

### Before (incorrect)
```
00:00:00|00:00:03|TLT|<font color="#ffff00">and he was pretty convinced</font>...
```

### After (correct, matching original C behavior)
```
00:00:00,480|00:00:03,520|TLT|<font color="#ffff00">and he was pretty convinced</font>...
```

## Root Cause

In `src/rust/src/parser.rs`, the `OutFormat::Ttxt` handler was setting:
```rust
self.date_format = TimestampFormat::HHMMSS;  // Wrong - no milliseconds
```

Instead of:
```rust
self.date_format = TimestampFormat::HHMMSSFFF;  // Correct - includes milliseconds
```

## Verification

Tested locally with teletext sample:
```
ccextractor --autoprogram --out=ttxt --latin1 sample.mpg -o output.txt
```

Output now correctly includes milliseconds in timestamps.

## Test plan

- [x] Verified locally that milliseconds now appear in ttxt output
- [ ] CI teletext tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)