### PR TITLE
Docs: Add Windows WSL build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The core functionality is written in C. Other languages used include C++ and Pyt
 
 Downloads for precompiled binaries and source code can be found [on our website](https://ccextractor.org/public/general/downloads/).
 
+
 ### Windows Package Managers
 
 **WinGet:**
@@ -60,6 +61,10 @@ More usage information can be found on our website:
 You can also find the list of parameters and their brief description by running `ccextractor` without any arguments.
 
 You can find sample files on [our website](https://ccextractor.org/public/general/tvsamples/) to test the software.
+
+### Building from Source
+
+- [Building on Windows using WSL](docs/build-wsl.md)
 
 ## Compiling CCExtractor
 

--- a/docs/build-wsl.md
+++ b/docs/build-wsl.md
@@ -1,0 +1,137 @@
+# Building CCExtractor on Windows using WSL
+
+This guide explains how to build CCExtractor on Windows using WSL (Ubuntu).
+It is based on a fresh setup and includes all required dependencies and
+common build issues encountered during compilation.
+
+---
+
+## Prerequisites
+
+- Windows 10 or Windows 11
+- WSL enabled
+- Ubuntu installed via Microsoft Store
+
+---
+
+## Install WSL and Ubuntu
+
+From PowerShell (run as Administrator):
+
+```powershell
+wsl --install -d Ubuntu
+```
+
+Restart the system if prompted, then launch Ubuntu from the Start menu.
+
+---
+
+## Update system packages
+
+```bash
+sudo apt update
+```
+
+---
+
+## Install basic build tools
+
+```bash
+sudo apt install -y build-essential git pkg-config
+```
+
+---
+
+## Install Rust (required)
+
+CCExtractor includes Rust components, so Rust and Cargo are required.
+
+```bash
+curl https://sh.rustup.rs -sSf | sh
+source ~/.cargo/env
+```
+
+Verify installation:
+
+```bash
+cargo --version
+rustc --version
+```
+
+---
+
+## Install required libraries
+
+```bash
+sudo apt install -y \
+  libclang-dev clang \
+  libtesseract-dev tesseract-ocr \
+  libgpac-dev
+```
+
+---
+
+## Clone the repository
+
+```bash
+git clone https://github.com/CCExtractor/ccextractor.git
+cd ccextractor
+```
+
+---
+
+## Build CCExtractor
+
+```bash
+cd linux
+./build
+```
+
+After a successful build, verify by running:
+
+```bash
+./ccextractor
+```
+
+You should see the help/usage output.
+
+---
+
+## Common build issues
+
+### cargo: command not found
+
+```bash
+source ~/.cargo/env
+```
+
+---
+
+### Unable to find libclang
+
+```bash
+sudo apt install libclang-dev clang
+```
+
+---
+
+### gpac/isomedia.h: No such file or directory
+
+```bash
+sudo apt install libgpac-dev
+```
+
+---
+
+### please install tesseract development library
+
+```bash
+sudo apt install libtesseract-dev tesseract-ocr
+```
+
+---
+
+## Notes
+
+- Compiler warnings during the build process are expected and do not indicate failure.
+- This guide was tested on Ubuntu (WSL) running on Windows 11.


### PR DESCRIPTION
This PR adds documentation for building CCExtractor on Windows using WSL (Ubuntu).

The guide includes:
- WSL and Ubuntu setup
- Rust installation
- Required dependencies (libclang, tesseract, gpac)
- Build steps
- Common build errors and fixes

This should help first-time contributors build CCExtractor more easily on Windows.
