### PR TITLE
ci(linux): Add workflow for system-libs builds

### DIFF
--- a/.github/workflows/build_linux_systemlibs.yml
+++ b/.github/workflows/build_linux_systemlibs.yml
@@ -17,6 +17,9 @@ on:
       - '.github/workflows/build_linux_systemlibs.yml'
       - 'linux/build'
 
+permissions:
+  contents: write
+
 jobs:
   build-systemlibs:
     runs-on: ubuntu-22.04

--- a/linux/build
+++ b/linux/build
@@ -143,7 +143,12 @@ if [ "$USE_SYSTEM_LIBS" = true ]; then
     $UTF8PROC_COMPAT $PKG_CFLAGS $LEPTONICA_CFLAGS $TESSERACT_CFLAGS $GPAC_CFLAGS"
 
     BLD_SOURCES="../src/ccextractor.c $SRC_CCX $SRC_HASH"
-    BLD_LINKER="$PKG_LIBS -ltesseract -lleptonica -lgpac -lpthread -ldl -lm"
+    # Preserve FFmpeg libraries if -hardsubx was specified
+    FFMPEG_LIBS=""
+    if [ "$HARDSUBX" = true ]; then
+        FFMPEG_LIBS="-lswscale -lavutil -pthread -lavformat -lavcodec -lavfilter -lxcb-shm -lxcb -lX11 -llzma -lswresample"
+    fi
+    BLD_LINKER="$PKG_LIBS -ltesseract -lleptonica -lgpac -lpthread -ldl -lm $FFMPEG_LIBS"
 fi
 
 


### PR DESCRIPTION
## Summary

- Add a new GitHub Actions workflow that builds CCExtractor using the `-system-libs` flag
- Creates binaries that dynamically link against system libraries instead of bundling dependencies
- Fix for `-system-libs -hardsubx` combination where FFmpeg libs were being lost

## Use Cases

This is useful for:
- Linux distribution packaging (Debian, Ubuntu, Fedora, etc.)
- Homebrew/Linuxbrew packaging  
- Users who prefer smaller binaries with system library updates

## Build Variants

Two variants are built:
- **basic**: Standard OCR-enabled build
- **hardsubx**: Build with HardSubX (burned-in subtitle extraction)

## Workflow Triggers

- Runs automatically on releases
- Can be manually triggered via workflow_dispatch
- Builds on pushes to the workflow file itself (for testing)

## Test plan

- [ ] Verify workflow runs successfully on manual trigger
- [ ] Check that both basic and hardsubx variants build
- [ ] Confirm binaries link against system libraries (ldd output)

Related to #1907

🤖 Generated with [Claude Code](https://claude.com/claude-code)