### PR TITLE
ci(windows): Optimize Windows build workflow for faster CI

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -35,17 +35,8 @@ jobs:
         with:
           msbuild-architecture: x64
 
-      # Cache Chocolatey packages
-      - name: Cache Chocolatey packages
-        id: choco-cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            C:\ProgramData\chocolatey\lib\gpac
-          key: choco-gpac-2.4.0
-
+      # Install GPAC (fast, ~30s, not worth caching complexity)
       - name: Install gpac
-        if: steps.choco-cache.outputs.cache-hit != 'true'
         run: choco install gpac --version 2.4.0 --no-progress
 
       # Use lukka/run-vcpkg for better caching


### PR DESCRIPTION
## Summary

Major optimizations to reduce Windows build time from **~45 minutes to ~8 minutes** (with warm cache):

### Changes

1. **Single consolidated job** - Previously two parallel jobs (Release/Debug) duplicated the entire 34-minute vcpkg install. Now builds both configurations sequentially in one job, sharing all cached dependencies.

2. **lukka/run-vcpkg action** - Replaces manual git clone + bootstrap with the official vcpkg action that has built-in caching and better handling.

3. **Cache vcpkg installed packages** - Separately cache the `installed/` directory (239 MB) with hash-based keys. On cache hit, the 35-minute vcpkg install is **completely skipped**.

4. **Cargo caching** - Add caching for Rust registry and build artifacts (277 MB), similar to the Linux build workflow.

5. **Updated Rust toolchain action** - Replace deprecated `actions-rs/toolchain` with `dtolnay/rust-toolchain`.

### Measured Results

| Scenario | Before | After | Improvement |
|----------|--------|-------|-------------|
| Cold cache (first run) | ~45 min | ~46 min | Same (expected) |
| **Warm cache (subsequent runs)** | ~45 min | **~8 min** | **~83% faster** |

### Timing Breakdown (warm cache run)

| Step | Duration |
|------|----------|
| Install gpac | 36s |
| Setup vcpkg | 15s |
| Cache restore | ~30s |
| **vcpkg install** | **SKIPPED** (cache hit) |
| Build Release-Full | 2m 43s |
| Build Debug-Full | 2m 56s |
| **Total** | **7m 50s** |

### Cache Storage (GitHub Actions)

- `vcpkg-installed-*`: 239.4 MB
- `Windows-cargo-registry-*`: 276.7 MB

## Test plan

- [x] Verify Windows Release build succeeds
- [x] Verify Windows Debug build succeeds  
- [x] Verify artifacts are uploaded correctly
- [x] Verify cache hits on subsequent runs
- [x] Measured ~83% time reduction with warm cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)