### PR TITLE
docs(mac): Add documentation for -system-libs build mode

### DIFF
--- a/docs/Building_macos_system_libs.md
+++ b/docs/Building_macos_system_libs.md
@@ -1,0 +1,157 @@
+# Building CCExtractor on macOS using System Libraries (-system-libs)
+
+## Overview
+
+This document explains how to build CCExtractor on macOS using system-installed libraries instead of bundled third-party libraries.
+
+This build mode is required for Homebrew compatibility and is enabled via the `-system-libs` flag introduced in PR #1862.
+
+## Why is -system-libs needed?
+
+### Background
+
+CCExtractor was removed from Homebrew (homebrew-core) because:
+
+- Homebrew does not allow bundling third-party libraries
+- The default CCExtractor build compiles libraries from `src/thirdparty/`
+- This violates Homebrew packaging policies
+
+### What -system-libs fixes
+
+The `-system-libs` flag allows CCExtractor to:
+
+- Use system-installed libraries via Homebrew
+- Resolve headers and linker flags using `pkg-config`
+- Skip compiling bundled copies of common libraries
+
+This makes CCExtractor acceptable for Homebrew packaging.
+
+## Build Modes Explained
+
+### 1️⃣ Default Build (Bundled Libraries)
+
+**Command:**
+
+```bash
+./mac/build.command
+```
+
+**Behavior:**
+
+- Compiles bundled libraries:
+  - `freetype`
+  - `libpng`
+  - `zlib`
+  - `utf8proc`
+- Self-contained binary
+- Larger size
+- Suitable for standalone builds
+
+### 2️⃣ System Libraries Build (Homebrew-compatible)
+
+**Command:**
+
+```bash
+./mac/build.command -system-libs
+```
+
+**Behavior:**
+
+- Uses system libraries via `pkg-config`
+- Does not compile bundled libraries
+- Smaller binary
+- Faster build
+- Required for Homebrew
+
+## Required Homebrew Dependencies
+
+Install required dependencies:
+
+```bash
+brew install pkg-config autoconf automake libtool \
+  gpac freetype libpng protobuf-c utf8proc zlib
+```
+
+**Optional** (OCR / HARDSUBX support):
+
+```bash
+brew install tesseract leptonica ffmpeg
+```
+
+## How to Build
+
+```bash
+cd mac
+./build.command -system-libs
+```
+
+**Verify:**
+
+```bash
+./ccextractor --version
+```
+
+## What Changes Internally with -system-libs
+
+### Libraries NOT compiled (system-provided)
+
+- **FreeType**
+- **libpng**
+- **zlib**
+- **utf8proc**
+
+### Libraries STILL bundled
+
+- **lib_hash** (Custom SHA-256 implementation, no system equivalent)
+
+## CI Coverage
+
+A new CI job was added:
+
+- `build_shell_system_libs`
+
+**What it does:**
+
+- Installs Homebrew dependencies
+- Runs `./build.command -system-libs`
+- Verifies the binary runs correctly
+
+This ensures Homebrew-compatible builds stay working.
+
+## Verification (Local)
+
+You can confirm system libraries are used:
+
+```bash
+otool -L mac/ccextractor
+```
+
+**Expected output includes paths like:**
+
+```
+/opt/homebrew/opt/gpac/lib/libgpac.dylib
+```
+
+## Homebrew Formula Usage (Future)
+
+Example formula snippet:
+
+```ruby
+def install
+  system "./mac/build.command", "-system-libs"
+  bin.install "mac/ccextractor"
+end
+```
+
+## Summary
+
+- `-system-libs` is opt-in
+- Default build remains unchanged
+- Enables CCExtractor to return to Homebrew
+- Fully tested in CI and locally
+
+## Related
+
+- **PR #1862** — Add `-system-libs` flag
+- **Issue #1580** — Homebrew compatibility
+- **Issue #1534** — System library support


### PR DESCRIPTION
[IMPROVEMENT]

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

PR Summary

This PR documents the macOS -system-libs build mode introduced in #1862, which enables building CCExtractor using system-installed libraries instead of bundled dependencies.

This mode is required for Homebrew compatibility and uses pkg-config to link against Homebrew-provided libraries (e.g. gpac, freetype, libpng, zlib). The default bundled build remains unchanged.

The documentation explains:

When to use the default vs -system-libs build

Required Homebrew dependencies

How to verify the build

CI coverage for the system-libs path

This provides a clear upstream reference for package managers and unblocks future Homebrew formula work.
