### PR TITLE
fix(epg): Silence snprintf buffer truncation warnings

### DIFF
--- a/src/lib_ccx/ts_functions.h
+++ b/src/lib_ccx/ts_functions.h
@@ -50,8 +50,8 @@ struct EPG_rating
 struct EPG_event
 {
 	uint32_t id;
-	char start_time_string[21]; //"YYYYMMDDHHMMSS +0000" = 20 chars
-	char end_time_string[21];
+	char start_time_string[74]; // "YYYYMMDDHHMMSS +0000" = 20 chars, 74 to silence compiler warning
+	char end_time_string[74];
 	uint8_t running_status;
 	uint8_t free_ca_mode;
 	char ISO_639_language_code[4];

--- a/src/lib_ccx/ts_tables_epg.c
+++ b/src/lib_ccx/ts_tables_epg.c
@@ -125,7 +125,7 @@ void EPG_ATSC_calc_time(char *output, uint32_t time)
 	timeinfo.tm_hour = 0;
 	timeinfo.tm_isdst = -1;
 	mktime(&timeinfo);
-	snprintf(output, 21, "%02d%02d%02d%02d%02d%02d +0000", timeinfo.tm_year + 1900, timeinfo.tm_mon + 1, timeinfo.tm_mday, timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec);
+	snprintf(output, 74, "%02d%02d%02d%02d%02d%02d +0000", timeinfo.tm_year + 1900, timeinfo.tm_mon + 1, timeinfo.tm_mday, timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec);
 }
 
 // Fills event.start_time_string in XMLTV format with passed DVB time


### PR DESCRIPTION
## Summary

Extends EPG time string buffers from 21 to 74 bytes to silence compiler warnings about potential buffer truncation.

## Problem

Every build showed warnings like:
```
ts_tables_epg.c:128:35: warning: '%02d' directive output may be truncated writing between 2 and 11 bytes into a region of size between 10 and 19 [-Wformat-truncation=]
ts_tables_epg.c:128:9: note: 'snprintf' output between 19 and 73 bytes into a destination of size 21
```

## Solution

The actual output is always 20 chars (`YYYYMMDDHHMMSS +0000`) plus null terminator, but the compiler warns because `%02d` with `int` arguments could theoretically produce larger output (e.g., if year were somehow negative or very large).

Extended buffers to 74 bytes to match the compiler's calculated maximum, eliminating the warning while maintaining correct functionality.

## Changes

- `ts_functions.h`: `start_time_string[21]` → `start_time_string[74]`
- `ts_functions.h`: `end_time_string[21]` → `end_time_string[74]`
- `ts_tables_epg.c`: `snprintf(output, 21, ...)` → `snprintf(output, 74, ...)`

## Test Plan

- [x] Build completes with no warnings
- [x] No functional changes - output format remains the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)