### PR TITLE
Fix pmtentry clean

### DIFF
--- a/src/rust/src/ctorust.rs
+++ b/src/rust/src/ctorust.rs
@@ -867,12 +867,13 @@ mod cto_rust_vulnerability_tests {
             stream_type: 0x02,
             printable_stream_type: 0,
         };
-        
-        let ptr_opt = unsafe { <*mut PMTEntry as FromCType<*mut PMT_entry>>::from_ctype(&mut c_entry) };
+
+        let ptr_opt =
+            unsafe { <*mut PMTEntry as FromCType<*mut PMT_entry>>::from_ctype(&mut c_entry) };
         assert!(ptr_opt.is_some());
         let ptr = ptr_opt.unwrap();
         assert!(!ptr.is_null());
-        
+
         unsafe {
             let entry = &*ptr;
             assert_eq!(entry.program_number, 1);


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**[FIX] Critical Rust FFI memory safety: avoid returning pointer to stack-allocated PMTEntry**

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

### Description

PR fixes a **use-after-scope (dangling pointer) bug** in the Rust FFI layer.

The implementation of:

```rust
impl FromCType<*mut PMT_entry> for *mut PMTEntry
```

previously returned a raw pointer derived from a stack-allocated PMTEntry.
Once the function returned, the stack frame was destroyed, leaving the pointer
dangling and causing undefined behavior in Rust.

This is a correctness and memory-safety issue independent of C-side usage,
tests, or call order.

Fixes #1986

