### PR TITLE
[FEATURE] Add guarded ASS/SSA \pos positioning for CEA-608 captions

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 0.96.7 (unreleased)
 -------------------
+- New: Added ASS/SSA \pos-based positioning for CEA-608 captions when layout is simple (1–2 rows) (#1726)
 - Fix: Remove strdup() memory leaks in WebVTT styling encoder, fix invalid CSS rgba(0,256,0) green value, fix missing free(unescaped) on write-error path (#2154)
 - Fix: Prevent crash in Rust timing module when logging out-of-range PTS/FTS timestamps from malformed streams.
 

--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -38,14 +38,8 @@
 - Fix: Configuration file parser bugs — heap buffer overflow on long lines, broken EOF
   detection due to incorrect fgetc() return type, and last line dropped if file lacks
   trailing newline
-- Fix: Typos in configuration keys: FIX_PADDINDG → FIX_PADDING, INVASTIGATE_PACKET → INVESTIGATE_PACKET
-
-0.96.6 (unreleased)
--------------------
-- New: Added ASS/SSA \pos-based positioning for CEA-608 captions when layout is simple (1–2 rows) (#1726)
-- Fix: Prevent infinite loop on truncated MKV files
-- Fix: Various memory safety and stability fixes in demuxers (MP4, PS, MKV, DVB)
-- Fix: Delete empty output files instead of leaving 0-byte files (#1282)
+- Fix: Typos in configuration keys: FIX_PADDINDG → FIX_PADDING,
+  INVASTIGATE_PACKET → INVESTIGATE_PACKET
 
 0.96.5 (2026-01-05)
 -------------------

--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -38,8 +38,14 @@
 - Fix: Configuration file parser bugs — heap buffer overflow on long lines, broken EOF
   detection due to incorrect fgetc() return type, and last line dropped if file lacks
   trailing newline
-- Fix: Typos in configuration keys: FIX_PADDINDG → FIX_PADDING,
-  INVASTIGATE_PACKET → INVESTIGATE_PACKET
+- Fix: Typos in configuration keys: FIX_PADDINDG → FIX_PADDING, INVASTIGATE_PACKET → INVESTIGATE_PACKET
+
+0.96.6 (unreleased)
+-------------------
+- New: Added ASS/SSA \pos-based positioning for CEA-608 captions when layout is simple (1–2 rows) (#1726)
+- Fix: Prevent infinite loop on truncated MKV files
+- Fix: Various memory safety and stability fixes in demuxers (MP4, PS, MKV, DVB)
+- Fix: Delete empty output files instead of leaving 0-byte files (#1282)
 
 0.96.5 (2026-01-05)
 -------------------

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -48,6 +48,8 @@ static const char *ssa_header =
     "[Script Info]\n\
 Title: Default file\n\
 ScriptType: v4.00+\n\
+PlayResX: 384\n\
+PlayResY: 288\n\
 \n\
 [V4+ Styles]\n\
 Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding\n\

--- a/src/lib_ccx/ccx_encoders_ssa.c
+++ b/src/lib_ccx/ccx_encoders_ssa.c
@@ -5,6 +5,25 @@
 #include "ccx_encoders_helpers.h"
 #include "ocr.h"
 
+static void ass_position_from_row(
+    int row,
+    int play_res_x,
+    int play_res_y,
+    int *out_x,
+    int *out_y)
+{
+	// Center horizontally
+	*out_x = play_res_x / 2;
+
+	// Map CEA-608 row (0–14) to ASS Y coordinate
+	// SSA default PlayResY is 288
+	int top = play_res_y * 60 / 100; // start of lower third
+	int bottom = play_res_y * 95 / 100;
+
+	int y = top + (row * (bottom - top) / 14);
+	*out_y = y;
+}
+
 int write_stringz_as_ssa(char *string, struct encoder_ctx *context, LLONG ms_start, LLONG ms_end)
 {
 	int used;
@@ -168,11 +187,18 @@ int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *conte
 	unsigned h1, m1, s1, ms1;
 	unsigned h2, m2, s2, ms2;
 	int wrote_something = 0;
+	int used_row_count = 0;
 
 	int prev_line_start = -1, prev_line_end = -1;	    // Column in which the previous line started and ended, for autodash
 	int prev_line_center1 = -1, prev_line_center2 = -1; // Center column of previous line text
 	int empty_buf = 1;
-	for (int i = 0; i < 15; i++)
+
+	int first_row = -1;
+	int x, y;
+	char pos_tag[64];
+	int i;
+
+	for (i = 0; i < 15; i++)
 	{
 		if (data->row_used[i])
 		{
@@ -182,6 +208,12 @@ int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *conte
 	}
 	if (empty_buf)
 		return 0;
+
+	for (i = 0; i < 15; i++)
+	{
+		if (data->row_used[i])
+			used_row_count++;
+	}
 
 	millis_to_time(data->start_time, &h1, &m1, &s1, &ms1);
 	millis_to_time(data->end_time - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
@@ -194,8 +226,59 @@ int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *conte
 	dbg_print(CCX_DMT_DECODER_608, "%s", timeline);
 
 	write_wrapped(context->out->fh, context->buffer, used);
+
+	/*
+	 * ASS precise positioning note:
+	 * We emit {\an2\pos(x,y)} using ASS script resolution coordinates.
+	 * PlayResX/PlayResY are explicitly declared in the SSA header (384x288),
+	 * which is the SSA/libass default resolution and ensures consistent
+	 * positioning across players.
+	 *
+	 * Positioning is intentionally guarded to avoid regressions when
+	 * caption layout information is ambiguous.
+	 */
+
+	/* ---- ASS precise positioning ---- */
+
+	first_row = -1;
+
+	/*
+	 * Only apply ASS positioning when:
+	 * - At least one row is present
+	 * - AND there is a single logical caption region
+	 * Otherwise, fall back to legacy SSA behavior.
+	 */
+
+	if (used_row_count > 0 && used_row_count <= 2)
+	{
+		for (i = 0; i < 15; i++)
+		{
+			if (data->row_used[i])
+			{
+				first_row = i;
+				break;
+			}
+		}
+
+		if (first_row >= 0)
+		{
+			// SSA default resolution (used by libass / Aegisub)
+			ass_position_from_row(first_row, 384, 288, &x, &y);
+
+			snprintf(
+			    pos_tag,
+			    sizeof(pos_tag),
+			    "{\\an2\\pos(%d,%d)}",
+			    x, y);
+
+			write_wrapped(context->out->fh, pos_tag, strlen(pos_tag));
+		}
+	}
+
+	/* ---- end ASS positioning ---- */
+
 	int line_count = 0;
-	for (int i = 0; i < 15; i++)
+	for (i = 0; i < 15; i++)
 	{
 		if (data->row_used[i])
 		{

--- a/src/lib_ccx/ccx_encoders_ssa.c
+++ b/src/lib_ccx/ccx_encoders_ssa.c
@@ -17,7 +17,7 @@ static void ass_position_from_row(
 
 	// Map CEA-608 row (0–14) to ASS Y coordinate
 	// SSA default PlayResY is 288
-	int top = play_res_y * 60 / 100; // start of lower third
+	int top = play_res_y * 10 / 100; // start of lower third
 	int bottom = play_res_y * 95 / 100;
 
 	int y = top + (row * (bottom - top) / 14);

--- a/src/lib_ccx/ccx_encoders_ssa.c
+++ b/src/lib_ccx/ccx_encoders_ssa.c
@@ -5,23 +5,23 @@
 #include "ccx_encoders_helpers.h"
 #include "ocr.h"
 
-static void ass_position_from_row(
+static void ass_position_from_row_col(
     int row,
+    int col,
     int play_res_x,
     int play_res_y,
     int *out_x,
     int *out_y)
 {
-	// Center horizontally
-	*out_x = play_res_x / 2;
+	/* vertical: matches FFmpeg's 0.1 + 0.0533*i formula (0.80/15 = 0.05333) */
+	double top = play_res_y * 0.10;
+	double row_step = (play_res_y * 0.80) / 15.0;
+	*out_y = (int)(top + row * row_step + 0.5);
 
-	// Map CEA-608 row (0–14) to ASS Y coordinate
-	// SSA default PlayResY is 288
-	int top = play_res_y * 10 / 100; // start of lower third
-	int bottom = play_res_y * 95 / 100;
-
-	int y = top + (row * (bottom - top) / 14);
-	*out_y = y;
+	/* horizontal: matches FFmpeg's 0.1 + 0.025*j (0.025 = 0.80/32, 32 cells) */
+	double left = play_res_x * 0.10;
+	double col_step = play_res_x * 0.025;
+	*out_x = (int)(left + col * col_step + 0.5);
 }
 
 int write_stringz_as_ssa(char *string, struct encoder_ctx *context, LLONG ms_start, LLONG ms_end)
@@ -187,11 +187,9 @@ int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *conte
 	unsigned h1, m1, s1, ms1;
 	unsigned h2, m2, s2, ms2;
 	int wrote_something = 0;
-	int used_row_count = 0;
 
 	int prev_line_start = -1, prev_line_end = -1;	    // Column in which the previous line started and ended, for autodash
 	int prev_line_center1 = -1, prev_line_center2 = -1; // Center column of previous line text
-	int empty_buf = 1;
 
 	int first_row = -1;
 	int last_row = -1;
@@ -202,18 +200,22 @@ int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *conte
 	{
 		if (data->row_used[i])
 		{
-			empty_buf = 0;
+			first_row = i;
 			break;
 		}
 	}
-	if (empty_buf)
-		return 0;
 
-	for (int i = 0; i < 15; i++)
+	for (int i = 14; i >= 0; i--)
 	{
 		if (data->row_used[i])
-			used_row_count++;
+		{
+			last_row = i;
+			break;
+		}
 	}
+
+	if (first_row < 0)
+		return 0;
 
 	millis_to_time(data->start_time, &h1, &m1, &s1, &ms1);
 	millis_to_time(data->end_time - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
@@ -229,7 +231,7 @@ int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *conte
 
 	/*
 	 * ASS precise positioning note:
-	 * We emit {\an2\pos(x,y)} using ASS script resolution coordinates.
+	 * We emit {\an7\pos(x,y)} using ASS script resolution coordinates.
 	 * PlayResX/PlayResY are explicitly declared in the SSA header (384x288),
 	 * which is the SSA/libass default resolution and ensures consistent
 	 * positioning across players.
@@ -247,38 +249,54 @@ int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *conte
 	 * Otherwise, fall back to legacy SSA positioning.
 	 */
 
-	if (used_row_count > 0 && used_row_count <= 2)
+	if ((last_row - first_row) <= 1)
 	{
-		for (int i = 0; i < 15; i++)
+		int first_col = 31;
+
+		for (int r = first_row; r <= last_row; r++)
 		{
-			if (data->row_used[i])
+			if (!data->row_used[r])
+				continue;
+
+			int f = -1, l = -1;
+
+			find_limit_characters(
+			    data->characters[r],
+			    &f,
+			    &l,
+			    CCX_DECODER_608_SCREEN_WIDTH);
+
+			/* Fallback: row_used but only control/padding bytes present */
+			if (f < 0)
 			{
-				first_row = i;
-				break;
+				unsigned char *line = data->characters[r];
+				for (int c = 0; c < CCX_DECODER_608_SCREEN_WIDTH; c++)
+				{
+					if (line[c] != ' ' && line[c] != 0 && line[c] != 0x89) /* match find_limit_characters */
+					{
+						f = c;
+						break;
+					}
+				}
 			}
+
+			/* Safety clamp: fully empty row defaults to left edge */
+			if (f < 0)
+				f = 0;
+
+			if (f < first_col)
+				first_col = f;
 		}
 
-		for (int i = 14; i >= 0; i--)
-		{
-			if (data->row_used[i])
-			{
-				last_row = i;
-				break;
-			}
-		}
+		ass_position_from_row_col(first_row, first_col, 384, 288, &x, &y);
 
-		if (first_row >= 0 && last_row >= 0 && (last_row - first_row) <= 1)
-		{
-			ass_position_from_row(last_row, 384, 288, &x, &y);
+		snprintf(
+		    pos_tag,
+		    sizeof(pos_tag),
+		    "{\\an7\\pos(%d,%d)}",
+		    x, y);
 
-			snprintf(
-			    pos_tag,
-			    sizeof(pos_tag),
-			    "{\\an2\\pos(%d,%d)}",
-			    x, y);
-
-			write_wrapped(context->out->fh, pos_tag, strlen(pos_tag));
-		}
+		write_wrapped(context->out->fh, pos_tag, strlen(pos_tag));
 	}
 
 	int line_count = 0;

--- a/src/lib_ccx/ccx_encoders_ssa.c
+++ b/src/lib_ccx/ccx_encoders_ssa.c
@@ -194,11 +194,11 @@ int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *conte
 	int empty_buf = 1;
 
 	int first_row = -1;
+	int last_row = -1;
 	int x, y;
 	char pos_tag[64];
-	int i;
 
-	for (i = 0; i < 15; i++)
+	for (int i = 0; i < 15; i++)
 	{
 		if (data->row_used[i])
 		{
@@ -209,7 +209,7 @@ int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *conte
 	if (empty_buf)
 		return 0;
 
-	for (i = 0; i < 15; i++)
+	for (int i = 0; i < 15; i++)
 	{
 		if (data->row_used[i])
 			used_row_count++;
@@ -240,18 +240,16 @@ int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *conte
 
 	/* ---- ASS precise positioning ---- */
 
-	first_row = -1;
-
 	/*
 	 * Only apply ASS positioning when:
 	 * - At least one row is present
-	 * - AND there is a single logical caption region
-	 * Otherwise, fall back to legacy SSA behavior.
+	 * - And captions occupy a single logical region (1–2 adjacent rows)
+	 * Otherwise, fall back to legacy SSA positioning.
 	 */
 
 	if (used_row_count > 0 && used_row_count <= 2)
 	{
-		for (i = 0; i < 15; i++)
+		for (int i = 0; i < 15; i++)
 		{
 			if (data->row_used[i])
 			{
@@ -260,10 +258,18 @@ int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *conte
 			}
 		}
 
-		if (first_row >= 0)
+		for (int i = 14; i >= 0; i--)
 		{
-			// SSA default resolution (used by libass / Aegisub)
-			ass_position_from_row(first_row, 384, 288, &x, &y);
+			if (data->row_used[i])
+			{
+				last_row = i;
+				break;
+			}
+		}
+
+		if (first_row >= 0 && last_row >= 0 && (last_row - first_row) <= 1)
+		{
+			ass_position_from_row(last_row, 384, 288, &x, &y);
 
 			snprintf(
 			    pos_tag,
@@ -275,10 +281,8 @@ int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *conte
 		}
 	}
 
-	/* ---- end ASS positioning ---- */
-
 	int line_count = 0;
-	for (i = 0; i < 15; i++)
+	for (int i = 0; i < 15; i++)
 	{
 		if (data->row_used[i])
 		{


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [X] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [X] I am an active contributor to CCExtractor.

---
## [FEATURE] - Add ASS/SSA \pos positioning for CEA-608 captions ([feature request #1726](https://github.com/CCExtractor/ccextractor/issues/1726))

## Summary
Implements precise positioning for ASS/SSA subtitle export using `\pos(x,y)` tags, replacing whitespace-based layout where sufficient positioning information is available.

Fixes #1726

## Changes
- Added `ass_position_from_row_col()` function to map CEA-608 grid position (row and column) to ASS coordinates and alignment anchor
- Applied `{\anN\pos(x,y)}` positioning tags for single-region captions (1–2 adjacent rows), with alignment derived from CEA-608 PAC indent zones
- Added PlayResX/PlayResY declarations to Script Info header (384×288)
- Maintained backward compatibility via conservative guards

## Design Decisions

**Positioning is intentionally conservative:**
- Applied only when 1–2 adjacent caption rows are active to avoid layout conflicts
- Falls back to legacy whitespace behavior when layout is ambiguous (>2 rows)

**Geometry is spec-grounded:**
- Safe-area margins use approximately 3/32 of the active picture on each side (≈9.375%), reflecting historical CEA-608 hardware display geometry
- Horizontal alignment anchor (`\an1`/`\an2`/`\an3`) is derived from the CEA-608 PAC indent level (`first_col`), approximating native left-, center-, and right-aligned caption placement
- Column extents are computed as a union across all used rows for consistent 2-line anchoring
- Vertical placement uses 15 equal row slots with slot-center mapping

**Resolution choice:**
- Uses SSA default 384×288 resolution (standard for libass/Aegisub/VSFilter)
- Explicitly declared in header for spec compliance

## Testing
Verified output using a [sample](https://sampleplatform.ccextractor.org/sample/27fab4dbb603753d76e8b7701bbf0a5b1b9d41d2748759bb22f7fe6afc75597b) from the CCExtractor sample platform, comparing generated SSA against embedded 608 captions in mpv. Left-, center-, and right-aligned captions now render at approximately the correct screen position. Legacy layout is preserved for multi-region captions.


## Future Enhancements
The remaining small offset between SSA and native 608 rendering is due to libass font glyph bearing and is not resolvable at this level.