### PR TITLE
fix(args): Add --sc alias for --sentencecap for backwards compatibility

### DIFF
--- a/src/rust/src/args.rs
+++ b/src/rust/src/args.rs
@@ -486,7 +486,7 @@ pub struct Args {
     pub defaultcolor: Option<String>,
     /// Sentence capitalization. Use if you hate
     /// ALL CAPS in subtitles.
-    #[arg(long, verbatim_doc_comment, help_heading=OUTPUT_AFFECTING_OUTPUT_FILES)]
+    #[arg(long, alias="sc", verbatim_doc_comment, help_heading=OUTPUT_AFFECTING_OUTPUT_FILES)]
     pub sentencecap: bool,
     /// Add the contents of 'file' to the list of words
     /// that must be capitalized. For example, if file


### PR DESCRIPTION
## Summary

Add `--sc` (and `-sc`) as an alias for `--sentencecap` for backwards compatibility.

The `-sc` flag was used in older versions (0.94 and earlier) for sentence capitalization. After the migration to the Rust argument parser, only `--sentencecap` was accepted.

This is the same pattern used for `--svc` → `--service` in commit 64ce4ac8.

## Changes

```rust
// Before
#[arg(long, verbatim_doc_comment, help_heading=OUTPUT_AFFECTING_OUTPUT_FILES)]
pub sentencecap: bool,

// After
#[arg(long, alias="sc", verbatim_doc_comment, help_heading=OUTPUT_AFFECTING_OUTPUT_FILES)]
pub sentencecap: bool,
```

## Test plan

```bash
$ ./ccextractor --sc
Error: No input file specified  # ✓ Accepts the flag

$ ./ccextractor -sc  
Error: No input file specified  # ✓ Also works with single dash
```

Related to #1917

🤖 Generated with [Claude Code](https://claude.com/claude-code)