### PR TITLE
Fix typo: 'sring' -> 'string' in DVB subtitle decoder

### DIFF
--- a/src/lib_ccx/dvb_subtitle_decoder.c
+++ b/src/lib_ccx/dvb_subtitle_decoder.c
@@ -1117,7 +1117,7 @@ static int dvbsub_parse_object_segment(void *dvb_ctx, const uint8_t *buf,
 	}
 	else if (coding_method == 1)
 	{
-		mprint("FIXME support for sring coding standard\n");
+		mprint("FIXME support for string coding standard\n");
 	}
 	else
 	{


### PR DESCRIPTION
## Description
Fixed a typo in the DVB subtitle decoder error message.

## Changes
- Changed "sring" to "string" in `dvb_subtitle_decoder.c` line 1120

## Testing
- Built successfully in WSL Ubuntu
- No functional changes, only a typo correction in an error message

This is my first contribution to CCExtractor. Looking forward to feedback!