### PR TITLE
feat: Add --input scc option for SCC input format

### DIFF
--- a/src/lib_ccx/ccx_demuxer.c
+++ b/src/lib_ccx/ccx_demuxer.c
@@ -285,6 +285,9 @@ static void ccx_demuxer_print_cfg(struct ccx_demuxer *ctx)
 		case CCX_SM_MXF:
 			mprint("MXF");
 			break;
+		case CCX_SM_SCC:
+			mprint("SCC");
+			break;
 #ifdef WTV_DEBUG
 		case CCX_SM_HEX_DUMP:
 			mprint("Hex");

--- a/src/rust/src/args.rs
+++ b/src/rust/src/args.rs
@@ -990,6 +990,8 @@ pub enum InFormat {
     Mkv,
     /// Material Exchange Format (MXF).
     Mxf,
+    /// Scenarist Closed Caption (SCC).
+    Scc,
     #[cfg(feature = "wtv_debug")]
     // For WTV Debug mode only
     Hex,

--- a/src/rust/src/demuxer/demux.rs
+++ b/src/rust/src/demuxer/demux.rs
@@ -327,6 +327,9 @@ impl CcxDemuxer<'_> {
             StreamMode::Mxf => {
                 info!("MXF");
             }
+            StreamMode::Scc => {
+                info!("SCC");
+            }
             #[cfg(feature = "wtv_debug")]
             StreamMode::HexDump => {
                 info!("Hex");

--- a/src/rust/src/parser.rs
+++ b/src/rust/src/parser.rs
@@ -311,6 +311,7 @@ impl OptionsExt for Options {
             InFormat::Mp4 => self.demux_cfg.auto_stream = StreamMode::Mp4,
             InFormat::Mkv => self.demux_cfg.auto_stream = StreamMode::Mkv,
             InFormat::Mxf => self.demux_cfg.auto_stream = StreamMode::Mxf,
+            InFormat::Scc => self.demux_cfg.auto_stream = StreamMode::Scc,
         }
     }
 


### PR DESCRIPTION
## Summary

Add support for `--input scc` command line option to explicitly specify SCC (Scenarist Closed Caption) input format, for consistency with other input format options.

**Before:**
```
$ ccextractor --input scc file.scc
error: invalid value 'scc' for '--input <format>'
  [possible values: ts, ps, es, asf, wtv, bin, raw, mp4, m2ts, mkv, mxf]
```

**After:**
```
$ ccextractor --help | grep -A20 "Input Formats:"
...
          - scc:  Scenarist Closed Caption (SCC)
```

## Changes
- Add `Scc` variant to `InFormat` enum in args.rs
- Handle `InFormat::Scc` in parser.rs to set `StreamMode::Scc`
- Add `StreamMode::Scc` case in `print_cfg()` in both Rust (demux.rs) and C (ccx_demuxer.c)

## Test plan
- [x] `--help` shows `scc` as valid input format
- [x] `--input scc` accepted without error
- [x] SCC files processed correctly with explicit format
- [x] All 265 Rust unit tests pass

Fixes #1972

🤖 Generated with [Claude Code](https://claude.com/claude-code)