### PR TITLE
fix(ci): Fix Windows CI cargo build cache path

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -74,10 +74,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-registry-
 
+      # Cache Cargo build artifacts - rust.bat sets CARGO_TARGET_DIR to windows/
+      # which results in artifacts at windows/x86_64-pc-windows-msvc/
       - name: Cache Cargo build artifacts
         uses: actions/cache@v5
         with:
-          path: ${{ github.workspace }}/windows/target
+          path: ${{ github.workspace }}/windows/x86_64-pc-windows-msvc
           key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('src/rust/**/*.rs') }}
           restore-keys: |
             ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}-
@@ -94,7 +96,6 @@ jobs:
         env:
           LIBCLANG_PATH: "C:\\Program Files\\LLVM\\lib"
           LLVM_CONFIG_PATH: "C:\\Program Files\\LLVM\\bin\\llvm-config"
-          CARGO_TARGET_DIR: "..\\..\\windows"
           BINDGEN_EXTRA_CLANG_ARGS: -fmsc-version=0
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
         run: msbuild ccextractor.sln /p:Configuration=Release-Full /p:Platform=x64
@@ -117,7 +118,6 @@ jobs:
         env:
           LIBCLANG_PATH: "C:\\Program Files\\LLVM\\lib"
           LLVM_CONFIG_PATH: "C:\\Program Files\\LLVM\\bin\\llvm-config"
-          CARGO_TARGET_DIR: "..\\..\\windows"
           BINDGEN_EXTRA_CLANG_ARGS: -fmsc-version=0
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
         run: msbuild ccextractor.sln /p:Configuration=Debug-Full /p:Platform=x64


### PR DESCRIPTION
## Summary

This PR fixes the Windows CI cargo build cache which was pointing to the wrong path.

### Changes:

1. **Fix cargo build cache path**: `rust.bat` sets `CARGO_TARGET_DIR` to the `windows/` directory, which results in artifacts being stored at `windows/x86_64-pc-windows-msvc/`, not `windows/target/`. The cache was pointing to the wrong path and never getting hits.

2. **Remove redundant CARGO_TARGET_DIR**: The workflow was setting `CARGO_TARGET_DIR: "..\\..\\windows"` in the build steps, but `rust.bat` overrides this anyway. Removed the redundant environment variable.

### Results:

- vcpkg cache: Working (Install vcpkg dependencies skipped on cache hit)
- Cargo build cache: Now points to correct path for future cache hits
- Build time: ~8 minutes with cache hits vs 38+ minutes without

## Test plan

- [x] Verify Windows CI build passes
- [x] Verify vcpkg cache is restored (check "Install vcpkg dependencies" is skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)