### PR TITLE
fix: Correct is_decoder_processed_enough() multiprogram logic and suppress false warnings

### DIFF
--- a/src/lib_ccx/lib_ccx.c
+++ b/src/lib_ccx/lib_ccx.c
@@ -260,13 +260,31 @@ void dinit_libraries(struct lib_ccx_ctx **ctx)
 int is_decoder_processed_enough(struct lib_ccx_ctx *ctx)
 {
 	struct lib_cc_decode *dec_ctx;
-	list_for_each_entry(dec_ctx, &ctx->dec_ctx_head, list, struct lib_cc_decode)
-	{
-		if (dec_ctx->processed_enough == CCX_TRUE && ctx->multiprogram == CCX_FALSE)
-			return CCX_TRUE;
-	}
 
-	return CCX_FALSE;
+	// If the decoder list is empty, no user-defined limits could have been reached
+	if (list_empty(&ctx->dec_ctx_head))
+		return CCX_FALSE;
+
+	if (ctx->multiprogram == CCX_FALSE)
+	{
+		// In single-program mode, return TRUE if ANY decoder has processed enough
+		list_for_each_entry(dec_ctx, &ctx->dec_ctx_head, list, struct lib_cc_decode)
+		{
+			if (dec_ctx->processed_enough == CCX_TRUE)
+				return CCX_TRUE;
+		}
+		return CCX_FALSE;
+	}
+	else
+	{
+		// In multiprogram mode, return TRUE only if ALL decoders have processed enough
+		list_for_each_entry(dec_ctx, &ctx->dec_ctx_head, list, struct lib_cc_decode)
+		{
+			if (dec_ctx->processed_enough == CCX_FALSE)
+				return CCX_FALSE;
+		}
+		return CCX_TRUE;
+	}
 }
 struct lib_cc_decode *update_decoder_list(struct lib_ccx_ctx *ctx)
 {


### PR DESCRIPTION
## Summary

Fixes #1701

The `is_decoder_processed_enough()` function had a bug where it would always return FALSE in multiprogram mode, causing false "Error in switch_to_next_file()" warnings for files without captions.

### Root Cause
The condition `dec_ctx->processed_enough == CCX_TRUE && ctx->multiprogram == CCX_FALSE` meant that in multiprogram mode (`ctx->multiprogram == CCX_TRUE`), the function would never return TRUE, even when all decoders had finished processing.

### Changes
- **Fixed `is_decoder_processed_enough()`** in both C and Rust:
  - In single-program mode: return TRUE if ANY decoder has processed enough
  - In multiprogram mode: return TRUE only if ALL decoders have processed enough
- **Added empty decoder list check** in `switch_to_next_file()`:
  - If no decoders exist (no captions found), suppress the "premature ending" warning
  - This is a normal condition for files without closed captions, not an error
- **Updated Rust tests** to verify the new behavior

### Files Modified
- `src/lib_ccx/lib_ccx.c` - Fixed `is_decoder_processed_enough()` logic
- `src/lib_ccx/file_functions.c` - Added empty decoder list check
- `src/rust/src/hlist.rs` - Fixed Rust version + updated tests
- `src/rust/src/file_functions/file.rs` - Added empty decoder list check

## Test plan
- [x] Tested with sample `.ogg` file from issue - no more false error message
- [x] Tested with files containing captions - normal operation unaffected
- [x] Tested with `--autoprogram` (multiprogram mode) - works correctly
- [x] All Rust tests pass (12/12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)