### PR TITLE
fix(ci): Update Windows release build to use x64 platform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,10 @@ jobs:
         LLVM_CONFIG_PATH: "C:\\Program Files\\LLVM\\bin\\llvm-config"
         CARGO_TARGET_DIR: "..\\..\\windows"
         BINDGEN_EXTRA_CLANG_ARGS: -fmsc-version=0
-      run: msbuild ccextractor.sln /p:Configuration=Release-Full /p:Platform=Win32
+      run: msbuild ccextractor.sln /p:Configuration=Release-Full /p:Platform=x64
       working-directory: ./windows
     - name: Copy files to directory for installer
-      run: mkdir installer; cp ./Release-Full/ccextractorwinfull.exe ./installer; cp ./Release-Full/*.dll ./installer
+      run: mkdir installer; cp ./x64/Release-Full/ccextractorwinfull.exe ./installer; cp ./x64/Release-Full/*.dll ./installer
       working-directory: ./windows
     - name: install WiX
       run: dotnet tool install --global wix --version 4.0.0-preview.0 &&  wix extension -g add WixToolset.UI.wixext


### PR DESCRIPTION
## Summary

The v0.96 release workflow failed because the Windows build was trying to use `Win32` platform, but the solution file only has `x64` configurations.

**Error:**
```
error MSB4126: The specified solution configuration "Release-Full|Win32" is invalid.
```

**Failed run:** https://github.com/CCExtractor/ccextractor/actions/runs/20470181971/job/58823455083

## Changes

| Line | Before | After |
|------|--------|-------|
| 37 | `Platform=Win32` | `Platform=x64` |
| 40 | `./Release-Full/` | `./x64/Release-Full/` |

## Solution File Configurations

The `.sln` only has these configurations:
- `Debug-Full|x64`
- `Release-Full|x64`

No `Win32` platform exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)