### PR TITLE
[FIX]: Add ATSC VCT virtual channel numbers and call signs to XMLTV output

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,7 @@
 0.95 (2025-09-15)
 -----------------
+- FIX: Include ATSC VCT virtual channel numbers and call signs in XMLTV output
+- FIX: Restore ATSC XMLTV generation with ETT parsing for extended descriptions, multi-segment handling, extended table ID's (EIT/VCT), corrected <programme> XMLTV formatting, buffer bounds fixes
 - Fix: DVB subtitle extraction improvements for Chinese broadcasts (#224):
   - Fix crash in parse_PMT() due to missing bounds checks
   - Fix negative timestamps in DVB subtitle output

--- a/src/lib_ccx/ccx_demuxer.h
+++ b/src/lib_ccx/ccx_demuxer.h
@@ -48,6 +48,7 @@ struct program_info
 	int16_t pcr_pid;
 	uint64_t got_important_streams_min_pts[COUNT];
 	int has_all_min_pts;
+	char virtual_channel[16];  // Stores ATSC virtual channel like "2.1"
 };
 
 struct cap_info

--- a/src/rust/src/common.rs
+++ b/src/rust/src/common.rs
@@ -1001,6 +1001,7 @@ impl CType<program_info> for ProgramInfo {
             pcr_pid: self.pcr_pid,
             got_important_streams_min_pts: min_pts_c,
             has_all_min_pts: self.has_all_min_pts as c_int,
+            virtual_channel: [0; 16],
         }
     }
 }


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [X] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [X] I am an active contributor to CCExtractor.

---

### Description

XMLTV channel definitions now include ATSC VCT-derived virtual channel numbers (major.minor) and call signs, emitted as separate `<display-name>` elements and associated with the existing channel ID (program number).

Example output:

```
<channel id="1">
  <display-name>5.1</display-name>
  <display-name>KPIX-TV</display-name>
</channel>

```

This follows the XMLTV DTD (display-name+) and the approach discussed in [#1835](https://github.com/CCExtractor/ccextractor/issues/1835)

Note: This PR also adds a changelog entry for the previously merged PR https://github.com/CCExtractor/ccextractor/pull/1773