### PR TITLE
fix(avc): Remove unnecessary TODO for idr_pic_id

### DIFF
--- a/src/lib_ccx/avc_functions.c
+++ b/src/lib_ccx/avc_functions.c
@@ -992,9 +992,9 @@ void slice_header(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, un
 
 	if (nal_unit_type == 5)
 	{
+		// idr_pic_id: Read to advance bitstream position; value not needed for caption extraction
 		tmp = read_exp_golomb_unsigned(&q1);
 		dvprint("idr_pic_id=            % 4lld (%#llX)\n", tmp, tmp);
-		// TODO
 	}
 	if (dec_ctx->avc_ctx->pic_order_cnt_type == 0)
 	{


### PR DESCRIPTION
## Summary

Removes the TODO comment at `src/lib_ccx/avc_functions.c:997` and adds a clarifying comment explaining why `idr_pic_id` is read but not stored.

### Why idr_pic_id doesn't need to be stored:

1. **Bitstream parsing requirement**: The value must be read to advance the bitstream position - subsequent fields like `pic_order_cnt_lsb` come after it in the slice header

2. **Not needed for caption extraction**: CCExtractor uses `pic_order_cnt_lsb` for frame ordering (when `--usepicorder` is set) and PTS for timing synchronization - neither requires `idr_pic_id`

3. **Purpose in H.264**: `idr_pic_id` distinguishes between consecutive IDR pictures for decoder error recovery - not relevant for extracting embedded captions from SEI NAL units

Closes #1895

🤖 Generated with [Claude Code](https://claude.com/claude-code)