### PR TITLE
[FIX] Delete empty output files instead of leaving 0-byte files (#1282)

### DIFF
--- a/src/lib_ccx/output.c
+++ b/src/lib_ccx/output.c
@@ -14,7 +14,19 @@ void dinit_write(struct ccx_s_write *wb)
 		return;
 	}
 	if (wb->fh > 0)
+	{
+		// Check if the file is empty before closing
+		off_t file_size = lseek(wb->fh, 0, SEEK_END);
 		close(wb->fh);
+
+		// Delete empty output files to avoid generating useless 0-byte files
+		// This commonly happens with -12 option when one field has no captions
+		if (file_size == 0 && wb->filename != NULL)
+		{
+			unlink(wb->filename);
+			mprint("Deleted empty output file: %s\n", wb->filename);
+		}
+	}
 	freep(&wb->filename);
 	freep(&wb->original_filename);
 	if (wb->with_semaphore && wb->semaphore_filename)


### PR DESCRIPTION
## Summary
- When using `--output-field both`, CCExtractor creates separate output files for each field
- If one field has no captions (e.g., CC3 when only CC1 has data), a 0-byte file was left behind
- This fix checks file size in `dinit_write()` before closing - if empty, deletes the file

## Approach
This is a simpler approach than PR #1793 (deferred file creation):
- Files are still created at initialization (no changes to init path)
- At cleanup, if a file is empty (0 bytes), it's deleted with an informational message
- Minimal code change (1 file, ~12 lines)

## Test Results
```
$ ccextractor sample.ts --output-field both -o /tmp/test.srt
...
Deleted empty output file: /tmp/test_2.srt
```

Only the file with actual captions remains.

Fixes #1282

🤖 Generated with [Claude Code](https://claude.com/claude-code)