### PR TITLE
fix(args): Add --svc alias for --service for backwards compatibility

### DIFF
--- a/src/rust/src/args.rs
+++ b/src/rust/src/args.rs
@@ -227,7 +227,7 @@ pub struct Args {
     /// "all[EUC-KR]") and it will encode specified charset to
     /// UTF-8 using iconv. See iconv documentation to check if
     /// required encoding/charset is supported.
-    #[arg(long="service", value_name="services", verbatim_doc_comment, help_heading=OPTION_AFFECT_PROCESSED)]
+    #[arg(long="service", alias="svc", value_name="services", verbatim_doc_comment, help_heading=OPTION_AFFECT_PROCESSED)]
     pub cea708services: Option<String>,
     /// With the exception of McPoodle's raw format, which is just the closed
     /// caption data with no other info, CCExtractor can usually detect the


### PR DESCRIPTION
## Summary
- Adds `--svc` as an alias for `--service` to maintain backwards compatibility

The help text references `-svc` for CEA-708 service selection, but the Rust argument parser only accepted `--service`. This adds `--svc` as an alias so existing documentation and user scripts continue to work.

Fixes #1917

## Test plan
- [x] Verify `--service 1` still works
- [x] Verify `--svc 1` now works
- [x] Verify `-svc 1` now works
- [x] Functional test with CEA-708 sample produces correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)