### PR TITLE
Fix OOB read/write in Teletext G0 charset remapping

### DIFF
--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -434,10 +434,21 @@ void remap_g0_charset(uint8_t c)
 {
 	if (c != primary_charset.current)
 	{
+		if (c >= 56)
+		{
+			fprintf(stderr, "- G0 Latin National Subset ID 0x%1x.%1x is out of bounds\n", (c >> 3), (c & 0x7));
+			return;
+		}
 		uint8_t m = G0_LATIN_NATIONAL_SUBSETS_MAP[c];
 		if (m == 0xff)
 		{
 			fprintf(stderr, "- G0 Latin National Subset ID 0x%1x.%1x is not implemented\n", (c >> 3), (c & 0x7));
+			return;
+		}
+		else if (m >= 14)
+		{
+			fprintf(stderr, "- G0 Latin National Subset index %d is out of bounds\n", m);
+			return;
 		}
 		else
 		{


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

### Summary

This PR fixes an out-of-bounds read/write in the Teletext decoder, specifically in the function `remap_g0_charset(uint8_t c)`.

### Root Cause

- The input value `c` was used as an index into `G0_LATIN_NATIONAL_SUBSETS_MAP` (size 56) without bounds checking.
- The resulting value `m` was then used as an index into another table (size 14) without validation.
- Malformed input could trigger out-of-bounds reads/writes, potentially corrupting global tables.

### Fix

- Added bounds checks for both `c` and `m`.
- Added early returns to prevent unsafe memory access.

### Impact

- Prevents memory corruption on malformed Teletext input.
- Maintains decoder stability without affecting normal operation.

fixed Issue: #1979

