### PR TITLE
[FEATURE] Add AppImage build variants and CI workflow (#1348)

### DIFF
--- a/.github/workflows/build_appimage.yml
+++ b/.github/workflows/build_appimage.yml
@@ -83,7 +83,8 @@ jobs:
             libavutil-dev \
             libswscale-dev \
             libswresample-dev \
-            libavfilter-dev
+            libavfilter-dev \
+            libavdevice-dev
 
       - name: Install Rust toolchain
         if: steps.should_build.outputs.should_build == 'true'

--- a/linux/build_appimage.sh
+++ b/linux/build_appimage.sh
@@ -203,9 +203,18 @@ esac
 # Build AppImage
 echo "Building AppImage..."
 export OUTPUT="$OUTPUT_NAME"
+
+# Determine which executable to pass to linuxdeploy
+# For OCR builds, we have a wrapper script, so pass the actual binary (.bin)
+if [ -f "AppDir/usr/bin/ccextractor.bin" ]; then
+    LINUXDEPLOY_EXEC="AppDir/usr/bin/ccextractor.bin"
+else
+    LINUXDEPLOY_EXEC="AppDir/usr/bin/ccextractor"
+fi
+
 ./linuxdeploy-x86_64.AppImage \
     --appdir=AppDir \
-    --executable=AppDir/usr/bin/ccextractor \
+    --executable="$LINUXDEPLOY_EXEC" \
     --desktop-file=AppDir/ccextractor.desktop \
     --icon-file=AppDir/ccextractor.png \
     --output=appimage


### PR DESCRIPTION
## Summary
Rewrites the AppImage build script and adds a CI workflow to automatically build AppImages on releases.

### Build Variants (matching Docker)
- **minimal**: Basic CCExtractor without OCR (smallest size, ~14MB)
- **ocr**: CCExtractor with OCR support (default)
- **hardsubx**: CCExtractor with burned-in subtitle extraction (OCR + FFmpeg)

### Changes to `linux/build_appimage.sh`
- Add `BUILD_TYPE` environment variable to select variant
- Fix CMake options (was incorrectly passing `ENABLE_OCR=yes` to make instead of `-DWITH_OCR=ON` to cmake)
- Bundle tessdata for OCR builds with wrapper script that sets `TESSDATA_PREFIX`
- Create proper desktop file and icon handling
- Improve error handling and cleanup

### New CI Workflow `.github/workflows/build_appimage.yml`
- Builds all three variants on release
- Uploads AppImages as release assets automatically
- Can be manually triggered for specific variants
- Caches GPAC build for faster CI runs

## Usage
```bash
./build_appimage.sh              # Builds 'ocr' variant (default)
BUILD_TYPE=minimal ./build_appimage.sh
BUILD_TYPE=hardsubx ./build_appimage.sh
```

## Testing
Tested locally - minimal variant builds successfully and runs:
```
$ ./ccextractor-minimal-x86_64.AppImage --version
CCExtractor detailed version info
    Version: 0.95
    ...
```

Closes #1348

🤖 Generated with [Claude Code](https://claude.com/claude-code)