### PR TITLE
build(rust): Upgrade bindgen to 0.72.1 for Fedora packaging

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -130,6 +130,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.10.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,7 +171,7 @@ checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
 name = "ccx_rust"
 version = "0.1.0"
 dependencies = [
- "bindgen 0.64.0",
+ "bindgen 0.72.1",
  "cfg-if",
  "clap",
  "encoding_rs",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -39,7 +39,7 @@ rsmpeg = { git = "https://github.com/CCExtractor/rsmpeg.git", default-features =
 rsmpeg = { git = "https://github.com/CCExtractor/rsmpeg.git", default-features = false, features = ["ffmpeg7", "link_system_ffmpeg"], optional = true }
 
 [build-dependencies]
-bindgen = "0.64.0"
+bindgen = "0.72.1"
 pkg-config = "0.3.32"
 
 [dev-dependencies]

--- a/src/rust/build.rs
+++ b/src/rust/build.rs
@@ -5,7 +5,8 @@ use std::path::PathBuf;
 fn main() {
     let mut allowlist_functions = Vec::new();
     allowlist_functions.extend_from_slice(&[
-        ".*(?i)_?dtvcc_.*",
+        // Match both lowercase (dtvcc_*) and uppercase (DTVCC_*) patterns
+        ".*_?[Dd][Tt][Vv][Cc][Cc]_.*",
         "get_visible_.*",
         "get_fts",
         "printdata",
@@ -44,7 +45,8 @@ fn main() {
 
     let mut allowlist_types = Vec::new();
     allowlist_types.extend_from_slice(&[
-        ".*(?i)_?dtvcc_.*",
+        // Match both lowercase (dtvcc_*) and uppercase (DTVCC_*) patterns
+        ".*_?[Dd][Tt][Vv][Cc][Cc]_.*",
         "encoder_ctx",
         "lib_cc_decode",
         "ccx_demuxer",
@@ -118,7 +120,7 @@ fn main() {
 
     // Tell cargo to invalidate the built crate whenever any of the
     // included header files changed.
-    builder = builder.parse_callbacks(Box::new(bindgen::CargoCallbacks));
+    builder = builder.parse_callbacks(Box::new(bindgen::CargoCallbacks::new()));
 
     for type_name in allowlist_types {
         builder = builder.allowlist_type(type_name);


### PR DESCRIPTION
## Summary
- Upgrades bindgen from 0.64.0 to 0.72.1 to enable Fedora Linux packaging
- Fixes deprecated `CargoCallbacks` API for newer bindgen versions
- Replaces `(?i)` regex flags with character classes for compatibility (the inline flag causes bindgen 0.72.1 to silently produce empty bindings)

Fixes #1608

## Test plan
- [x] Build completes successfully with bindgen 0.72.1
- [x] Binary version check passes
- [x] Subtitle extraction works correctly (tested with DTVCC sample)

🤖 Generated with [Claude Code](https://claude.com/claude-code)