### PR TITLE
build(autoconf): add tesseract/leptonica linking for HARDSUBX

### DIFF
--- a/linux/Makefile.am
+++ b/linux/Makefile.am
@@ -294,12 +294,18 @@ ccextractor_CPPFLAGS+= ${libavformat_CFLAGS}
 ccextractor_CPPFLAGS+= ${libavfilter_CFLAGS}
 ccextractor_CPPFLAGS+= ${libavutil_CFALGS}
 ccextractor_CPPFLAGS+= ${libswscale_CFLAGS}
+# HARDSUBX requires tesseract/leptonica for OCR (same as OCR feature)
+ccextractor_CPPFLAGS+= ${tesseract_CFLAGS}
+ccextractor_CPPFLAGS+= ${lept_CFLAGS}
 AV_LIB = ${libavcodec_LIBS}
 AV_LIB += ${libavformat_LIBS}
 AV_LIB += ${libavfilter_LIBS}
 AV_LIB += ${libavutil_LIBS}
 AV_LIB += ${libswscale_LIBS}
 ccextractor_LDADD += $(AV_LIB)
+# HARDSUBX requires tesseract/leptonica libs for OCR
+ccextractor_LDADD += ${tesseract_LIBS}
+ccextractor_LDADD += ${lept_LIBS}
 HARDSUBX_FEATURE_RUST += --features "hardsubx_ocr"
 endif
 


### PR DESCRIPTION
## Summary

This is the autoconf equivalent of the CMake fix in PR #1760.

- Adds explicit tesseract/leptonica include flags (`${tesseract_CFLAGS}`, `${lept_CFLAGS}`) to the HARDSUBX block in `linux/Makefile.am`
- Adds explicit tesseract/leptonica library linking (`${tesseract_LIBS}`, `${lept_LIBS}`) to the HARDSUBX block

## Background

PR #1760 fixed the CMake build system to properly link tesseract/leptonica when building with `-DWITH_HARDSUBX=ON -DWITH_OCR=OFF`. The autoconf build system had a similar structure where tesseract/leptonica were only explicitly linked in the OCR block.

Note: The autoconf `configure.ac` already sets `OCR_IS_ENABLED` when HARDSUBX is enabled, so the build would technically work via the OCR block. However, this change makes the dependency explicit and consistent with the CMake fix.

## Related

- PR #1760 (CMake fix, now merged)
- Issue #1719 (original bug report)

## Test plan

- [ ] Build with `--enable-hardsubx` without `--enable-ocr`
- [ ] Verify no undefined reference errors for tesseract/leptonica symbols

🤖 Generated with [Claude Code](https://claude.ai/code)