### PR TITLE
fix(rust): Handle NULL file pointer in ccxr_demuxer_open for UDP/TCP input

### DIFF
--- a/src/rust/src/libccxr_exports/demuxer.rs
+++ b/src/rust/src/libccxr_exports/demuxer.rs
@@ -427,10 +427,15 @@ pub unsafe extern "C" fn ccxr_demuxer_open(ctx: *mut ccx_demuxer, file: *const c
     if ctx.is_null() {
         return -1;
     }
-    let c_str = CStr::from_ptr(file);
-    let file_str = match c_str.to_str() {
-        Ok(s) => s,
-        Err(_) => return -1,
+
+    // Handle NULL file pointer (e.g., when using --udp or --tcp network input)
+    let file_str = if !file.is_null() {
+        match CStr::from_ptr(file).to_str() {
+            Ok(s) => s,
+            Err(_) => return -1,
+        }
+    } else {
+        ""
     };
 
     let mut demux_ctx = copy_demuxer_from_c_to_rust(ctx);


### PR DESCRIPTION
## Summary

Fixes #1846

When using `--udp` or `--tcp` options, `ccxr_demuxer_open()` was called with a NULL file pointer, causing a crash in `CStr::from_ptr()`.

### Root Cause

The Rust FFI function `ccxr_demuxer_open` assumed the `file` parameter was always a valid C string pointer:

```rust
let c_str = CStr::from_ptr(file);  // Crashes if file is NULL
```

For network input modes (UDP/TCP), the C code passes NULL since there's no file to open.

### Fix

Check if the file pointer is NULL before dereferencing:

```rust
let file_str = if !file.is_null() {
    match CStr::from_ptr(file).to_str() {
        Ok(s) => s,
        Err(_) => return -1,
    }
} else {
    ""
};
```

## Testing

Verified both UDP and TCP modes work:

```bash
# UDP - confirmed listening with ss
$ timeout 10 ./ccextractor --udp 54321 &
$ ss -ulnp | grep 54321
UNCONN 0 0 0.0.0.0:54321 0.0.0.0:* users:(("ccextractor",pid=99942,fd=4))

# TCP - confirmed listening
$ timeout 10 ./ccextractor --tcp 54322 &
$ ss -tlnp | grep 54322
LISTEN 0 128 *:54322 *:* users:(("ccextractor",pid=98972,fd=4))
```

## Test Plan

- [x] Build succeeds
- [x] UDP mode starts and listens on specified port
- [x] TCP mode starts and listens on specified port
- [x] No crash on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)