### PR TITLE
fix(rust): correctly count and store multiple input files

### DIFF
--- a/src/rust/src/common.rs
+++ b/src/rust/src/common.rs
@@ -212,8 +212,13 @@ pub unsafe fn copy_from_rust(ccx_s_options: *mut ccx_s_options, options: Options
     }
     if options.inputfile.is_some() {
         (*ccx_s_options).inputfile = string_to_c_chars(options.inputfile.clone().unwrap());
-        (*ccx_s_options).num_input_files =
-            options.inputfile.iter().filter(|s| !s.is_empty()).count() as _;
+        (*ccx_s_options).num_input_files = options
+            .inputfile
+            .as_ref()
+            .unwrap()
+            .iter()
+            .filter(|s| !s.is_empty())
+            .count() as _;
     }
     (*ccx_s_options).demux_cfg = options.demux_cfg.to_ctype();
     (*ccx_s_options).enc_cfg = options.enc_cfg.to_ctype();

--- a/src/rust/src/parser.rs
+++ b/src/rust/src/parser.rs
@@ -427,31 +427,17 @@ impl OptionsExt for Options {
         }
     }
 
-    fn append_file_to_queue(&mut self, filename: &str, inputfile_capacity: &mut i32) -> i32 {
+    fn append_file_to_queue(&mut self, filename: &str, _inputfile_capacity: &mut i32) -> i32 {
         if filename.is_empty() {
             return 0;
         }
 
-        let num_input_files = if let Some(ref inputfile) = self.inputfile {
-            inputfile.len()
-        } else {
-            0
-        };
-        if num_input_files >= *inputfile_capacity as usize {
-            *inputfile_capacity += 10;
-        }
-
-        let new_size = (*inputfile_capacity).try_into().unwrap_or(0);
-
         if self.inputfile.is_none() {
-            self.inputfile = Some(Vec::with_capacity(new_size));
+            self.inputfile = Some(Vec::new());
         }
 
         if let Some(ref mut inputfile) = self.inputfile {
-            inputfile.resize(new_size, String::new());
-
-            let index = num_input_files;
-            inputfile[index] = filename.to_string();
+            inputfile.push(filename.to_string());
         }
 
         0


### PR DESCRIPTION
## Summary
- Fix bug where `num_input_files` was always set to 1 regardless of how many input files were provided
- Fix bug where input files were stored at wrong indices (0, 10, 20... instead of 0, 1, 2...)

## Root Cause

Two bugs in the Rust argument parsing code prevented multi-file processing from working:

### Bug 1: Incorrect iteration in `common.rs:216`
```rust
// BUG: .iter() on Option<Vec<String>> yields 0 or 1 items (the Vec itself), not Vec contents
options.inputfile.iter().filter(|s| !s.is_empty()).count()

// FIX: Iterate over the Vec contents
options.inputfile.as_ref().unwrap().iter().filter(|s| !s.is_empty()).count()
```

### Bug 2: Wrong indexing in `parser.rs:append_file_to_queue()`
The function used `inputfile.len()` as the index for new files, but after `resize(10, String::new())`, the length becomes 10 even with only 1 file. This caused the second file to go to index 10, third to index 20, etc.

Fixed by simply using `push()` instead of manual index calculation.

## Test plan
- [x] Build ccextractor with fixes
- [x] Test with multiple input files: `ccextractor file1.mpg file2.mpg file3.mpg -o output.srt`
- [x] Verify all files are opened (check for "Opening file:" messages)
- [x] Verify no crash occurs
- [x] Run cargo clippy - no warnings on changed files

Fixes #1810

🤖 Generated with [Claude Code](https://claude.com/claude-code)