### PR TITLE
ci: Add winget and Chocolatey packaging workflows

### DIFF
--- a/.github/workflows/publish_chocolatey.yml
+++ b/.github/workflows/publish_chocolatey.yml
@@ -1,0 +1,136 @@
+# Publish to Chocolatey Community Repository
+#
+# PREREQUISITES:
+# 1. Create a Chocolatey account at https://community.chocolatey.org/account/Register
+# 2. Get your API key from https://community.chocolatey.org/account
+# 3. Add the API key as repository secret: CHOCOLATEY_API_KEY
+#
+# Reference: https://docs.chocolatey.org/en-us/create/create-packages-quick-start
+
+name: Publish to Chocolatey
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to publish (e.g., v0.96.1)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Get version from tag
+        id: version
+        shell: bash
+        run: |
+          TAG="${{ github.event.inputs.release_tag || github.event.release.tag_name }}"
+          # Strip 'v' prefix if present
+          VERSION="${TAG#v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Download MSI from release
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.version }}"
+          $tag = "${{ steps.version.outputs.tag }}"
+          $msiUrl = "https://github.com/CCExtractor/ccextractor/releases/download/$tag/CCExtractor.$version.msi"
+
+          Write-Host "Downloading MSI from: $msiUrl"
+          Invoke-WebRequest -Uri $msiUrl -OutFile "CCExtractor.msi"
+
+          # Calculate SHA256 checksum
+          $hash = (Get-FileHash -Path "CCExtractor.msi" -Algorithm SHA256).Hash
+          Write-Host "SHA256: $hash"
+          echo "MSI_CHECKSUM=$hash" >> $env:GITHUB_ENV
+
+      - name: Update nuspec version
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.version }}"
+          $nuspecPath = "packaging/chocolatey/ccextractor.nuspec"
+
+          $content = Get-Content $nuspecPath -Raw
+          $content = $content -replace '<version>.*</version>', "<version>$version</version>"
+          Set-Content -Path $nuspecPath -Value $content
+
+          Write-Host "Updated nuspec to version $version"
+
+      - name: Update install script
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.version }}"
+          $tag = "${{ steps.version.outputs.tag }}"
+          $checksum = $env:MSI_CHECKSUM
+          $installScript = "packaging/chocolatey/tools/chocolateyInstall.ps1"
+
+          $content = Get-Content $installScript -Raw
+
+          # Update URL
+          $newUrl = "https://github.com/CCExtractor/ccextractor/releases/download/$tag/CCExtractor.$version.msi"
+          $content = $content -replace "url64bit\s*=\s*'[^']*'", "url64bit       = '$newUrl'"
+
+          # Update checksum
+          $content = $content -replace "checksum64\s*=\s*'[^']*'", "checksum64     = '$checksum'"
+
+          Set-Content -Path $installScript -Value $content
+
+          Write-Host "Updated install script with URL and checksum"
+
+      - name: Build Chocolatey package
+        shell: pwsh
+        run: |
+          cd packaging/chocolatey
+          choco pack ccextractor.nuspec
+
+          # List the generated package
+          Get-ChildItem *.nupkg
+
+      - name: Test package locally
+        shell: pwsh
+        run: |
+          cd packaging/chocolatey
+          $nupkg = Get-ChildItem *.nupkg | Select-Object -First 1
+          Write-Host "Testing package: $($nupkg.Name)"
+
+          # Install from local package
+          choco install ccextractor --source="'.;https://community.chocolatey.org/api/v2/'" --yes --force
+
+          # Verify installation
+          $ccx = Get-Command ccextractor -ErrorAction SilentlyContinue
+          if ($ccx) {
+            Write-Host "CCExtractor found at: $($ccx.Source)"
+            & ccextractor --version
+          } else {
+            Write-Host "CCExtractor not found in PATH, checking Program Files..."
+            $exePath = Join-Path $env:ProgramFiles "CCExtractor\ccextractor.exe"
+            if (Test-Path $exePath) {
+              & $exePath --version
+            }
+          }
+
+      - name: Push to Chocolatey
+        shell: pwsh
+        env:
+          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+        run: |
+          cd packaging/chocolatey
+          $nupkg = Get-ChildItem *.nupkg | Select-Object -First 1
+
+          Write-Host "Pushing $($nupkg.Name) to Chocolatey..."
+          choco push $nupkg.Name --source="https://push.chocolatey.org/" --api-key="$env:CHOCOLATEY_API_KEY"
+
+          Write-Host "Package submitted to Chocolatey! It may take some time to be moderated and published."
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: chocolatey-package
+          path: packaging/chocolatey/*.nupkg

--- a/.github/workflows/publish_winget.yml
+++ b/.github/workflows/publish_winget.yml
@@ -1,0 +1,38 @@
+# Publish to Windows Package Manager (winget)
+#
+# PREREQUISITES:
+# 1. CCExtractor must already have ONE version in winget-pkgs before this works
+#    - Submit the initial manifest manually from packaging/winget/
+#    - PR to: https://github.com/microsoft/winget-pkgs
+#
+# 2. Create a fork of microsoft/winget-pkgs under the CCExtractor organization
+#    - https://github.com/CCExtractor/winget-pkgs (needs to be created)
+#
+# 3. Create a GitHub Personal Access Token (classic) with 'public_repo' scope
+#    - Add as repository secret: WINGET_TOKEN
+#
+# Reference: https://github.com/vedantmgoyal9/winget-releaser
+
+name: Publish to WinGet
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to publish (e.g., v0.96.1)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - name: Publish to WinGet
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: CCExtractor.CCExtractor
+          installers-regex: '\.msi$'  # Only use the MSI installer
+          token: ${{ secrets.WINGET_TOKEN }}
+          release-tag: ${{ github.event.inputs.release_tag || github.event.release.tag_name }}

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,96 @@
+# CCExtractor Packaging
+
+This directory contains packaging configurations for Windows package managers.
+
+## Windows Package Manager (winget)
+
+### Initial Setup (One-time)
+
+1. **Calculate MSI hash** for the current release:
+   ```powershell
+   certutil -hashfile CCExtractor.0.96.1.msi SHA256
+   ```
+
+2. **Update the manifest files** in `winget/` with the SHA256 hash
+
+3. **Fork microsoft/winget-pkgs** to the CCExtractor organization:
+   - Go to https://github.com/microsoft/winget-pkgs
+   - Fork to https://github.com/CCExtractor/winget-pkgs
+
+4. **Submit initial manifest** via PR:
+   - Clone your fork
+   - Create directory: `manifests/c/CCExtractor/CCExtractor/0.96.1/`
+   - Copy the three YAML files from `winget/`
+   - Submit PR to microsoft/winget-pkgs
+
+5. **Create GitHub token** for automation:
+   - Go to GitHub Settings > Developer settings > Personal access tokens > Tokens (classic)
+   - Create token with `public_repo` scope
+   - Add as secret `WINGET_TOKEN` in CCExtractor/ccextractor repository
+
+### Automated Updates
+
+After the initial submission is merged, the `publish_winget.yml` workflow will automatically submit PRs for new releases.
+
+## Chocolatey
+
+### Initial Setup (One-time)
+
+1. **Create Chocolatey account**:
+   - Register at https://community.chocolatey.org/account/Register
+
+2. **Get API key**:
+   - Go to https://community.chocolatey.org/account
+   - Copy your API key
+
+3. **Add secret**:
+   - Add `CHOCOLATEY_API_KEY` secret to CCExtractor/ccextractor repository
+
+### Package Structure
+
+```
+chocolatey/
+├── ccextractor.nuspec      # Package metadata
+└── tools/
+    ├── chocolateyInstall.ps1    # Installation script
+    └── chocolateyUninstall.ps1  # Uninstallation script
+```
+
+### Manual Testing
+
+```powershell
+cd packaging/chocolatey
+
+# Update version and checksum in files first, then:
+choco pack ccextractor.nuspec
+
+# Test locally
+choco install ccextractor --source="'.'" --yes --force
+
+# Verify
+ccextractor --version
+```
+
+### Automated Updates
+
+The `publish_chocolatey.yml` workflow automatically:
+1. Downloads the MSI from the release
+2. Calculates the SHA256 checksum
+3. Updates the nuspec and install script
+4. Builds and tests the package
+5. Pushes to Chocolatey
+
+Note: Chocolatey packages go through moderation before being publicly available.
+
+## Workflow Triggers
+
+Both workflows trigger on:
+- **Release published**: Automatic publishing when a new release is created
+- **Manual dispatch**: Can be triggered manually with a specific tag
+
+## Secrets Required
+
+| Secret | Purpose |
+|--------|---------|
+| `WINGET_TOKEN` | GitHub PAT with `public_repo` scope for winget PRs |
+| `CHOCOLATEY_API_KEY` | Chocolatey API key for package uploads |

--- a/packaging/chocolatey/ccextractor.nuspec
+++ b/packaging/chocolatey/ccextractor.nuspec
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>ccextractor</id>
+    <version>0.96.2</version>
+    <title>CCExtractor</title>
+    <authors>CCExtractor Development Team</authors>
+    <owners>CCExtractor</owners>
+    <licenseUrl>https://github.com/CCExtractor/ccextractor/blob/master/LICENSE.txt</licenseUrl>
+    <projectUrl>https://ccextractor.org</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/CCExtractor/ccextractor/master/windows/CCX.ico</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>CCExtractor is a tool that analyzes video files and produces independent subtitle files from the closed captions data.
+
+### Features
+- Extracts closed captions from various video formats (MPEG, H.264, MKV, MP4, etc.)
+- Supports multiple input sources including DVDs, DVRs, and live TV captures
+- Outputs to multiple formats (SRT, WebVTT, SAMI, transcript, etc.)
+- OCR support for bitmap-based subtitles (DVB, teletext)
+- Includes a graphical user interface
+
+### Usage
+After installation, run `ccextractor` from the command line or use the GUI.
+
+```
+ccextractor video.ts -o output.srt
+```
+
+For more options: `ccextractor --help`
+    </description>
+    <summary>Extract closed captions and subtitles from video files</summary>
+    <releaseNotes>https://github.com/CCExtractor/ccextractor/releases</releaseNotes>
+    <copyright>Copyright (c) CCExtractor Development</copyright>
+    <tags>subtitles closed-captions video extraction accessibility srt dvb teletext ocr media cli</tags>
+    <projectSourceUrl>https://github.com/CCExtractor/ccextractor</projectSourceUrl>
+    <packageSourceUrl>https://github.com/CCExtractor/ccextractor/tree/master/packaging/chocolatey</packageSourceUrl>
+    <docsUrl>https://github.com/CCExtractor/ccextractor/wiki</docsUrl>
+    <bugTrackerUrl>https://github.com/CCExtractor/ccextractor/issues</bugTrackerUrl>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/packaging/chocolatey/tools/chocolateyInstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyInstall.ps1
@@ -1,0 +1,24 @@
+$ErrorActionPreference = 'Stop'
+
+$packageName = 'ccextractor'
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+# Package parameters
+$packageArgs = @{
+  packageName    = $packageName
+  fileType       = 'MSI'
+  url64bit       = 'https://github.com/CCExtractor/ccextractor/releases/download/v0.96.2/CCExtractor.0.96.2.msi'
+  checksum64     = 'FFCAB0D766180AFC2832277397CDEC885D15270DECE33A9A51947B790F1F095B'
+  checksumType64 = 'sha256'
+  silentArgs     = '/quiet /norestart'
+  validExitCodes = @(0, 3010, 1641)
+}
+
+Install-ChocolateyPackage @packageArgs
+
+# Add to PATH if not already there
+$installPath = Join-Path $env:ProgramFiles 'CCExtractor'
+if (Test-Path $installPath) {
+  Install-ChocolateyPath -PathToInstall $installPath -PathType 'Machine'
+  Write-Host "CCExtractor installed to: $installPath"
+}

--- a/packaging/chocolatey/tools/chocolateyUninstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyUninstall.ps1
@@ -1,0 +1,23 @@
+$ErrorActionPreference = 'Stop'
+
+$packageName = 'ccextractor'
+
+# Get the uninstall registry key
+$regKey = Get-UninstallRegistryKey -SoftwareName 'CCExtractor*'
+
+if ($regKey) {
+  $silentArgs = '/quiet /norestart'
+  $file = $regKey.UninstallString -replace 'msiexec.exe','msiexec.exe ' -replace '/I','/X'
+
+  $packageArgs = @{
+    packageName    = $packageName
+    fileType       = 'MSI'
+    silentArgs     = "$($regKey.PSChildName) $silentArgs"
+    file           = ''
+    validExitCodes = @(0, 3010, 1605, 1614, 1641)
+  }
+
+  Uninstall-ChocolateyPackage @packageArgs
+} else {
+  Write-Warning "CCExtractor was not found in the registry. It may have been uninstalled already."
+}

--- a/packaging/winget/CCExtractor.CCExtractor.installer.yaml
+++ b/packaging/winget/CCExtractor.CCExtractor.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.9.0.schema.json
+PackageIdentifier: CCExtractor.CCExtractor
+PackageVersion: 0.96.2
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.0.0
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /quiet
+  SilentWithProgress: /passive
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerType: msi
+  InstallerUrl: https://github.com/CCExtractor/ccextractor/releases/download/v0.96.2/CCExtractor.0.96.2.msi
+  InstallerSha256: FFCAB0D766180AFC2832277397CDEC885D15270DECE33A9A51947B790F1F095B
+ManifestType: installer
+ManifestVersion: 1.9.0

--- a/packaging/winget/CCExtractor.CCExtractor.locale.en-US.yaml
+++ b/packaging/winget/CCExtractor.CCExtractor.locale.en-US.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.9.0.schema.json
+PackageIdentifier: CCExtractor.CCExtractor
+PackageVersion: 0.96.2
+PackageLocale: en-US
+Publisher: CCExtractor Development
+PublisherUrl: https://ccextractor.org
+PublisherSupportUrl: https://github.com/CCExtractor/ccextractor/issues
+Author: CCExtractor Development Team
+PackageName: CCExtractor
+PackageUrl: https://ccextractor.org
+License: GPL-2.0
+LicenseUrl: https://github.com/CCExtractor/ccextractor/blob/master/LICENSE.txt
+Copyright: Copyright (c) CCExtractor Development
+ShortDescription: A tool to extract subtitles from video files
+Description: |-
+  CCExtractor is a tool that analyzes video files and produces independent subtitle files from the closed captions data.
+
+  Key features:
+  - Extracts closed captions from various video formats (MPEG, H.264, MKV, MP4, etc.)
+  - Supports multiple input sources including DVDs, DVRs, and live TV captures
+  - Outputs to multiple formats (SRT, WebVTT, SAMI, transcript, etc.)
+  - OCR support for bitmap-based subtitles (DVB, teletext)
+  - Cross-platform (Windows, Linux, macOS)
+  - Includes a GUI for easy operation
+Moniker: ccextractor
+Tags:
+- subtitles
+- closed-captions
+- video
+- extraction
+- accessibility
+- srt
+- dvb
+- teletext
+- ocr
+- media
+ReleaseNotesUrl: https://github.com/CCExtractor/ccextractor/releases
+ManifestType: defaultLocale
+ManifestVersion: 1.9.0

--- a/packaging/winget/CCExtractor.CCExtractor.yaml
+++ b/packaging/winget/CCExtractor.CCExtractor.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.9.0.schema.json
+PackageIdentifier: CCExtractor.CCExtractor
+PackageVersion: 0.96.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.9.0


### PR DESCRIPTION
## Summary

Add automated package publishing for Windows package managers, addressing #1308.

## Changes

### Winget
- Initial manifest files for `CCExtractor.CCExtractor` (in `packaging/winget/`)
- `publish_winget.yml` workflow to auto-submit PRs to microsoft/winget-pkgs on release

### Chocolatey  
- Package files: nuspec, install/uninstall scripts (in `packaging/chocolatey/`)
- `publish_chocolatey.yml` workflow to build and push packages on release

### Documentation
- `packaging/README.md` with setup instructions

## Setup Required

| Secret | Purpose |
|--------|---------|
| `WINGET_TOKEN` | GitHub PAT with `public_repo` scope for winget PRs |
| `CHOCOLATEY_API_KEY` | API key from chocolatey.org account |

## Related

- Initial winget submission: https://github.com/microsoft/winget-pkgs/pull/326399
- Closes #1308

## Test plan

- [ ] Merge this PR
- [ ] Trigger `publish_chocolatey.yml` workflow manually for v0.96.2
- [ ] Verify package appears on Chocolatey after moderation

🤖 Generated with [Claude Code](https://claude.com/claude-code)