### PR TITLE
docs: Add Windows package manager installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ The core functionality is written in C. Other languages used include C++ and Pyt
 
 Downloads for precompiled binaries and source code can be found [on our website](https://ccextractor.org/public/general/downloads/).
 
+### Windows Package Managers
+
+**WinGet:**
+```powershell
+winget install CCExtractor.CCExtractor
+```
+
+**Chocolatey:**
+```powershell
+choco install ccextractor
+```
+
+**Scoop:**
+```powershell
+scoop bucket add extras
+scoop install ccextractor
+```
+
 Extracting subtitles is relatively simple. Just run the following command:
 
 `ccextractor <input>`


### PR DESCRIPTION
Add instructions for installing CCExtractor via Windows package managers:

- **WinGet**: `winget install CCExtractor.CCExtractor`
- **Chocolatey**: `choco install ccextractor`
- **Scoop**: `scoop bucket add extras && scoop install ccextractor`

This supersedes https://github.com/Harshini-ctrl/ccextractor/pull/1 which had a typo (`ccextractors` instead of `ccextractor`) and incorrect placement.