### PR TITLE
fix(teletext): Add --ttxtforcelatin option to force Latin G0 charset

### DIFF
--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -66,7 +66,8 @@ struct ccx_s_teletext_config
 	int nofontcolor;
 	int nohtmlescape;
 	char millis_separator;
-    int latrusmap;
+	int latrusmap;
+	int forceg0latin;  // Force G0 Latin charset, ignore Cyrillic designations (issue #1395)
 };
 
 struct ccx_s_mp4Cfg

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -396,6 +396,14 @@ uint32_t unham_24_18(uint32_t a)
 void set_g0_charset(uint32_t triplet)
 {
 	// ETS 300 706, Table 32
+	// If user requested to force Latin charset, always use it (issue #1395)
+	// Some broadcasts incorrectly signal Cyrillic when content is actually Latin
+	if (tlt_config.forceg0latin)
+	{
+		default_g0_charset = LATIN;
+		return;
+	}
+
 	if ((triplet & 0x3c00) == 0x1000)
 	{
 		if ((triplet & 0x0380) == 0x0000)

--- a/src/rust/lib_ccxr/src/teletext.rs
+++ b/src/rust/lib_ccxr/src/teletext.rs
@@ -747,6 +747,8 @@ pub struct TeletextConfig {
     pub nofontcolor: bool,
     pub nohtmlescape: bool,
     pub latrusmap: bool,
+    /// Force Latin G0 charset, ignore Cyrillic designations (issue #1395)
+    pub forceg0latin: bool,
 }
 
 impl Default for TeletextConfig {
@@ -766,6 +768,7 @@ impl Default for TeletextConfig {
             nofontcolor: false,
             nohtmlescape: false,
             latrusmap: false,
+            forceg0latin: false,
         }
     }
 }

--- a/src/rust/src/args.rs
+++ b/src/rust/src/args.rs
@@ -530,6 +530,11 @@ pub struct Args {
     /// of Russian Teletext files (issue #1086)
     #[arg(long, verbatim_doc_comment, help_heading=OUTPUT_AFFECTING_OUTPUT_FILES)]
     pub latrusmap: bool,
+    /// Force Latin G0 charset for Teletext, ignoring any Cyrillic
+    /// designation in the stream. Use when broadcasts incorrectly
+    /// signal Cyrillic but content is Latin (issue #1395)
+    #[arg(long, verbatim_doc_comment, help_heading=OUTPUT_AFFECTING_OUTPUT_FILES)]
+    pub ttxtforcelatin: bool,
     /// In timed transcripts, all XDS information will be saved
     /// to the output file.
     #[arg(long, verbatim_doc_comment, help_heading=OUTPUT_AFFECTING_OUTPUT_FILES)]

--- a/src/rust/src/common.rs
+++ b/src/rust/src/common.rs
@@ -533,6 +533,7 @@ impl CType2<ccx_s_teletext_config, &Options> for TeletextConfig {
             nohtmlescape: self.nohtmlescape.into(),
             millis_separator: value.millis_separator() as _,
             latrusmap: self.latrusmap.into(),
+            forceg0latin: self.forceg0latin.into(),
         };
         config.set_verbose(self.verbose.into());
         config.set_bom(1);

--- a/src/rust/src/parser.rs
+++ b/src/rust/src/parser.rs
@@ -1214,6 +1214,10 @@ impl OptionsExt for Options {
             tlt_config.latrusmap = true;
         }
 
+        if args.ttxtforcelatin {
+            tlt_config.forceg0latin = true;
+        }
+
         if args.tickertext {
             self.tickertext = true;
         }


### PR DESCRIPTION
## Summary
- Added new `--ttxtforcelatin` command-line option
- Forces teletext G0 character set to Latin, ignoring Cyrillic designations in the stream
- Fixes garbled output where Latin text appears as Cyrillic characters

## Problem
Some broadcast streams (e.g., UK Freesat recordings) incorrectly signal Cyrillic character set via X/28 or M/29 teletext packets when the actual content is Latin English text.

**Before (garbled Cyrillic):**
```
Но. Нот бацк тхен, анiваi.
```

**Expected (correct Latin):**
```
No. Not back then, anyway.
```

## Root Cause
The broadcast stream contains triplet value `0x1290` which has:
- Bits 10-13 = 0x1 (Cyrillic character set family per ETS 300 706 Table 32)
- Bits 7-9 = 0x5 (Ukrainian option)

This causes CCExtractor to select CYRILLIC3 (Ukrainian) charset instead of Latin.

## Solution
Added `--ttxtforcelatin` option that bypasses the Cyrillic character set detection and always uses Latin G0 charset.

## Changes
- `src/lib_ccx/lib_ccx.h`: Added `forceg0latin` field to teletext config
- `src/lib_ccx/telxcc.c`: Modified `set_g0_charset()` to respect `forceg0latin` option  
- `src/rust/src/args.rs`: Added `--ttxtforcelatin` CLI argument
- `src/rust/src/parser.rs`: Added argument handling
- `src/rust/src/common.rs`: Added field to struct conversion
- `src/rust/lib_ccxr/src/teletext.rs`: Added `forceg0latin` to TeletextConfig

## Test plan
- [x] Downloaded sample from issue #1395
- [x] Reproduced the Cyrillic output issue
- [x] Verified `--ttxtforcelatin` produces correct Latin output
- [x] Build succeeds for both C and Rust components

## Usage
```bash
ccextractor input.ts --ttxtforcelatin -o output.srt
```

Fixes #1395

🤖 Generated with [Claude Code](https://claude.com/claude-code)