### PR TITLE
fix(mp4): Use fixed-width integer types in bswap functions

### DIFF
--- a/src/lib_ccx/mp4.c
+++ b/src/lib_ccx/mp4.c
@@ -31,15 +31,17 @@
 #define GF_ISOM_SUBTYPE_MPEG4 GF_4CC('M', 'P', 'E', 'G')
 #endif
 
-static short bswap16(short v)
+static int16_t bswap16(int16_t v)
 {
 	return ((v >> 8) & 0x00FF) | ((v << 8) & 0xFF00);
 }
 
-static long bswap32(long v)
+static int32_t bswap32(int32_t v)
 {
 	// For 0x12345678 returns 78563412
-	long swapped = ((v & 0xFF) << 24) | ((v & 0xFF00) << 8) | ((v & 0xFF0000) >> 8) | ((v & 0xFF000000) >> 24);
+	// Use int32_t instead of long for consistent behavior across platforms
+	// (long is 4 bytes on Windows x64 but 8 bytes on Linux x64)
+	int32_t swapped = ((v & 0xFF) << 24) | ((v & 0xFF00) << 8) | ((v & 0xFF0000) >> 8) | ((v & 0xFF000000) >> 24);
 	return swapped;
 }
 static struct
@@ -82,10 +84,10 @@ static int process_avc_sample(struct lib_ccx_ctx *ctx, u32 timescale, GF_AVCConf
 				nal_length = s->data[i];
 				break;
 			case 2:
-				nal_length = bswap16(*(short *)&s->data[i]);
+				nal_length = bswap16(*(int16_t *)&s->data[i]);
 				break;
 			case 4:
-				nal_length = bswap32(*(long *)&s->data[i]);
+				nal_length = bswap32(*(int32_t *)&s->data[i]);
 				break;
 		}
 		const u32 previous_index = i;
@@ -151,10 +153,10 @@ static int process_hevc_sample(struct lib_ccx_ctx *ctx, u32 timescale, GF_HEVCCo
 				nal_length = s->data[i];
 				break;
 			case 2:
-				nal_length = bswap16(*(short *)&s->data[i]);
+				nal_length = bswap16(*(int16_t *)&s->data[i]);
 				break;
 			case 4:
-				nal_length = bswap32(*(long *)&s->data[i]);
+				nal_length = bswap32(*(int32_t *)&s->data[i]);
 				break;
 			default:
 				mprint("Unexpected nal_unit_size %u in HEVC config\n", c->nal_unit_size);


### PR DESCRIPTION
## Summary

- Changes `bswap16` and `bswap32` to use `int16_t` and `int32_t` instead of `short` and `long`
- Ensures consistent NAL unit length parsing across Windows and Linux platforms

## Problem

On Windows x64, `long` is 4 bytes (LLP64 model), while on Linux x64 `long` is 8 bytes (LP64 model). This type size difference in the `bswap32` function could cause inconsistent behavior when parsing NAL unit lengths in MP4/MOV files.

When reading NAL lengths with `*(long *)&s->data[i]`:
- **Linux x64**: Reads 8 bytes from memory
- **Windows x64**: Reads 4 bytes from memory

This could potentially affect timestamp calculations and cause the timing differences observed between Windows and Linux CI tests.

## Changes

| Function | Before | After |
|----------|--------|-------|
| `bswap16` | `short` | `int16_t` |
| `bswap32` | `long` | `int32_t` |

All call sites in `process_avc_sample()` and `process_hevc_sample()` updated accordingly.

## Test plan

- [x] Builds successfully on Linux
- [ ] Verify Windows CI tests pass (particularly timing-related tests)
- [ ] Check if tests 37, 136, 226-230 show improved results

🤖 Generated with [Claude Code](https://claude.com/claude-code)