### PR TITLE
fix(708): Handle null timing pointer in CEA-708 settings conversion

### DIFF
--- a/src/rust/src/ctorust.rs
+++ b/src/rust/src/ctorust.rs
@@ -121,19 +121,25 @@ impl FromCType<ccx_decoder_dtvcc_settings> for DecoderDtvccSettings {
         {
             services_enabled[i] = flag != 0;
         }
+        // Handle timing - use default if pointer is null to avoid losing other settings
+        let timing = if settings.timing.is_null() {
+            CommonTimingCtx::default()
+        } else {
+            CommonTimingCtx::from_ctype(settings.timing).unwrap_or_default()
+        };
 
         Some(DecoderDtvccSettings {
             enabled: settings.enabled != 0,
             print_file_reports: settings.print_file_reports != 0,
             no_rollup: settings.no_rollup != 0,
             report: if !settings.report.is_null() {
-                Some(DecoderDtvccReport::from_ctype(settings.report)?)
+                DecoderDtvccReport::from_ctype(settings.report)
             } else {
                 None
             },
             active_services_count: settings.active_services_count,
             services_enabled,
-            timing: CommonTimingCtx::from_ctype(settings.timing)?,
+            timing,
         })
     }
 }


### PR DESCRIPTION
## Summary

- Fix CEA-708 decoder not activating when `--service` option is specified
- Handle null timing pointer gracefully in `from_ctype()` conversion
- Prevents critical settings (`enabled`, `services_enabled`) from being reset to defaults

## Problem

When converting CEA-708 decoder settings from C to Rust via `from_ctype()`, a null timing pointer caused the entire conversion to fail and return `None`. This triggered the `unwrap_or(default())` fallback, resetting:
- `enabled` from `true` to `false`
- `active_services_count` from `1` to `0`

This caused CEA-708 captions to not be extracted (exit code 10) even when `--service 1` was specified.

## Root Cause

In `src/rust/src/ctorust.rs`, the `?` operator on timing conversion propagated `None` when timing was null:
```rust
timing: CommonTimingCtx::from_ctype(settings.timing)?,  // Returns None if timing is null
```

## Fix

Handle null timing pointer gracefully:
```rust
let timing = if settings.timing.is_null() {
    CommonTimingCtx::default()
} else {
    CommonTimingCtx::from_ctype(settings.timing).unwrap_or_default()
};
```

## Test plan

- [x] Test with CEA-708 sample that was failing (exit code 10 → exit code 0)
- [x] Verify captions are extracted with `--service 1`
- [ ] CI tests for CEA-708 (tests 141, 142, 146, 147, 149)

🤖 Generated with [Claude Code](https://claude.com/claude-code)