### PR TITLE
ci: Add Docker build workflow to test all image variants

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,0 +1,92 @@
+name: Build CCExtractor Docker Images
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+    - '.github/workflows/build_docker.yml'
+    - 'docker/**'
+    - '**.c'
+    - '**.h'
+    - 'src/rust/**'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+    - '.github/workflows/build_docker.yml'
+    - 'docker/**'
+    - '**.c'
+    - '**.h'
+    - 'src/rust/**'
+
+jobs:
+  build_minimal:
+    name: Docker build (minimal)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Build minimal image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: docker/Dockerfile
+        build-args: |
+          BUILD_TYPE=minimal
+          USE_LOCAL_SOURCE=1
+        tags: ccextractor:minimal
+        load: true
+        cache-from: type=gha,scope=docker-minimal
+        cache-to: type=gha,mode=max,scope=docker-minimal
+    - name: Test minimal image
+      run: |
+        docker run --rm ccextractor:minimal --version
+        echo "Minimal build successful"
+
+  build_ocr:
+    name: Docker build (ocr)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Build OCR image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: docker/Dockerfile
+        build-args: |
+          BUILD_TYPE=ocr
+          USE_LOCAL_SOURCE=1
+        tags: ccextractor:ocr
+        load: true
+        cache-from: type=gha,scope=docker-ocr
+        cache-to: type=gha,mode=max,scope=docker-ocr
+    - name: Test OCR image
+      run: |
+        docker run --rm ccextractor:ocr --version
+        echo "OCR build successful"
+
+  build_hardsubx:
+    name: Docker build (hardsubx)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Build HardSubX image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: docker/Dockerfile
+        build-args: |
+          BUILD_TYPE=hardsubx
+          USE_LOCAL_SOURCE=1
+        tags: ccextractor:hardsubx
+        load: true
+        cache-from: type=gha,scope=docker-hardsubx
+        cache-to: type=gha,mode=max,scope=docker-hardsubx
+    - name: Test HardSubX image
+      run: |
+        docker run --rm ccextractor:hardsubx --version
+        echo "HardSubX build successful"


### PR DESCRIPTION
## Summary
- Adds new GitHub Actions workflow to test Docker builds
- Tests all three Dockerfile BUILD_TYPE variants in parallel:
  - `minimal`: Basic CCExtractor without OCR
  - `ocr`: CCExtractor with Tesseract OCR support (default)
  - `hardsubx`: CCExtractor with burned-in subtitle extraction (FFmpeg)

## Changes
- New file: `.github/workflows/build_docker.yml`

## How it works
Each job:
1. Checks out the repository
2. Sets up Docker Buildx for layer caching
3. Builds the image using `USE_LOCAL_SOURCE=1` (local source, not git clone)
4. Uses GitHub Actions cache for faster rebuilds on subsequent runs
5. Runs `ccextractor --version` to verify the image works

## Test plan
- [ ] All three Docker build jobs pass
- [ ] Each image successfully runs `--version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)