### PR TITLE
fix(memory): Add null checks for unchecked memory allocations

### DIFF
--- a/src/lib_ccx/asf_functions.c
+++ b/src/lib_ccx/asf_functions.c
@@ -150,6 +150,10 @@ int asf_get_more_data(struct lib_ccx_ctx *ctx, struct demuxer_data **ppdata)
 		    .StreamNumberLType = 0,
 		    .PacketLength = 0,
 		    .PaddingLength = 0};
+		// Check for allocation failure
+		if (!asf_data_container.parsebuf)
+			fatal(EXIT_NOT_ENOUGH_MEMORY, "In asf_getmoredata: Out of memory allocating initial parse buffer.");
+
 		// Initialize the Payload Extension System
 		for (int stream = 0; stream < STREAMNUM; stream++)
 		{

--- a/src/lib_ccx/ccx_decoders_608.c
+++ b/src/lib_ccx/ccx_decoders_608.c
@@ -127,6 +127,8 @@ ccx_decoder_608_context *ccx_decoder_608_init_library(struct ccx_decoder_608_set
 	ccx_decoder_608_context *data = NULL;
 
 	data = malloc(sizeof(ccx_decoder_608_context));
+	if (!data)
+		return NULL;
 
 	data->cursor_column = 0;
 	data->cursor_row = 0;

--- a/src/lib_ccx/ccx_decoders_isdb.c
+++ b/src/lib_ccx/ccx_decoders_isdb.c
@@ -345,6 +345,11 @@ static struct ISDBText *allocate_text_node(ISDBSubLayout *ls)
 
 	text->used = 0;
 	text->buf = malloc(128);
+	if (!text->buf)
+	{
+		free(text);
+		return NULL;
+	}
 	text->len = 128;
 	*text->buf = 0;
 	return text;

--- a/src/lib_ccx/ccx_decoders_xds.c
+++ b/src/lib_ccx/ccx_decoders_xds.c
@@ -499,6 +499,10 @@ int xds_do_current_and_future(struct cc_subtitle *sub, struct ccx_decoders_xds_c
 	int was_proc = 0;
 
 	char *str = malloc(1024);
+	if (!str)
+	{
+		return CCX_ENOMEM;
+	}
 	char *tstr = NULL;
 	int str_len = 1024;
 

--- a/src/lib_ccx/ccx_dtvcc.c
+++ b/src/lib_ccx/ccx_dtvcc.c
@@ -115,10 +115,10 @@ dtvcc_ctx *dtvcc_init(struct ccx_decoder_dtvcc_settings *opts)
 		dtvcc_service_decoder *decoder = &ctx->decoders[i];
 		decoder->cc_count = 0;
 		decoder->tv = (dtvcc_tv_screen *)malloc(sizeof(dtvcc_tv_screen));
-		decoder->tv->service_number = i + 1;
-		decoder->tv->cc_count = 0;
 		if (!decoder->tv)
 			ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "dtvcc_init");
+		decoder->tv->service_number = i + 1;
+		decoder->tv->cc_count = 0;
 
 		for (int j = 0; j < CCX_DTVCC_MAX_WINDOWS; j++)
 			decoder->windows[j].memory_reserved = 0;

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -474,6 +474,10 @@ int write_cc_buffer_as_webvtt(struct eia608_screen *data, struct encoder_ctx *co
 			{
 				color_events = (int *)calloc(COLUMNS + 1, sizeof(int));
 				font_events = (int *)calloc(COLUMNS + 1, sizeof(int));
+				if (!color_events || !font_events)
+				{
+					fatal(EXIT_NOT_ENOUGH_MEMORY, "In write_cc_bitmap_as_webvtt: Out of memory allocating color/font events.");
+				}
 
 				get_color_events(color_events, i, data);
 				get_font_events(font_events, i, data);

--- a/src/lib_ccx/dvb_subtitle_decoder.c
+++ b/src/lib_ccx/dvb_subtitle_decoder.c
@@ -1485,11 +1485,11 @@ static void dvbsub_parse_display_definition_segment(void *dvb_ctx,
 	{
 		display_def = (struct DVBSubDisplayDefinition *)malloc(
 		    sizeof(*display_def));
+		if (!display_def)
+			return;
 		memset(display_def, 0, sizeof(*display_def));
 		ctx->display_definition = display_def;
 	}
-	if (!display_def)
-		return;
 
 	display_def->version = dds_version;
 	display_def->x = 0;

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -360,6 +360,10 @@ void process_hex(struct lib_ccx_ctx *ctx, char *filename)
 {
 	size_t max = (size_t)ctx->inputsize + 1; // Enough for the whole thing. Hex dumps are small so we can be lazy here
 	char *line = (char *)malloc(max);
+	if (!line)
+	{
+		fatal(EXIT_NOT_ENOUGH_MEMORY, "In process_hex: Out of memory allocating line buffer.");
+	}
 	/* const char *mpeg_header="00 00 01 b2 43 43 01 f8 "; // Always present */
 	FILE *fr = fopen(filename, "rt");
 	unsigned char *bytes = NULL;
@@ -430,7 +434,6 @@ void process_hex(struct lib_ccx_ctx *ctx, char *filename)
 		bytes = (unsigned char *)malloc(byte_count);
 		if (!bytes)
 			fatal(EXIT_NOT_ENOUGH_MEMORY, "In process_hex: Out of memory to store processed hex value.\n");
-		unsigned char *bytes = (unsigned char *)malloc(byte_count);
 		for (unsigned i = 0; i < byte_count; i++)
 		{
 			unsigned char high = c2[0];
@@ -1251,6 +1254,10 @@ int rcwt_loop(struct lib_ccx_ctx *ctx)
 
 	// Generic buffer to hold some data
 	parsebuf = (unsigned char *)malloc(1024);
+	if (!parsebuf)
+	{
+		fatal(EXIT_NOT_ENOUGH_MEMORY, "In rcwt_loop: Out of memory allocating parsebuf.");
+	}
 
 	result = buffered_read(ctx->demux_ctx, parsebuf, 11);
 	ctx->demux_ctx->past += result;

--- a/src/lib_ccx/lib_ccx.c
+++ b/src/lib_ccx/lib_ccx.c
@@ -114,12 +114,12 @@ struct lib_ccx_ctx *init_libraries(struct ccx_s_options *opt)
 		ctx->eit_programs = (struct EIT_program *)malloc(sizeof(struct EIT_program) * (TS_PMT_MAP_SIZE + 1));
 		ctx->eit_current_events = (int32_t *)malloc(sizeof(int32_t) * (TS_PMT_MAP_SIZE + 1));
 		ctx->ATSC_source_pg_map = (int16_t *)malloc(sizeof(int16_t) * (0xffff));
+		if (!ctx->epg_buffers || !ctx->eit_programs || !ctx->eit_current_events || !ctx->ATSC_source_pg_map)
+			ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "lib_ccx_ctx");
 		memset(ctx->epg_buffers, 0, sizeof(struct PSI_buffer) * (0xfff + 1));
 		memset(ctx->eit_programs, 0, sizeof(struct EIT_program) * (TS_PMT_MAP_SIZE + 1));
 		memset(ctx->eit_current_events, 0, sizeof(int32_t) * (TS_PMT_MAP_SIZE + 1));
 		memset(ctx->ATSC_source_pg_map, 0, sizeof(int16_t) * (0xffff));
-		if (!ctx->epg_buffers || !ctx->eit_programs || !ctx->eit_current_events || !ctx->ATSC_source_pg_map)
-			ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "lib_ccx_ctx");
 	}
 	else
 	{
@@ -173,6 +173,8 @@ struct lib_ccx_ctx *init_libraries(struct ccx_s_options *opt)
 	ctx->subs_delay = opt->subs_delay;
 
 	ctx->pesheaderbuf = (unsigned char *)malloc(188); // Never larger anyway
+	if (!ctx->pesheaderbuf)
+		ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "init_libraries: Not enough memory allocating pesheaderbuf");
 
 	ctx->cc_to_stdout = opt->cc_to_stdout;
 	ctx->pes_header_to_stdout = opt->pes_header_to_stdout;
@@ -290,6 +292,8 @@ struct lib_cc_decode *update_decoder_list(struct lib_ccx_ctx *ctx)
 		{
 			dec_ctx->prev = malloc(sizeof(struct lib_cc_decode));
 			dec_ctx->dec_sub.prev = malloc(sizeof(struct cc_subtitle));
+			if (!dec_ctx->prev || !dec_ctx->dec_sub.prev)
+				ccx_common_logging.fatal_ftn(EXIT_NOT_ENOUGH_MEMORY, "update_decoder_list: Not enough memory for DVB context");
 			memset(dec_ctx->dec_sub.prev, 0, sizeof(struct cc_subtitle));
 		}
 	}

--- a/src/lib_ccx/mp4.c
+++ b/src/lib_ccx/mp4.c
@@ -509,6 +509,10 @@ static int process_tx3g(struct lib_ccx_ctx *ctx, struct encoder_ctx *enc_ctx,
 	if (dec_sub->data != NULL)
 		free(dec_sub->data);
 	dec_sub->data = malloc(atom_length + 1);
+	if (!dec_sub->data)
+	{
+		fatal(EXIT_NOT_ENOUGH_MEMORY, "In process_tx3g_atom: Out of memory allocating subtitle data.");
+	}
 	dec_sub->datatype = CC_DATATYPE_GENERIC;
 	memcpy(dec_sub->data, data, atom_length);
 	*((char *)dec_sub->data + atom_length) = '\0';


### PR DESCRIPTION
## Summary

- Add proper null checks after malloc/calloc/realloc calls to prevent potential NULL pointer dereferences on out-of-memory conditions
- Fix a variable shadowing bug in `general_loop.c` that caused a memory leak
- Fix incorrect check ordering where null checks happened after pointer dereferences

## Changes

| File | Issue Fixed |
|------|-------------|
| `general_loop.c` | Add null checks for `line` and `parsebuf`; remove duplicate allocation that shadowed outer `bytes` variable (memory leak) |
| `ccx_encoders_webvtt.c` | Add null check for `color_events`/`font_events` calloc |
| `ccx_decoders_isdb.c` | Add null check for `text->buf` before dereference |
| `dvb_subtitle_decoder.c` | Move null check before `memset` (was crashing on OOM before reaching check) |
| `mp4.c` | Add null check for `dec_sub->data` before `memcpy` |
| `ccx_decoders_608.c` | Add null check for decoder context allocation |
| `ccx_decoders_xds.c` | Add null check for string buffer allocation |
| `asf_functions.c` | Add null check after struct initialization containing malloc |
| `ccx_dtvcc.c` | Move null check before dereferences (was checking *after* using pointer) |
| `lib_ccx.c` | Fix memset-before-check ordering; add checks for `pesheaderbuf` and DVB context |

## Test plan

- [x] Build completes successfully
- [ ] Run test suite to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)