### PR TITLE
fix(args): Add backward compatibility for single-dash long options

### DIFF
--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -558,27 +558,15 @@ mod test {
     #[test]
     fn test_normalize_legacy_option_short_options() {
         // Single-letter short options should remain unchanged
-        assert_eq!(
-            normalize_legacy_option("-o".to_string()),
-            "-o".to_string()
-        );
-        assert_eq!(
-            normalize_legacy_option("-s".to_string()),
-            "-s".to_string()
-        );
+        assert_eq!(normalize_legacy_option("-o".to_string()), "-o".to_string());
+        assert_eq!(normalize_legacy_option("-s".to_string()), "-s".to_string());
     }
 
     #[test]
     fn test_normalize_legacy_option_numeric_options() {
         // Numeric options should remain unchanged (these are valid ccextractor options)
-        assert_eq!(
-            normalize_legacy_option("-1".to_string()),
-            "-1".to_string()
-        );
-        assert_eq!(
-            normalize_legacy_option("-2".to_string()),
-            "-2".to_string()
-        );
+        assert_eq!(normalize_legacy_option("-1".to_string()), "-1".to_string());
+        assert_eq!(normalize_legacy_option("-2".to_string()), "-2".to_string());
         assert_eq!(
             normalize_legacy_option("-12".to_string()),
             "-12".to_string()
@@ -605,19 +593,10 @@ mod test {
     #[test]
     fn test_normalize_legacy_option_edge_cases() {
         // Empty string
-        assert_eq!(
-            normalize_legacy_option("".to_string()),
-            "".to_string()
-        );
+        assert_eq!(normalize_legacy_option("".to_string()), "".to_string());
         // Just a dash
-        assert_eq!(
-            normalize_legacy_option("-".to_string()),
-            "-".to_string()
-        );
+        assert_eq!(normalize_legacy_option("-".to_string()), "-".to_string());
         // Double dash alone (end of options marker)
-        assert_eq!(
-            normalize_legacy_option("--".to_string()),
-            "--".to_string()
-        );
+        assert_eq!(normalize_legacy_option("--".to_string()), "--".to_string());
     }
 }


### PR DESCRIPTION
## Summary

- Fixes issue where scripts using `-quiet` (single-dash) instead of `--quiet` (double-dash) would fail silently with exit code 7 and produce zero-length output files
- Adds `normalize_legacy_option()` function that pre-processes command-line arguments to convert legacy single-dash long options to double-dash format before passing to clap
- Maintains full backward compatibility with old scripts while preserving correct behavior for short options like `-o`

## Root Cause

The Rust-based argument parser (clap) only accepts double-dash long options (`--quiet`), but old versions of ccextractor accepted single-dash (`-quiet`). When clap received `-quiet`, it parsed it as five individual short options `-q -u -i -e -t`. Since `-q` wasn't defined, it failed with exit code 7.

Users with scripts that redirected stderr (`> /dev/null 2>&1`) never saw the error message, causing the "intermittent" zero-length output described in the issue.

## Changes

**src/rust/src/lib.rs:**
- Added `normalize_legacy_option()` function that converts single-dash long options to double-dash
- Pre-processes all arguments before passing to clap's parser
- Added 6 unit tests covering all edge cases

## Test Results

| Test Case | Before Fix | After Fix |
|-----------|-----------|-----------|
| `-quiet` | Exit code 7, no output | Exit code 0, correct output ✓ |
| `--quiet` | Works | Works ✓ |
| `-stdout` | Exit code 7 | Works ✓ |
| `-autoprogram` | Exit code 7 | Works ✓ |
| Short options (`-o`) | Works | Works ✓ |
| Numeric options (`-1`, `-12`) | Works | Works ✓ |

All 292 Rust tests pass (286 existing + 6 new).

## Test plan

- [x] Verify `-quiet` now works (was failing before)
- [x] Verify `--quiet` still works
- [x] Verify short options like `-o` still work
- [x] Verify numeric options like `-1`, `-12` still work
- [x] Run full Rust test suite
- [ ] CI passes

Fixes #1576

🤖 Generated with [Claude Code](https://claude.com/claude-code)