### PR TITLE
Clean up VCL HRD TODO comment in avc_functions.c

### DIFF
--- a/src/lib_ccx/avc_functions.c
+++ b/src/lib_ccx/avc_functions.c
@@ -908,7 +908,6 @@ void seq_parameter_set_rbsp(struct avc_ctx *ctx, unsigned char *seqbuf, unsigned
 			// Just skip and continue - this doesn't affect our ability to extract captions.
 			mprint("Skipping VCL HRD parameters (not needed for caption extraction)\n");
 			ctx->num_vcl_hrd++;
-
 		}
 		if (tmp || tmp1)
 		{


### PR DESCRIPTION
**[IMPROVEMENT]** Clean up VCL HRD TODO comment in avc_functions.c

Addresses #1894

### Summary
Replace unclear TODO with explanation of why VCL HRD parameters are skipped. VCL HRD is for video buffering compliance and not needed for caption extraction.

### Changes:
- Replace TODO comment with clear explanation
- Update mprint message to be more informative
- Remove commented-out exit(1)

### Context:
This code handles VCL (Video Coding Layer) HRD parameters in H.264/AVC streams. These parameters are for video decoder buffering compliance and are not needed for CCExtractor's purpose of extracting closed captions from SEI NAL units.

The existing code correctly skips these parameters - this PR just improves the code documentation to make that clear.

### Testing:
- ✅ Code changes reviewed (comments and log message only)
- ✅ No functional/logic changes
- ⚠️ Local build not tested (requires Visual Studio C++ Build Tools on Windows)
- CI will verify compilation

Thanks to @cfsmp3 for the detailed guidance on this cleanup!

---

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**Note:** CHANGES.TXT not updated as this is a minor documentation-only change with no functional impact.

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [x] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.