### PR TITLE
[FIX] Fix MSVC warning C4098: void function returning a value in networking.c

### DIFF
--- a/src/lib_ccx/networking.c
+++ b/src/lib_ccx/networking.c
@@ -104,7 +104,7 @@ void connect_to_srv(const char *addr, const char *port, const char *cc_desc, con
 {
 #ifndef DISABLE_RUST
 	(void)ccxr_connect_to_srv(addr, port, cc_desc, pwd);
-
+	return;
 #endif
 	if (NULL == addr)
 	{
@@ -139,7 +139,7 @@ void net_send_header(const unsigned char *data, size_t len)
 {
 #ifndef DISABLE_RUST
 	(void)ccxr_net_send_header(data, len);
-
+	return;
 #endif
 	assert(srv_sd > 0);
 
@@ -256,7 +256,7 @@ void net_send_epg(
 {
 #ifndef DISABLE_RUST
 	(void)ccxr_net_send_epg(start, stop, title, desc, lang, category);
-
+	return;
 #endif
 	size_t st;
 	size_t sp;


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x ] I have checked that another pull request for this purpose does not exist.
- [x ] I have considered, and confirmed that this submission will be valuable to others.
- [x ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

**Description**
This PR fixes multiple instances of compiler warning C4098 in `src/lib_ccx/networking.c`.
Several functions (`connect_to_srv`, `net_send_header`, etc.) were declared as `void` but were attempting to return values from internal function calls.

**Changes**
- Casted the return values of the internal Rust functions to (void) to suppress MSVC warning C4098.

- Removed the explicit return; statements to ensure the subsequent C implementation is correctly executed (fixing a logic error   where the C fallback was being skipped).

**Environment**
- Windows 11
- MSVC / CMake
