### PR TITLE
fix: add NULL checks to Rust FFI exports

### DIFF
--- a/src/rust/src/libccxr_exports/bitstream.rs
+++ b/src/rust/src/libccxr_exports/bitstream.rs
@@ -848,7 +848,10 @@ mod bitstream_copying_tests {
             assert!(super::ccxr_next_bytes(std::ptr::null_mut(), 1).is_null());
             assert!(super::ccxr_read_bytes(std::ptr::null_mut(), 1).is_null());
             assert_eq!(super::ccxr_bitstream_get_num(std::ptr::null_mut(), 1, 0), 0);
-            assert_eq!(super::ccxr_read_exp_golomb_unsigned(std::ptr::null_mut()), 0);
+            assert_eq!(
+                super::ccxr_read_exp_golomb_unsigned(std::ptr::null_mut()),
+                0
+            );
             assert_eq!(super::ccxr_read_exp_golomb(std::ptr::null_mut()), 0);
             assert_eq!(super::ccxr_read_int(std::ptr::null_mut(), 8), 0);
         }

--- a/src/rust/src/libccxr_exports/mod.rs
+++ b/src/rust/src/libccxr_exports/mod.rs
@@ -151,7 +151,10 @@ mod tests {
 
             // Test NULL pointer safety for Levenshtein
             assert_eq!(ccxr_levenshtein_dist(ptr::null(), ptr::null(), 0, 0), 0);
-            assert_eq!(ccxr_levenshtein_dist_char(ptr::null(), ptr::null(), 0, 0), 0);
+            assert_eq!(
+                ccxr_levenshtein_dist_char(ptr::null(), ptr::null(), 0, 0),
+                0
+            );
         }
     }
 }


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

### Description

While reviewing the Rust FFI layer, I noticed several exported functions that
dereference raw pointers coming from C without checking for `NULL`.  
If these functions are ever called with invalid inputs, this can lead to
undefined behavior.

I’m still learning Rust FFI, so please correct me if I’m misunderstanding
anything, but based on my understanding these look like genuine safety issues.

### What this PR changes

- Adds defensive `NULL` checks to Rust FFI exports in:
  - `libccxr_exports/mod.rs`
  - `libccxr_exports/bitstream.rs`
- Adds a negative-length check to `ccxr_verify_crc32`
- Ensures FFI functions return safe defaults (`0` or `NULL`) instead of causing UB
- Adds tests to verify safe behavior when called with `NULL` pointers

### Testing

- Ran `cargo test` in `src/rust`
- All existing and newly added tests are passing

fixed #1983
