### PR TITLE
[FIX] Correct typos in warning message and code comment

### DIFF
--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -30,7 +30,7 @@ ccx_encoders_transcript_format ccx_encoders_default_transcript_settings =
 	.useColors = 1,
 	.isFinal = 0};
 
-// TODO sami header doesn't carry about CRLF/LF option
+// TODO sami header doesn't care about CRLF/LF option
 static const char *sami_header = // TODO: Revise the <!-- comments
     "<SAMI>\n\
 <HEAD>\n\
@@ -193,7 +193,7 @@ static int write_bom(struct encoder_ctx *ctx, struct ccx_s_write *out)
 			ret = write(out->fh, UTF8_BOM, sizeof(UTF8_BOM));
 			if (ret < sizeof(UTF8_BOM))
 			{
-				mprint("WARNING: Unable tp write UTF BOM\n");
+				mprint("WARNING: Unable to write UTF BOM\n");
 				return -1;
 			}
 		}


### PR DESCRIPTION
This PR fixes two small typos in `src/lib_ccx/ccx_encoders_common.c`.

### What was changed
- Fixed a typo in a user-facing warning message:
  - `"Unable tp write UTF BOM"` → `"Unable to write UTF BOM"`
- Corrected a typo in an internal TODO comment:
  - `"carry about"` → `"care about"`

### Why this change
- Improves clarity and professionalism of user-facing log output.
- Improves readability of internal comments for future contributors.
- No functional or behavioral changes.

### Testing
- No functional testing required (comment and log text only).
- Build was already verified locally before this change.



**In raising this pull request, I confirm the following:**

- [x] I have read and understood the contributors guide.
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**My familiarity with the project is as follows:**

- [x] I have used CCExtractor just a couple of times.
