### PR TITLE
style: use CCX_STREAM_TYPE_VIDEO_HEVC enum instead of raw 0x24

### DIFF
--- a/src/lib_ccx/ts_tables.c
+++ b/src/lib_ccx/ts_tables.c
@@ -35,8 +35,7 @@ unsigned get_printable_stream_type(enum ccx_stream_type stream_type)
 		case CCX_STREAM_TYPE_AUDIO_HDMV_DTS:
 			break;
 
-		case 0x24: // HEVC / H.265
-			tmp_stream_type = CCX_STREAM_TYPE_VIDEO_HEVC;
+		case CCX_STREAM_TYPE_VIDEO_HEVC:
 			break;
 
 		default:
@@ -415,10 +414,10 @@ int parse_PMT(struct ccx_demuxer *ctx, unsigned char *buf, int len, struct progr
 			}
 		}
 
-		// Support H.264 and HEVC video streams
-		if (stream_type == CCX_STREAM_TYPE_VIDEO_H264 || stream_type == CCX_STREAM_TYPE_VIDEO_MPEG2 || stream_type == 0x24)
+		// Support H.264, MPEG-2 and HEVC video streams
+		if (stream_type == CCX_STREAM_TYPE_VIDEO_H264 || stream_type == CCX_STREAM_TYPE_VIDEO_MPEG2 || stream_type == CCX_STREAM_TYPE_VIDEO_HEVC)
 		{
-			if (stream_type == 0x24)
+			if (stream_type == CCX_STREAM_TYPE_VIDEO_HEVC)
 				mprint("Detected HEVC video stream (0x24) - enabling ATSC CC parsing.\n");
 			update_capinfo(ctx, elementary_PID, stream_type, CCX_CODEC_ATSC_CC, program_number, NULL);
 		}


### PR DESCRIPTION
## Summary

Follow-up to PR #1769 - use the defined enum constant `CCX_STREAM_TYPE_VIDEO_HEVC` instead of the magic number `0x24` for better code maintainability and consistency.

## Changes

- Replace `0x24` with `CCX_STREAM_TYPE_VIDEO_HEVC` in PMT parsing condition
- Simplify `get_printable_stream_type()` case statement by removing redundant assignment (the enum value passes through unchanged)
- Update comment to list all three supported video stream types

## Testing

Tested with ATSC 3.0 sample from issue #1639 - HEVC streams are still properly recognized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)