### PR TITLE
fix(windows): Bundle tessdata for OCR support out of the box

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,14 @@ jobs:
     - name: Copy files to directory for installer
       run: mkdir installer; cp ./x64/Release-Full/ccextractorwinfull.exe ./installer; cp ./x64/Release-Full/*.dll ./installer
       working-directory: ./windows
+    - name: Download tessdata for OCR support
+      run: |
+        mkdir -p ./installer/tessdata
+        # Download English traineddata from tessdata_fast (smaller, faster, good for most use cases)
+        Invoke-WebRequest -Uri "https://github.com/tesseract-ocr/tessdata_fast/raw/main/eng.traineddata" -OutFile "./installer/tessdata/eng.traineddata"
+        # Download OSD (Orientation and Script Detection) for automatic script detection
+        Invoke-WebRequest -Uri "https://github.com/tesseract-ocr/tessdata_fast/raw/main/osd.traineddata" -OutFile "./installer/tessdata/osd.traineddata"
+      working-directory: ./windows
     - name: install WiX
       run: dotnet tool uninstall --global wix; dotnet tool install --global wix --version 6.0.2 && wix extension add -g WixToolset.UI.wixext/6.0.2
     - name: Make sure WiX works

--- a/windows/installer.wxs
+++ b/windows/installer.wxs
@@ -4,6 +4,7 @@
 		<MediaTemplate EmbedCab="yes"/>
 		<Feature Id="CCX" Title="CCExtractor Setup" Level="1">
 			<ComponentGroupRef Id="CCX_Components_MainFolder"/>
+			<ComponentGroupRef Id="CCX_Components_tessdata"/>
 			<ComponentGroupRef Id="CCX_Components_MainFolder_data"/>
 			<ComponentGroupRef Id="CCX_Components_MainFolder_data_flutter_assets"/>
 			<ComponentGroupRef Id="CCX_Components_MainFolder_data_flutter_assets_assets"/>
@@ -40,6 +41,7 @@
     </StandardDirectory>
 		<StandardDirectory Id="ProgramFiles6432Folder">
 			<Directory Id="INSTALLFOLDER" Name="CCExtractor">
+				<Directory Id="CCX_tessdata" Name="tessdata"/>
 				<Directory Id="CCX_data" Name="data">
 					<Directory Id="CCX_data_flutter_assets" Name="flutter_assets">
 						<Directory Id="CCX_data_flutter_assets_assets" Name="assets"/>
@@ -192,6 +194,15 @@
 			</Component>
 			<Component Id="cmpWmUnmaximize" Guid="{8F012345-6789-0123-8901-345678901234}">
 				<File Id="filWmUnmaximize" KeyPath="yes" Source="./installer/data/flutter_assets/packages/window_manager/images/ic_chrome_unmaximize.png"/>
+			</Component>
+		</ComponentGroup>
+		<!-- Tesseract OCR data files for HardSubx feature -->
+		<ComponentGroup Id="CCX_Components_tessdata" Directory="CCX_tessdata">
+			<Component Id="cmpTessdataEng" Guid="{A1234567-8901-2345-6789-0123456789AB}">
+				<File Id="filEngTraineddata" KeyPath="yes" Source="./installer/tessdata/eng.traineddata"/>
+			</Component>
+			<Component Id="cmpTessdataOsd" Guid="{B2345678-9012-3456-7890-123456789ABC}">
+				<File Id="filOsdTraineddata" KeyPath="yes" Source="./installer/tessdata/osd.traineddata"/>
 			</Component>
 		</ComponentGroup>
 	</Fragment>


### PR DESCRIPTION
## Summary

The Windows release was missing Tesseract OCR runtime dependencies (tessdata files) needed for the HardSubx feature to work. Users had to manually install Tesseract OCR and set `TESSDATA_PREFIX` environment variable.

This PR fixes that by:
- Adding `get_executable_directory()` to `ocr.c` that finds the directory where CCExtractor is installed (works on Windows, Linux, and macOS)
- Updating `probe_tessdata_location()` to search for tessdata in the executable directory, enabling bundled tessdata to be found automatically
- Updating release workflow to download `eng.traineddata` and `osd.traineddata` from `tesseract-ocr/tessdata_fast` during release builds
- Updating WiX installer to include the `tessdata/` directory with the traineddata files

Now the Windows release includes tessdata files, and CCExtractor will automatically find them in the installation directory without requiring users to install Tesseract separately or set environment variables.

## Test plan

- [x] Created test release on fork: https://github.com/cfsmp3/ccextractor/releases/tag/v0.97.0-test-tessdata
- [x] Verified portable ZIP contains `tessdata/eng.traineddata` and `tessdata/osd.traineddata`
- [x] Tested on Windows VM - HardSubx works out of the box without Tesseract installation

Fixes #1578

🤖 Generated with [Claude Code](https://claude.com/claude-code)