### PR TITLE
fix(mcc): Add MCC output support for raw caption files

### DIFF
--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -8,6 +8,7 @@
 
 #include "dvb_subtitle_decoder.h"
 #include "ccx_encoders_common.h"
+#include "ccx_encoders_mcc.h"
 #include "activity.h"
 #include "utility.h"
 #include "ccx_demuxer.h"
@@ -520,6 +521,50 @@ void process_hex(struct lib_ccx_ctx *ctx, char *filename)
 	fclose(fr);
 }
 #endif
+
+/* Process raw caption data (2-byte pairs) and encode directly to MCC format.
+ * This bypasses the 608 decoder and writes raw cc_data to MCC.
+ * Used when -out=mcc is specified with raw input files (issue #1542). */
+static size_t process_raw_for_mcc(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx,
+				  unsigned char *buffer, size_t len)
+{
+	unsigned char cc_data[3];
+	size_t i;
+	size_t pairs_processed = 0;
+
+	// Set frame rate to 29.97fps (code 4) for raw 608 captions
+	// This is needed for proper MCC timing
+	if (dec_ctx->current_frame_rate == 0)
+		dec_ctx->current_frame_rate = 4; // CCX_FR_29_97
+
+	cc_data[0] = 0x04; // Field 1, cc_valid=1, cc_type=0 (NTSC field 1)
+
+	for (i = 0; i < len; i += 2)
+	{
+		// Skip broadcast header (0xff 0xff)
+		if (!dec_ctx->saw_caption_block && buffer[i] == 0xff && buffer[i + 1] == 0xff)
+			continue;
+
+		dec_ctx->saw_caption_block = 1;
+		cc_data[1] = buffer[i];
+		cc_data[2] = buffer[i + 1];
+
+		// Update timing for this CC pair (each pair is one frame at 29.97fps)
+		// Timing: 1001/30 ms per pair = ~33.37ms
+		set_fts(enc_ctx->timing);
+
+		// Encode this CC pair to MCC format
+		mcc_encode_cc_data(enc_ctx, dec_ctx, cc_data, 1);
+
+		// Advance timing for next pair
+		add_current_pts(enc_ctx->timing, 1001 * (MPEG_CLOCK_FREQ / 1000) / 30);
+
+		pairs_processed++;
+	}
+
+	return pairs_processed;
+}
+
 // Raw file process
 int raw_loop(struct lib_ccx_ctx *ctx)
 {
@@ -529,10 +574,19 @@ int raw_loop(struct lib_ccx_ctx *ctx)
 	struct encoder_ctx *enc_ctx = update_encoder_list(ctx);
 	struct lib_cc_decode *dec_ctx = NULL;
 	int caps = 0;
-	int is_dvdraw = 0; // Flag to track if this is DVD raw format
+	int is_dvdraw = 0;     // Flag to track if this is DVD raw format
+	int is_mcc_output = 0; // Flag for MCC output format
 
 	dec_ctx = update_decoder_list(ctx);
 	dec_sub = &dec_ctx->dec_sub;
+
+	// Check if MCC output is requested (issue #1542)
+	if (enc_ctx && dec_ctx->write_format == CCX_OF_MCC)
+	{
+		is_mcc_output = 1;
+		// Share timing context between decoder and encoder for MCC
+		enc_ctx->timing = dec_ctx->timing;
+	}
 
 	// For raw mode, timing is derived from the caption block counter (cb_field1).
 	// We set min_pts=0 and pts_set=MinPtsSet so set_fts() will calculate fts_now.
@@ -559,7 +613,15 @@ int raw_loop(struct lib_ccx_ctx *ctx)
 			mprint("Detected McPoodle's DVD raw format\n");
 		}
 
-		if (is_dvdraw)
+		if (is_mcc_output && !is_dvdraw)
+		{
+			// For MCC output, encode raw data directly without decoding
+			// This preserves the original CEA-608 byte pairs in CDP format
+			size_t pairs = process_raw_for_mcc(enc_ctx, dec_ctx, data->buffer, data->len);
+			if (pairs > 0)
+				caps = 1;
+		}
+		else if (is_dvdraw)
 		{
 			// Use Rust implementation - handles timing internally
 			ret = ccxr_process_dvdraw(dec_ctx, dec_sub, data->buffer, (unsigned int)data->len);
@@ -577,7 +639,7 @@ int raw_loop(struct lib_ccx_ctx *ctx)
 			set_fts(dec_ctx->timing);
 		}
 
-		if (dec_sub->got_output)
+		if (!is_mcc_output && dec_sub->got_output)
 		{
 			caps = 1;
 			encode_sub(enc_ctx, dec_sub);


### PR DESCRIPTION
## Summary

Fixes #1542 - MCC output now works with raw caption input files.

Previously, when using `-out=mcc` with raw input files (`-in=raw`), CCExtractor would print "Output format not supported" repeatedly and produce no output. This was because the raw file processing path decoded CEA-608 data to text, but MCC format requires raw cc_data bytes wrapped in CDP (Caption Distribution Packet) format.

## Changes

- Added `process_raw_for_mcc()` helper function in `general_loop.c` that:
  - Converts 2-byte raw pairs to 3-byte cc_data format (marker + 2 data bytes)
  - Wraps each CC pair in CDP format via `mcc_encode_cc_data()`
  - Maintains proper timing at 29.97fps
  - Skips broadcast headers (0xff 0xff)
  
- Modified `raw_loop()` to detect MCC output format and use the new code path instead of the normal decoder path

## Test plan

### Test 1: Basic raw file to MCC conversion
```bash
# Before fix:
$ ./linux/ccextractor --in=raw --out=mcc /tmp/test113_raw.raw -o /tmp/test.mcc
# Output: "Output format not supported" (123 times), exit code 10, empty file

# After fix:
$ ./linux/ccextractor --in=raw --out=mcc /tmp/test113_raw.raw -o /tmp/test.mcc
# Output: Success, 238KB MCC file with 5316 lines
```

### Test 2: MCC file content verification
```
$ head -50 /tmp/test.mcc | tail -10
UUID=76931FAC-9DAB-42B3-AC24-8B87D6AE33F9
Creation Program=CCExtractor
Creation Date=Saturday, December 20, 2025
Creation Time=11:52:38
Time Code Rate=30

00:00:00:00	T0FS0F4F43ZZ72E104808074ZZDC
00:00:00:01	T0FS0F4F43Z0172E104808074Z01DE
00:00:00:02	T0FS0F4F43Z0272E104808074Z02E0
```

### Test 3: Timing progression validation
```
$ tail -5 /tmp/test.mcc
00:02:55:15	T0FS0F4F43149172E104808074149126
00:02:55:16	T0FS0F4F43149272E104808074149228
00:02:55:17	T0FS0F4F43149372E10480807414932A
00:02:55:18	T0FS0F4F43149472E10480807414942C
00:02:55:19	T0FS0F4F43149572E10480807414952E
```
✅ Timing correctly progresses from 00:00:00:00 to 00:02:55:19 (matching Max PTS)

### Test 4: Caption data verification
The MCC output contains actual CEA-608 control codes and text:
```
# Around 5 seconds where captions start:
00:00:05:09	T0FS0F4F43Z9F72E104942674Z9FD4   # 9426 = roll-up command
00:00:05:10	T0FS0F4F43ZA072E10494AD74ZA05D   # 94AD = positioning
00:00:05:13	T0FS0F4F43ZA372E1045BC174ZA33E   # 5BC1 = "[A" text
00:00:05:14	T0FS0F4F43ZA472E1044C4C74ZA4BC   # 4C4C = "LL" text
```
✅ Matches raw file hex dump: `9426 94ad 9470 9470 5bc1 4c4c` → "[ALL..."

### Test 5: Large file (18 hours of content)
```bash
$ ./linux/ccextractor --in=raw --out=mcc /tmp/issue_1565/DTV3.raw -o /tmp/test_large.mcc
# Result: 87MB MCC file, 1,942,013 lines, timing to 17:58:52
```
✅ Processes 18 hours of raw caption data correctly

### Test 6: Regression test - SRT output still works
```bash
$ ./linux/ccextractor --in=raw --out=srt /tmp/test113_raw.raw -o /tmp/test.srt
$ head -10 /tmp/test.srt
1
00:00:00,001 --> 00:00:01,429
[ALL SHOUTG]                    
>> H OFFGET HER F.              
>>TOP IT.                       
```
✅ SRT output still works correctly

### Test 7: All Rust tests pass
```bash
$ cargo test
test result: ok. 299 passed; 0 failed; 0 ignored
```

### Test 8: Code quality checks
```bash
$ clang-format --style=file -i src/lib_ccx/general_loop.c  # ✅ No issues
$ cargo fmt --check                                         # ✅ No issues  
$ cargo clippy                                              # ✅ No warnings
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)