### PR TITLE
[FIX] Prevent creation of empty per-stream subtitle files

### DIFF
--- a/src/lib_ccx/ccx_encoders_structs.h
+++ b/src/lib_ccx/ccx_encoders_structs.h
@@ -25,6 +25,7 @@ struct ccx_s_write
 	char *semaphore_filename;
 	int with_playlist; // For m3u8 /webvtt: If 1, we'll generate a playlist and segments
 	char *playlist_filename;
+	int wrote_data; // Tracks whether any payload was written so empty outputs can be skipped
 	int renaming_extension; // Used for file rotations
 	int append_mode;	/* Append the file. Prevent overwriting of files */
 };


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [X] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [X] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---
## **[FIX] Prevent creation of empty per-stream subtitle files (Fixes #1282)**
#### This pull request implements deferred output file creation to avoid producing zero-byte `.srt` files for caption streams that contain no actual data.
- Track per-output writes via wrote_data on ccx_s_write.
- When no data is written to an output, skip footer writing and delete the file on teardown to avoid empty cc3 artifacts.
