### PR TITLE
Fix OOB read/write and length handling in CEA-608/708 decoders

### DIFF
--- a/src/lib_ccx/ccx_decoders_608.c
+++ b/src/lib_ccx/ccx_decoders_608.c
@@ -201,6 +201,9 @@ void delete_to_end_of_row(ccx_decoder_608_context *context)
 {
 	if (context->mode != MODE_TEXT)
 	{
+		if (context->cursor_row >= CCX_DECODER_608_SCREEN_ROWS)
+			return;
+
 		struct eia608_screen *use_buffer = get_writing_buffer(context);
 		for (int i = context->cursor_column; i <= CCX_DECODER_608_SCREEN_WIDTH - 1; i++)
 		{
@@ -221,6 +224,10 @@ void write_char(const unsigned char c, ccx_decoder_608_context *context)
 		/* printf ("\rWriting char [%c] at %s:%d:%d\n",c,
 		use_buffer == &wb->data608->buffer1?"B1":"B2",
 		wb->data608->cursor_row,wb->data608->cursor_column); */
+
+		if (context->cursor_row >= CCX_DECODER_608_SCREEN_ROWS || context->cursor_column >= CCX_DECODER_608_SCREEN_WIDTH)
+			return;
+
 		use_buffer->characters[context->cursor_row][context->cursor_column] = c;
 		use_buffer->colors[context->cursor_row][context->cursor_column] = context->current_color;
 		use_buffer->fonts[context->cursor_row][context->cursor_column] = context->font;


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

### description

This change addresses multiple robustness and security issues in the CEA-608 and CEA-708 caption decoders.
The issues were triggered by malformed or truncated caption streams and could lead to out-of-bounds memory access or decoder desynchronization.

These issues did not appear to be previously reported.

### Issues Identified
1. CEA-608 Decoder — Out-of-Bounds Write

File: src/lib_ccx/ccx_decoders_608.c
- write_char() could write to the screen buffer without validating cursor_row and cursor_column.
- delete_to_end_of_row() could access invalid rows if cursor state became inconsistent.
- Malformed input could desynchronize cursor state and cause memory corruption.

Impact:
Potential out-of-bounds write → memory corruption and crashes.

2. CEA-708 Decoder — Out-of-Bounds Read (EXT1, P16)

File: src/lib_ccx/ccx_decoders_708.c
- dtvcc_handle_extended_char() assumed at least one byte of data was available.
- dtvcc_handle_C0() processed P16 commands without verifying sufficient remaining data.
- Malformed packets could cause 1-byte heap buffer over-reads.

Impact:
Out-of-bounds read → crashes or processing of garbage data.

3. CEA-708 Decoder — Logic Error (Length Propagation)

File: src/lib_ccx/ccx_decoders_708.c
- dtvcc_process_service_block() passed incorrect remaining lengths to sub-handlers.
- This amplified OOB read conditions and could desynchronize decoder state.

Impact:
Increased likelihood of OOB reads and incorrect parsing behavior.

### Fixes Implemented
CEA-608 Decoder
- Added strict bounds checks for cursor_row and cursor_column before writing to screen buffers.
- Added early exit in delete_to_end_of_row() when cursor row is invalid.

CEA-708 Decoder
- Added minimum length validation for EXT1 and P16 commands.
- Fixed remaining-length calculation passed to extended character handlers.

Safely skip malformed EXT1 sequences without reading past buffer bounds.
