### PR TITLE
fix(timing): Fix --goptime producing compressed timestamps

### DIFF
--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -186,6 +186,11 @@ int start_ccx()
 					ccx_options.use_gop_as_pts = 0;
 				if (ccx_options.ignore_pts_jumps)
 					ccx_common_timing_settings.disable_sync_check = 1;
+				// When using GOP timing (--goptime), disable sync check because
+				// GOP time (wall-clock) and PES PTS (stream-relative) are in
+				// different time bases and will always appear as huge jumps.
+				if (ccx_options.use_gop_as_pts == 1)
+					ccx_common_timing_settings.disable_sync_check = 1;
 				mprint("\rAnalyzing data in general mode\n");
 				tmp = general_loop(ctx);
 				if (!ret)

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -1018,8 +1018,15 @@ int process_non_multiprogram_general_loop(struct lib_ccx_ctx *ctx,
 						pts = data_node_video->pts;
 					}
 
-					set_current_pts(dec_ctx_video->timing, pts);
-					set_fts(dec_ctx_video->timing);
+					// When using GOP timing (--goptime), timing is set from GOP headers
+					// in gop_header(), not from PES PTS. Skip PTS-based timing here
+					// to avoid conflicts between GOP time (absolute time-of-day) and
+					// PTS (relative stream time) that cause sync detection failures.
+					if (ccx_options.use_gop_as_pts != 1)
+					{
+						set_current_pts(dec_ctx_video->timing, pts);
+						set_fts(dec_ctx_video->timing);
+					}
 				}
 				size_t got = process_m2v(*enc_ctx, dec_ctx_video, data_node_video->buffer, data_node_video->len, dec_sub_video);
 				if (got > 0)


### PR DESCRIPTION
## Summary

Fixes Test 163 where `--goptime` option produced compressed timestamps (00:00:01-02) instead of actual GOP times (17:56:40-47).

### Root Cause
When using `--goptime`, there was a conflict between:
- GOP timing set from GOP headers (wall-clock time, e.g., 17:56:40)
- PES PTS timing (stream-relative time, e.g., 00:00:02)

The sync detection code saw these as ~64,598-second "jumps" and kept resetting timing, causing the output timestamps to be corrupted.

### Fixes Applied
1. **Guard video PES timing** in `general_loop.c` - skip `set_current_pts` and `set_fts` when `use_gop_as_pts == 1` to prevent PES PTS from overwriting GOP-based timing

2. **Disable sync check** in `ccextractor.c` when `use_gop_as_pts == 1` since GOP time and PES PTS are in different time bases and sync detection is meaningless in this mode

### Test Results
**Sample:** `c83f765c661595e1bfa4750756a54c006c6f2c697a436bc0726986f71f0706cd.ts`
- Initial GOP time: 17:56:40:433
- Final GOP time: 17:56:47:934

**Before fix:**
```
1
00:00:01,231 --> 00:00:01,729
(explosion)
```

**After fix:**
```
1
17:56:41,319 --> 17:56:43,084
(explosion)
```

## Test Plan
- [x] Verified `--goptime` now produces correct GOP-based timestamps
- [x] Verified normal mode (without `--goptime`) still works correctly
- [x] No warnings about "Reference clock has changed abruptly"

🤖 Generated with [Claude Code](https://claude.com/claude-code)