### PR TITLE
fix(rust): Flush stdout after print to fix stream mode display

### DIFF
--- a/src/rust/lib_ccxr/src/util/log.rs
+++ b/src/rust/lib_ccxr/src/util/log.rs
@@ -281,8 +281,16 @@ impl<'a> CCExtractorLogger {
 
     fn print(&self, args: &Arguments<'a>) {
         match &self.target {
-            OutputTarget::Stdout => print!("{args}"),
-            OutputTarget::Stderr => eprint!("{args}"),
+            OutputTarget::Stdout => {
+                print!("{args}");
+                // Flush stdout to ensure output appears immediately, especially when
+                // mixing with C code that also writes to stdout
+                let _ = std::io::Write::flush(&mut std::io::stdout());
+            }
+            OutputTarget::Stderr => {
+                eprint!("{args}");
+                let _ = std::io::Write::flush(&mut std::io::stderr());
+            }
             OutputTarget::Quiet => {}
         }
     }


### PR DESCRIPTION
## Summary
- Fixes empty `[Stream mode: ]` display when using `--input <format>` options
- Adds explicit stdout/stderr flush after print operations in Rust logger

## Problem
When using `--input scc` (or other formats), the startup output showed:
```
[Stream mode: ]
```
Instead of:
```
[Stream mode: SCC]
```

## Root Cause
The Rust logger's `print()` function uses `print!()` which doesn't automatically flush stdout. When mixing C and Rust code that both write to stdout, the Rust output was getting buffered and not appearing before the C code continued writing.

## Solution
Added explicit `std::io::stdout().flush()` after each `print!()` call to ensure output appears immediately and interleaves correctly with C code.

## Test plan
- [x] `--input scc` shows `[Stream mode: SCC]`
- [x] `--input mkv` shows `[Stream mode: MKV]`
- [x] `--input ts` shows `[Stream mode: Transport]`
- [x] Autodetect shows `[Stream mode: Autodetect]`
- [x] All 265 Rust tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)