### PR TITLE
build(autoconf): Add GPAC library detection to configure

### DIFF
--- a/linux/configure.ac
+++ b/linux/configure.ac
@@ -32,6 +32,11 @@ AC_CHECK_LIB([avformat], [avformat_version], [HAS_AVFORMAT=1 && PKG_CHECK_MODULE
 AC_CHECK_LIB([avutil], [avutil_version], [HAS_AVUTIL=1 && PKG_CHECK_MODULES([libavutil], [libavutil])], [HAS_AVUTIL=0])
 AC_CHECK_LIB([swscale], [swscale_version], [HAS_SWSCALE=1 && PKG_CHECK_MODULES([libswscale], [libswscale])], [HAS_SWSCALE=0])
 
+# Check for GPAC library (required for MP4 support)
+PKG_CHECK_MODULES([gpac], [gpac], [HAS_GPAC=1], [HAS_GPAC=0])
+AS_IF([test $HAS_GPAC -eq 0],
+  [AC_MSG_ERROR([GPAC library not found. Install gpac-devel (Fedora/RHEL), libgpac-dev (Debian/Ubuntu), or gpac (Arch) before proceeding.])])
+
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h float.h inttypes.h limits.h locale.h malloc.h netdb.h netinet/in.h stddef.h stdint.h stdlib.h string.h sys/socket.h sys/time.h sys/timeb.h termios.h unistd.h wchar.h])
 


### PR DESCRIPTION
## Summary

- Add GPAC library detection to configure script using pkg-config
- Fail early with a helpful error message if GPAC is not installed

## Problem

Previously, `./configure` would succeed even without GPAC installed, leading to a confusing compile-time error:
```
../src/lib_ccx/mp4.c:5:10: fatal error: gpac/isomedia.h: No such file or directory
```

## Solution

Now configure checks for GPAC via pkg-config and fails early with a clear error message:
```
configure: error: GPAC library not found. Install gpac-devel (Fedora/RHEL), libgpac-dev (Debian/Ubuntu), or gpac (Arch) before proceeding.
```

## Test plan

- [x] Verified `./configure` detects GPAC when installed (`checking for gpac... yes`)
- [x] Verified build completes successfully with the change
- [x] Verified `./ccextractor --version` works

Fixes #1584

🤖 Generated with [Claude Code](https://claude.com/claude-code)