### PR TITLE
IMPROVEMENT: 1. simplified verify_parity function. 2.Improved documentat…

### DIFF
--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -273,7 +273,6 @@ extern "C" fn ccxr_process_cc_data(
 ///      If this fails, the entire pair is deemed corrupt, and the function returns false.
 ///    - Sanitization: Validates parity for the first data byte (cc_block[1]).
 ///      If this fails (but byte 2 was valid), cc_block[1] is overwritten with CC_SOLID_BLANK (0x7F).
-
 const CC_SOLID_BLANK: u8 = 0x7F;
 
 pub fn validate_cc_pair(cc_block: &mut [u8]) -> bool {


### PR DESCRIPTION
…ion for public function validate_cc_pair. 3. Added constant for 0x7F.

**[IMPROVEMENT]**

**In raising this pull request, I confirm the following**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows:**
- [x] I have never used CCExtractor.

---
##Changes Made

1. Replaced magic number 0x7F with named constant `CC_BLANK_SPACE`.
2. Added comprehensive documentation to function `validate_cc_pair`.
3. Simplified verify_parity function.

##Tests
✅ All existing tests passed.
