### PR TITLE
fix(security): Add bounds checks for buffer overflow vulnerabilities

### DIFF
--- a/src/lib_ccx/avc_functions.c
+++ b/src/lib_ccx/avc_functions.c
@@ -954,6 +954,15 @@ void slice_header(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, un
 	dvprint("first_mb_in_slice=     % 4lld (%#llX)\n", tmp, tmp);
 	slice_type = read_exp_golomb_unsigned(&q1);
 	dvprint("slice_type=            % 4llX\n", slice_type);
+
+	// Validate slice_type to prevent buffer overflow in slice_types[] array
+	// Valid H.264 slice_type values are 0-9 (H.264 spec Table 7-6)
+	if (slice_type >= 10)
+	{
+		mprint("Invalid slice_type %lld in slice header, skipping.\n", slice_type);
+		return;
+	}
+
 	tmp = read_exp_golomb_unsigned(&q1);
 	dvprint("pic_parameter_set_id=  % 4lld (%#llX)\n", tmp, tmp);
 


### PR DESCRIPTION
## Summary

Fixes two buffer overflow vulnerabilities reported in issues #1427 and #1428:

- **#1428 (Global buffer overflow in slice_header)**: The `slice_type` value read from H.264 exp-golomb data was used to index `slice_types[]` array (10 elements) without bounds checking. Malformed H.264 data with `slice_type >= 10` would cause out-of-bounds read. Now validates `slice_type < 10` before use per H.264 spec Table 7-6.

- **#1427 (Heap buffer overflow in parse_PMT)**: `ES_info_length` from PMT descriptor data was trusted without validation against buffer bounds. Malformed PMT with excessive `ES_info_length` could read past the allocated buffer. Now validates `ES_info_length` and descriptor lengths against the actual buffer size.

Both issues were discovered using AddressSanitizer with crafted TS files.

## Changes

- `src/lib_ccx/avc_functions.c`: Added validation for `slice_type` value in `slice_header()` function
- `src/lib_ccx/ts_tables.c`: Added multiple bounds checks in `parse_PMT()` for ES_info descriptor parsing

## Test plan

- [x] All 299 Rust tests pass
- [x] Debug (ASAN) and release builds compile successfully
- [x] Tested with real TS samples (503.ts, 600_1080p60.ts) - no regressions

Fixes #1427
Fixes #1428

🤖 Generated with [Claude Code](https://claude.com/claude-code)