### PR TITLE
fix(wtv): Set sync_pts alongside min_pts to prevent PTS jump detection

### DIFF
--- a/src/lib_ccx/wtv_functions.c
+++ b/src/lib_ccx/wtv_functions.c
@@ -438,10 +438,13 @@ LLONG get_data(struct lib_ccx_ctx *ctx, struct wtv_chunked_buffer *cb, struct de
 			{ // Ignore -1 timestamps
 				LLONG pes_time = time_to_pes_time(time);
 				set_current_pts(dec_ctx->timing, pes_time);
-				// Set min_pts on first valid timestamp to enable fts_now calculation
+				// Set min_pts and sync_pts on first valid timestamp to enable fts_now calculation
 				if (dec_ctx->timing->min_pts == 0x01FFFFFFFF || pes_time < dec_ctx->timing->min_pts)
 				{
 					dec_ctx->timing->min_pts = pes_time;
+					// Also set sync_pts to prevent PTS jump detection from triggering
+					// when pts_set becomes MinPtsSet (sync_pts - current_pts would be huge otherwise)
+					dec_ctx->timing->sync_pts = pes_time;
 				}
 				// pts_set = 2 (MinPtsSet) is required for proper fts_now calculation
 				dec_ctx->timing->pts_set = 2;


### PR DESCRIPTION
## Summary

Fixes a regression introduced in PR #1849 (commit 300f8ca6) where WTV files with large initial PTS values would produce empty output.

**Root cause:** The WTV timing fix set `min_pts` and `pts_set=2` (MinPtsSet) but didn't set `sync_pts`. The Rust timing code checks for PTS jumps by computing `current_pts - sync_pts`, and with `sync_pts=0` but `current_pts` at a large value (e.g., 6039323550 for a file starting at 18:38:23), the difference triggered false PTS jump detection.

**Fix:** Set `sync_pts` to the same value as `min_pts` when first initializing timing.

## Test results

**Before (master):**
```
Last sync PTS value: 0
Current PTS value: 6039323550
Note: You can disable this behavior by adding -ignoreptsjumps to the parameters.
```
Output: Empty file, progress showed `-1118:-23` (negative hours!)

**After (this fix):**
- Caption 1: `00:00:00,601 --> 00:00:02,801` ✅ Matches expected
- Caption 2: `00:00:02,837 --> 00:00:06,305` ✅ Matches expected
- Caption 3: `00:00:11,145 --> 00:00:12,411` ✅ Matches expected

Tested on all WTV samples in the test corpus - all produce correct output.

## Test plan

- [ ] CI regression tests pass for WTV section
- [ ] Test 95 now passes (was showing empty result vs expected captions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)