### PR TITLE
[FIX]: utf8proc include path for system library builds

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 0.96.2 (2025-12-26)
 -------------------
+- Fix: Resolve utf8proc header include path when building against system libraries on Linux.
 - Rebundle Windows version to include required runtime files to process hardcoded subtitles
   (hardcodex mode).
 - New: Add optional -system-libs flag to Linux build script for package manager compatibility

--- a/linux/build
+++ b/linux/build
@@ -65,13 +65,6 @@ if [ "$USE_SYSTEM_LIBS" = true ]; then
     
     PKG_CFLAGS="$(pkg-config --cflags libpng zlib freetype2 libutf8proc)"
     PKG_LIBS="$(pkg-config --libs libpng zlib freetype2 libutf8proc)"
-    
-    UTF8PROC_COMPAT=""
-    if [ ! -d /usr/include/utf8proc ] && [ -f /usr/include/utf8proc.h ]; then
-        mkdir -p ./utf8proc_compat/utf8proc
-        ln -sf /usr/include/utf8proc.h ./utf8proc_compat/utf8proc/utf8proc.h
-        UTF8PROC_COMPAT="-I./utf8proc_compat"
-    fi
 fi
 
 BLD_FLAGS="$BLD_FLAGS -std=gnu99 -Wno-write-strings -Wno-pointer-sign -D_FILE_OFFSET_BITS=64 -DVERSION_FILE_PRESENT -DENABLE_OCR -DGPAC_DISABLE_VTT -DGPAC_DISABLE_OD_DUMP -DGPAC_DISABLE_REMOTERY -DNO_GZIP"
@@ -140,7 +133,7 @@ if [ "$USE_SYSTEM_LIBS" = true ]; then
     GPAC_CFLAGS="$(pkg-config --cflags --silence-errors gpac)"
 
     BLD_INCLUDE="-I../src -I../src/lib_ccx -I../src/lib_ccx/zvbi -I../src/thirdparty/lib_hash \
-    $UTF8PROC_COMPAT $PKG_CFLAGS $LEPTONICA_CFLAGS $TESSERACT_CFLAGS $GPAC_CFLAGS"
+    $PKG_CFLAGS $LEPTONICA_CFLAGS $TESSERACT_CFLAGS $GPAC_CFLAGS"
 
     BLD_SOURCES="../src/ccextractor.c $SRC_CCX $SRC_HASH"
     # Preserve FFmpeg libraries if -hardsubx was specified

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -13,8 +13,11 @@
 #include "../lib_hash/sha2.h"
 #include <string.h>
 #include <stdio.h>
+#if __has_include(<utf8proc.h>)
+#include <utf8proc.h>
+#else
 #include <utf8proc/utf8proc.h>
-
+#endif
 #ifdef ENABLE_OCR
 #include <tesseract/capi.h>
 #include <leptonica/allheaders.h>


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [X] I give this submission freely, and claim no ownership to its content.
- [X] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [X] I am an active contributor to CCExtractor.

---
## Problem

CCExtractor uses a non-standard include path for `utf8proc` in `src/lib_ccx/params.c`:

- `#include <utf8proc/utf8proc.h>`


However, utf8proc is installed as `<utf8proc.h>` (without a subdirectory) on all major platforms:
- **Debian/Ubuntu**: `/usr/include/utf8proc.h`
- **Fedora/RHEL**: `/usr/include/utf8proc.h`
- **Homebrew**: `$(brew --prefix)/include/utf8proc.h`
- **Nix**: `$out/include/utf8proc.h`
- **vcpkg**: `installed/<triplet>/include/utf8proc.h`

This caused build failures when using the `-system-libs` flag on Homebrew Linux.

## Solution

This PR uses `__has_include()` to support both paths:
- **System builds**: Uses `<utf8proc.h>` (standard location)
- **Vendored builds**: Uses `<utf8proc/utf8proc.h>` (CCExtractor's vendored copy)

Also removes the temporary symlink workaround from `linux/build` as it's no longer needed.

## Testing

- Builds with `-system-libs` and without on Linux
- Docker builds work (vendored)
- macOS builds pass
- windows build pass

