### PR TITLE
Fix infinite binary output when processing .ts files with no subtitles

### DIFF
--- a/src/lib_ccx/ts_functions.c
+++ b/src/lib_ccx/ts_functions.c
@@ -569,8 +569,8 @@ int copy_capbuf_demux_data(struct ccx_demuxer *ctx, struct demuxer_data **data, 
 
 	if (ptr->bufferdatatype == CCX_PRIVATE_MPEG2_CC)
 	{
-		dump(CCX_DMT_GENERIC_NOTICES, cinfo->capbuf, cinfo->capbuflen, 0, 1);
 		// Bogus data, so we return something
+		// Removed dump() call to prevent infinite binary output when processing files with no subtitles
 		ptr->buffer[ptr->len++] = 0xFA;
 		ptr->buffer[ptr->len++] = 0x80;
 		ptr->buffer[ptr->len++] = 0x80;


### PR DESCRIPTION
Problem
When CCExtractor processes a .ts file that contains no subtitles, it produces infinite binary/hex-like output in the terminal instead of stopping gracefully.

Solution
Removed the `dump()` call in `copy_capbuf_demux_data()` for `CCX_PRIVATE_MPEG2_CC` buffer type. This dump was using `CCX_DMT_GENERIC_NOTICES` which is enabled by default, causing continuous binary output to the terminal.

Changes
- Removed `dump(CCX_DMT_GENERIC_NOTICES, ...)` call from `copy_capbuf_demux_data()` function
- Added explanatory comment about why the dump was removed
- Function still processes data correctly, just without the debug output

Testing
- Verified that the problematic dump call is removed
- Code still handles `CCX_PRIVATE_MPEG2_CC` buffer type correctly
- No infinite binary output when processing TS files with no subtitles

Fixes #1754