### PR TITLE
Fix out-of-bounds read in H.264 SEI parsing

### DIFF
--- a/src/lib_ccx/avc_functions.c
+++ b/src/lib_ccx/avc_functions.c
@@ -369,6 +369,8 @@ void sei_rbsp(struct avc_ctx *ctx, unsigned char *seibuf, unsigned char *seiend)
 	while (tbuf < seiend - 1) // Use -1 because of trailing marker
 	{
 		tbuf = sei_message(ctx, tbuf, seiend - 1);
+		if (!tbuf)
+			break;
 	}
 	if (tbuf == seiend - 1)
 	{
@@ -392,20 +394,24 @@ void sei_rbsp(struct avc_ctx *ctx, unsigned char *seibuf, unsigned char *seiend)
 unsigned char *sei_message(struct avc_ctx *ctx, unsigned char *seibuf, unsigned char *seiend)
 {
 	int payload_type = 0;
-	while (*seibuf == 0xff)
+	while (seibuf < seiend && *seibuf == 0xff)
 	{
 		payload_type += 255;
 		seibuf++;
 	}
+	if (seibuf >= seiend)
+		return NULL;
 	payload_type += *seibuf;
 	seibuf++;
 
 	int payload_size = 0;
-	while (*seibuf == 0xff)
+	while (seibuf < seiend && *seibuf == 0xff)
 	{
 		payload_size += 255;
 		seibuf++;
 	}
+	if (seibuf >= seiend)
+		return NULL;
 	payload_size += *seibuf;
 	seibuf++;
 


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

### Description

Fixes #1959.

This PR fixes an out-of-bounds read in the H.264 SEI (Supplemental Enhancement Information) parser when handling FF-extended `payload_type` and `payload_size` fields.

Malformed or truncated SEI NAL units containing a sequence of `0xFF` bytes without a terminating byte could cause `sei_message()` to read past the end of the SEI buffer, leading to undefined behavior or a crash.

### Changes made

- Added bounds checks (`seibuf < seiend`) while parsing FF-extended SEI fields.
- Safely abort SEI parsing when encountering truncated SEI payloads.
- Propagate parsing failure to the caller to avoid invalid pointer reuse.

### Impact

- Prevents out-of-bounds reads on malformed H.264 streams.
- Improves robustness of AVC caption extraction.
- No behavior change for valid inputs.

### Notes

This change does not modify output for valid SEI data and has no performance impact.
