### PR TITLE
fix(xds): Don't output empty XDS content entries

### DIFF
--- a/src/lib_ccx/ccx_decoders_xds.c
+++ b/src/lib_ccx/ccx_decoders_xds.c
@@ -472,14 +472,17 @@ void xds_do_content_advisory(struct cc_subtitle *sub, struct ccx_decoders_xds_co
 	if (!a1 && a0) // US TV parental guidelines
 	{
 		xdsprint(sub, ctx, age);
-		xdsprint(sub, ctx, content);
+		if (content[0]) // Only output content if not empty
+			xdsprint(sub, ctx, content);
 		if (changed)
 		{
 			ccx_common_logging.log_ftn("\rXDS: %s\n  ", age);
-			ccx_common_logging.log_ftn("\rXDS: %s\n  ", content);
+			if (content[0])
+				ccx_common_logging.log_ftn("\rXDS: %s\n  ", content);
 		}
 		ccx_common_logging.debug_ftn(CCX_DMT_DECODER_XDS, "\rXDS: %s\n", age);
-		ccx_common_logging.debug_ftn(CCX_DMT_DECODER_XDS, "\rXDS: %s\n", content);
+		if (content[0])
+			ccx_common_logging.debug_ftn(CCX_DMT_DECODER_XDS, "\rXDS: %s\n", content);
 	}
 	if (!a0 ||			  // MPA
 	    (a0 && a1 && !Da2 && !La3) || // Canadian English Language Rating


### PR DESCRIPTION
## Summary
- Fix duplicate empty XDS entries in transcript output when US TV Parental Guidelines are extracted
- Only output the content flags (violence, language, etc.) if they are not empty
- This affects files with TV-G or other ratings that have no additional content advisories

## Root Cause
When outputting ContentAdvisory XDS data, the code always called `xdsprint()` for both:
1. The age rating (e.g., "TV-G (General Audience)")
2. The content flags (e.g., "[Violence] [Language]")

However, if there are no content flags (like for TV-G), the content string was empty, causing an empty duplicate XDS entry to be written.

## Changes
- Added `if (content[0])` check before outputting the content string
- Also added the check for the log and debug output calls

## Test plan
- [x] Verified locally with sample b992e0cccb (test 113)
- [x] Before fix: 224 XDS entries (112 content + 112 empty duplicates)
- [x] After fix: 112 XDS entries (all content, no duplicates)

Fixes regression test 113 (XDS output mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)