### PR TITLE
Prevent integer overflow in EIA-608 screen buffer reallocation

### DIFF
--- a/src/lib_ccx/ccx_decoders_608.c
+++ b/src/lib_ccx/ccx_decoders_608.c
@@ -316,10 +316,20 @@ int write_cc_buffer(ccx_decoder_608_context *context, struct cc_subtitle *sub)
 
 	if (!data->empty && context->output_format != CCX_OF_NULL)
 	{
-		struct eia608_screen *new_data = (struct eia608_screen *)realloc(sub->data, (sub->nb_data + 1) * sizeof(*data));
+		size_t new_size;
+
+		if (sub->nb_data + 1 > SIZE_MAX / sizeof(struct eia608_screen))
+		{
+			ccx_common_logging.log_ftn("Too many screens, cannot allocate more memory.\n");
+			return 0;
+		}
+
+		new_size = (sub->nb_data + 1) * sizeof(struct eia608_screen);
+
+		struct eia608_screen *new_data = (struct eia608_screen *)realloc(sub->data, new_size);
 		if (!new_data)
 		{
-			ccx_common_logging.log_ftn("No Memory left");
+			ccx_common_logging.log_ftn("Out of memory while reallocating screen buffer\n");
 			return 0;
 		}
 		sub->data = new_data;
@@ -386,10 +396,20 @@ int write_cc_line(ccx_decoder_608_context *context, struct cc_subtitle *sub)
 
 	if (!data->empty)
 	{
-		struct eia608_screen *new_data = (struct eia608_screen *)realloc(sub->data, (sub->nb_data + 1) * sizeof(*data));
+		size_t new_size;
+
+		if (sub->nb_data + 1 > SIZE_MAX / sizeof(struct eia608_screen))
+		{
+			ccx_common_logging.log_ftn("Too many screens, cannot allocate more memory.\n");
+			return 0;
+		}
+
+		new_size = (sub->nb_data + 1) * sizeof(struct eia608_screen);
+
+		struct eia608_screen *new_data = (struct eia608_screen *)realloc(sub->data, new_size);
 		if (!new_data)
 		{
-			ccx_common_logging.log_ftn("No Memory left");
+			ccx_common_logging.log_ftn("Out of memory while reallocating screen buffer\n");
 			return 0;
 		}
 		sub->data = new_data;


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).

**My familiarity with the project is as follows (check one):**

- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

[FIX] Prevent integer overflow in EIA-608 screen buffer allocation

### Description

This PR fixes a potential integer overflow in the EIA-608 decoder, which could lead to a heap buffer overflow when processing malformed subtitle input.

**Component:** EIA-608 decoder  
**File:** `src/lib_ccx/ccx_decoders_608.c`  
**Functions:** `write_cc_buffer`, `write_cc_line`  

### Problem

The screen buffer was being reallocated using:

```c
(sub->nb_data + 1) * sizeof(struct eia608_screen)
```
without checking for integer overflow. If sub->nb_data is extremely large (due to a malformed or crafted subtitle), this multiplication could wrap around, causing a tiny buffer allocation and heap overflow on subsequent writes.

### Fix

- Added an overflow guard before allocation:
```c
if (sub->nb_data + 1 > SIZE_MAX / sizeof(struct eia608_screen))
```
- Calculated allocation size explicitly using size_t new_size
- Ensured safe handling of realloc() failure (log error and return safely)

### Impact
- Prevents heap memory corruption
- Prevents program crashes
- Keeps normal behavior unchanged

Fixes #1948