### PR TITLE
fix(rust-ffi): Prevent dangling pointers in copy_from_rust

### DIFF
--- a/src/lib_ccx/ccx_common_option.c
+++ b/src/lib_ccx/ccx_common_option.c
@@ -147,6 +147,7 @@ void init_options(struct ccx_s_options *options)
 	options->settings_dtvcc.print_file_reports = 1;
 	options->settings_dtvcc.no_rollup = 0;
 	options->settings_dtvcc.report = NULL;
+	options->settings_dtvcc.timing = NULL;
 	memset(
 	    options->settings_dtvcc.services_enabled, 0,
 	    CCX_DTVCC_MAX_SERVICES * sizeof(options->settings_dtvcc.services_enabled[0]));

--- a/src/rust/src/common.rs
+++ b/src/rust/src/common.rs
@@ -78,8 +78,18 @@ pub unsafe fn copy_from_rust(ccx_s_options: *mut ccx_s_options, options: Options
     (*ccx_s_options).extraction_start = options.extraction_start.to_ctype();
     (*ccx_s_options).extraction_end = options.extraction_end.to_ctype();
     (*ccx_s_options).print_file_reports = options.print_file_reports as _;
+    // Preserve the original C-managed report pointer to avoid dangling pointer issues.
+    let saved_608_report = (*ccx_s_options).settings_608.report;
     (*ccx_s_options).settings_608 = options.settings_608.to_ctype();
+    (*ccx_s_options).settings_608.report = saved_608_report;
+    // Preserve the original C-managed report and timing pointers to avoid dangling pointer issues.
+    // These pointers are allocated and managed by C code (init_libraries, init_cc_decode),
+    // and to_ctype() would create temporary stack values that become dangling.
+    let saved_report = (*ccx_s_options).settings_dtvcc.report;
+    let saved_timing = (*ccx_s_options).settings_dtvcc.timing;
     (*ccx_s_options).settings_dtvcc = options.settings_dtvcc.to_ctype();
+    (*ccx_s_options).settings_dtvcc.report = saved_report;
+    (*ccx_s_options).settings_dtvcc.timing = saved_timing;
     (*ccx_s_options).is_608_enabled = options.is_608_enabled as _;
     (*ccx_s_options).is_708_enabled = options.is_708_enabled as _;
     (*ccx_s_options).millis_separator = options.millis_separator() as _;


### PR DESCRIPTION
## Summary

- Fixed dangling pointer bug in Rust FFI `copy_from_rust()` function that caused memory corruption
- Added missing `settings_dtvcc.timing = NULL` initialization in C's `init_options()`

## Problem

The `to_ctype()` implementations for `DecoderDtvccSettings` and `Decoder608Settings` were creating temporaries on the stack and returning pointers to them:

```rust
// In to_ctype():
report: if let Some(value) = self.report {
    &mut value.to_ctype()  // ← Creates temporary, returns dangling pointer!
} else { ... },
timing: &mut self.timing.to_ctype(),  // ← Same issue
```

When `copy_from_rust()` called `to_ctype()`, these dangling pointers were written to the C `ccx_options` struct. Later when C code tried to use `settings_dtvcc.report` or `settings_dtvcc.timing`, it accessed invalid memory.

### Valgrind errors before this fix:
```
Invalid write of size 4
   at 0x1D44ED: dtvcc_init
   Address 0x... is on thread 1's stack, 4016 bytes below stack pointer

Invalid read of size 1
   at 0x32F426: ccx_rust::common::copy_to_rust
   Address 0x... is on thread 1's stack, 1280 bytes below stack pointer
```

## Solution

Preserve the original C-managed pointers instead of overwriting them with dangling pointers:

```rust
// Save original C pointers
let saved_report = (*ccx_s_options).settings_dtvcc.report;
let saved_timing = (*ccx_s_options).settings_dtvcc.timing;

// Apply other fields from to_ctype()
(*ccx_s_options).settings_dtvcc = options.settings_dtvcc.to_ctype();

// Restore the C-managed pointers
(*ccx_s_options).settings_dtvcc.report = saved_report;
(*ccx_s_options).settings_dtvcc.timing = saved_timing;
```

## Test plan

- [x] Verified all 21 Teletext tests pass (tests 63-83)
- [x] Verified test 18 and 19 pass with exit code 0
- [x] Verified valgrind no longer reports "Invalid read/write" errors
- [x] Error summary reduced from 131,099 errors (15 contexts) to 131,074 errors (4 contexts) - the remaining warnings are unrelated uninitialized memory issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)