### PR TITLE
fix: Make --quiet flag work again

### DIFF
--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -435,6 +435,9 @@ int main(int argc, char *argv[])
 
 	int compile_ret = ccxr_parse_parameters(argc, argv);
 
+	// Update the Rust logger target after parsing so --quiet is respected
+	ccxr_update_logger_target();
+
 	if (compile_ret == EXIT_NO_INPUT_FILES)
 	{
 		print_usage();

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -160,6 +160,7 @@ struct lib_ccx_ctx *init_libraries(struct ccx_s_options *opt);
 void dinit_libraries(struct lib_ccx_ctx **ctx);
 
 extern void ccxr_init_basic_logger();
+extern void ccxr_update_logger_target();
 
 // ccextractor.c
 void print_end_msg(void);

--- a/src/rust/lib_ccxr/src/util/log.rs
+++ b/src/rust/lib_ccxr/src/util/log.rs
@@ -269,6 +269,11 @@ impl<'a> CCExtractorLogger {
         self.target
     }
 
+    /// Sets the target for logging messages.
+    pub fn set_target(&mut self, target: OutputTarget) {
+        self.target = target;
+    }
+
     /// Check if the messages are intercepted by GUI.
     pub fn is_gui_mode(&self) -> bool {
         self.gui_mode


### PR DESCRIPTION
## Summary

The `--quiet` flag was broken in version 0.96, causing output to still be printed even when the flag was specified.

**Root causes:**
1. **Inverted mapping in Rust FFI:** The C→Rust constant mapping was wrong. `CCX_MESSAGES_QUIET=0, CCX_MESSAGES_STDOUT=1, CCX_MESSAGES_STDERR=2` but the Rust code mapped `0→Stdout, 1→Stderr, 2→Quiet`.

2. **Logger initialization timing:** The Rust logger was initialized BEFORE command-line arguments were parsed, so `--quiet` had no effect on the logger's target.

**Changes:**
- Fix the `OutputTarget` mapping in `ccxr_init_basic_logger()`
- Add `set_target()` method to `CCExtractorLogger` to allow updating after initialization
- Add `ccxr_update_logger_target()` FFI function to update logger after arg parsing
- Call `ccxr_update_logger_target()` after `ccxr_parse_parameters()` in main

## Test plan

- [x] Verified `--quiet` now produces no output
- [x] Verified normal mode still produces expected output
- [x] Verified output files are still generated correctly with `--quiet`
- [x] All 265 Rust unit tests pass
- [ ] CI passes on Linux and Windows

Fixes #1956

🤖 Generated with [Claude Code](https://claude.com/claude-code)