### PR TITLE
fix(mp4): Fix 200ms timing offset for MOV/MP4 caption extraction

### DIFF
--- a/src/lib_ccx/mp4.c
+++ b/src/lib_ccx/mp4.c
@@ -202,6 +202,13 @@ static int process_xdvb_track(struct lib_ccx_ctx *ctx, const char *basename, GF_
 
 	dec_ctx = update_decoder_list(ctx);
 	enc_ctx = update_encoder_list(ctx);
+
+	// Set buffer data type to CCX_PES for MP4/MOV MPEG-2 tracks.
+	// This ensures cb_field counters are not incremented in do_cb(),
+	// which is correct because container formats associate captions
+	// with the frame's PTS directly.
+	dec_ctx->in_bufferdatatype = CCX_PES;
+
 	if ((sample_count = gf_isom_get_sample_count(f, track)) < 1)
 	{
 		return 0;
@@ -248,6 +255,12 @@ static int process_avc_track(struct lib_ccx_ctx *ctx, const char *basename, GF_I
 	struct lib_cc_decode *dec_ctx = NULL;
 
 	dec_ctx = update_decoder_list(ctx);
+
+	// Set buffer data type to CCX_H264 for MP4/MOV AVC tracks.
+	// This ensures cb_field counters are not incremented in do_cb(),
+	// which is correct because container formats associate captions
+	// with the frame's PTS directly.
+	dec_ctx->in_bufferdatatype = CCX_H264;
 
 	if ((sample_count = gf_isom_get_sample_count(f, track)) < 1)
 	{
@@ -325,6 +338,12 @@ static int process_hevc_track(struct lib_ccx_ctx *ctx, const char *basename, GF_
 
 	// Enable HEVC mode
 	dec_ctx->avc_ctx->is_hevc = 1;
+
+	// Set buffer data type to CCX_H264 for MP4/MOV HEVC tracks.
+	// This ensures cb_field counters are not incremented in do_cb(),
+	// which is correct because container formats associate captions
+	// with the frame's PTS directly.
+	dec_ctx->in_bufferdatatype = CCX_H264;
 
 	if ((sample_count = gf_isom_get_sample_count(f, track)) < 1)
 	{


### PR DESCRIPTION
## Summary

This PR fixes a 200ms timing offset that was affecting caption extraction from MOV/MP4 files, causing sample platform tests 226-230 to fail.

**Before fix:**
- FFmpeg first caption: 13,847ms
- CCExtractor first caption: 14,047ms  
- **Offset: 200ms late**

**After fix:**
- FFmpeg first caption: 13,847ms
- CCExtractor first caption: 13,847ms
- **Offset: 0ms (exact match)**

## Root Cause Analysis

### The Bug

The `in_bufferdatatype` variable was never set in `mp4.c` for MP4/MOV container tracks. It remained at its default value `CCX_UNKNOWN`, which caused incorrect behavior in the caption processing pipeline.

### How `in_bufferdatatype` Affects Timing

In `src/lib_ccx/ccx_decoders_common.c`, the `do_cb()` function has a check (lines 150-154):

```c
// For container formats (H.264, MPEG-2 PES), don't increment cb_field
// because the frame PTS already represents the correct timestamp.
// The cb_field offset is only meaningful for raw/elementary streams.
if (ctx->in_bufferdatatype != CCX_H264 && ctx->in_bufferdatatype != CCX_PES)
    cb_field1++;
```

This check is designed to skip `cb_field` counter increments for container formats. However, with `in_bufferdatatype == CCX_UNKNOWN`, this condition evaluated to `true`, causing `cb_field1` to be incremented for every CEA-608 caption block.

### The Timing Math

When `get_fts()` is called to timestamp captions, it calculates:

```c
fts_now + fts_global + cb_field1 * 1001 / 30
```

The `cb_field1 * 1001/30` term adds ~33.37ms per caption block. With a typical roll-up caption having ~6 blocks per frame:

```
6 blocks × 33.37ms/block ≈ 200ms offset
```

This explains the consistent 200ms timing offset observed in MOV/MP4 files.

### Why Container Formats Don't Need cb_field

For container formats (MP4, MOV, MKV, TS with PES), all caption data for a video frame is bundled together and associated with the frame's PTS. The caption blocks within a frame don't have sub-frame timing - they all belong to the same presentation timestamp.

In contrast, raw/elementary streams may have caption data arriving at field rate (59.94 Hz for NTSC), where each CEA-608 byte pair has its own timing. The `cb_field` offset accounts for this sub-frame timing.

## The Fix

Set `in_bufferdatatype` correctly in the three MP4 track processing functions:

| Function | Track Type | Setting |
|----------|------------|---------|
| `process_avc_track()` | H.264/AVC | `CCX_H264` |
| `process_hevc_track()` | H.265/HEVC | `CCX_H264` |
| `process_xdvb_track()` | MPEG-2 | `CCX_PES` |

## Verification

### Test Sample
`/home/cfsmp3/media_samples/completed/1974a299f0502fc8199dabcaadb20e422e79df45972e554d58d1d025ef7d0686.mov`

### Before Fix (ttxt output)
```
00:00:14,047|00:00:14,547|RU2|>> WHICH OF THESE STORIES WILL
00:00:14,547|00:00:15,948|RU2|YOU BE TALKING ABOUT TOMORROW?
```

### After Fix (ttxt output)
```
00:00:13,847|00:00:14,547|RU2|>> WHICH OF THESE STORIES WILL
00:00:14,547|00:00:15,248|RU2|YOU BE TALKING ABOUT TOMORROW?
```

### FFmpeg Reference
```
1
00:00:13,847 --> 00:00:14,548
>> WHICH OF THESE STORIES WILL
```

The fix aligns CCExtractor's output exactly with FFmpeg's authoritative timing.

### Regression Check
Verified that TS files still work correctly with the same timing (no regressions introduced).

## Test Plan

- [x] Verify MOV file timing matches FFmpeg (13,847ms)
- [x] Verify TS files still work correctly (no regressions)
- [ ] Run sample platform regression tests for tests 226-230
- [ ] Verify HEVC MP4 files (if samples available)

## Files Changed

- `src/lib_ccx/mp4.c` - Set `in_bufferdatatype` in 3 track processing functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)