### PR TITLE
feat(scc): Add configurable frame rate and styled PAC codes for SCC output

### DIFF
--- a/src/lib_ccx/ccx_common_option.c
+++ b/src/lib_ccx/ccx_common_option.c
@@ -140,6 +140,7 @@ void init_options(struct ccx_s_options *options)
 	options->enc_cfg.all_services_charset = NULL;
 	options->enc_cfg.with_semaphore = 0;
 	options->enc_cfg.force_dropframe = 0; // Assume No Drop Frame for MCC Encode.
+	options->enc_cfg.scc_framerate = 0;   // Default: 29.97fps for SCC output
 	options->enc_cfg.extract_only_708 = 0;
 
 	options->settings_dtvcc.enabled = 0;

--- a/src/lib_ccx/ccx_common_option.h
+++ b/src/lib_ccx/ccx_common_option.h
@@ -75,6 +75,9 @@ struct encoder_cfg
 	// MCC File
 	int force_dropframe; // 1 if dropframe frame count should be used. defaults to no drop frame.
 
+	// SCC output framerate
+	int scc_framerate; // SCC output framerate: 0=29.97 (default), 1=24, 2=25, 3=30
+
 	// text -> png (text render)
 	char *render_font; // The font used to render text if needed (e.g. teletext->spupng)
 	char *render_font_italics;

--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -840,6 +840,7 @@ struct encoder_ctx *init_encoder(struct encoder_cfg *opt)
 	ctx->segment_pending = 0;
 	ctx->segment_last_key_frame = 0;
 	ctx->nospupngocr = opt->nospupngocr;
+	ctx->scc_framerate = opt->scc_framerate;
 
 	// Initialize teletext multi-page output arrays (issue #665)
 	ctx->tlt_out_count = 0;

--- a/src/lib_ccx/ccx_encoders_common.h
+++ b/src/lib_ccx/ccx_encoders_common.h
@@ -153,6 +153,9 @@ struct encoder_ctx
 	unsigned int cdp_hdr_seq;
 	int force_dropframe;
 
+	// SCC output framerate
+	int scc_framerate; // SCC output framerate: 0=29.97 (default), 1=24, 2=25, 3=30
+
 	int new_sentence; // Capitalize next letter?
 
 	int program_number;

--- a/src/rust/src/common.rs
+++ b/src/rust/src/common.rs
@@ -276,6 +276,8 @@ pub unsafe fn copy_from_rust(ccx_s_options: *mut ccx_s_options, options: Options
     (*ccx_s_options).out_interval = options.out_interval;
     (*ccx_s_options).segment_on_key_frames_only = options.segment_on_key_frames_only as _;
     (*ccx_s_options).scc_framerate = options.scc_framerate;
+    // Also copy to enc_cfg so the encoder uses the same frame rate for SCC output
+    (*ccx_s_options).enc_cfg.scc_framerate = options.scc_framerate;
     #[cfg(feature = "with_libcurl")]
     {
         if options.curlposturl.is_some() {
@@ -975,6 +977,7 @@ impl CType<encoder_cfg> for EncoderConfig {
                 null_pointer()
             },
             extract_only_708: self.extract_only_708 as _,
+            scc_framerate: 0, // Will be set from ccx_options.scc_framerate in copy_to_c
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR addresses the remaining items from issue #1191 (SCC/CCD format improvements):

- **SCC Output Frame Rate**: The `--scc-framerate` option now affects both input parsing AND output encoding (was hardcoded to 29.97fps)
- **Styled PAC Optimization**: When captions start at column 0 with non-default color/font, uses a single styled PAC instead of indent PAC + mid-row code

## Changes

### 1. SCC Output Frame Rate
- Added `scc_framerate` to `encoder_cfg` and `encoder_ctx` structs
- Added `get_scc_fps()` helper function in SCC encoder
- Updated `add_timestamp()` to use configurable frame rate
- Supports 24, 25, 29.97 (default), and 30 fps

### 2. Styled PAC (Preamble Address Code) Optimization
- Added `get_styled_pac_byte2()` - computes byte2 for styled PACs (0x40-0x4F range)
- Added `row_uses_high_range()` - determines which PAC byte range to use
- Added `write_styled_preamble()` - writes styled PAC directly
- Added `can_use_styled_pac()` - checks if optimization applies
- Updated `write_cc_buffer_as_scenarist()` to use styled PAC when appropriate

This resolves the TODO comment at line 487: "Preamble code need to take into account font as well"

## Test plan

- [x] Build succeeds
- [x] SCC output with different frame rates produces correct frame numbers
- [x] Rust SCC demuxer tests pass (12/12)
- [ ] CI regression tests

## Issue Reference

Fixes #1191

🤖 Generated with [Claude Code](https://claude.com/claude-code)