### PR TITLE
rust: handle I/O errors in process_word_file (fixes #1990)

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 0.96.5 (2026-01-05)
 -------------------
+- Fix: Rust word file parser panic when reading malformed lines (#1990)
 - New: Add support for raw CDP (Caption Distribution Packet) files (#1406)
 - New: Add --scc-accurate-timing option for bandwidth-aware SCC output (#1120)
 - Fix: MXF files containing CEA-708 captions not being detected/extracted (#1647)

--- a/src/rust/src/parser.rs
+++ b/src/rust/src/parser.rs
@@ -107,7 +107,16 @@ fn process_word_file(filename: &str, list: &mut Vec<String>) -> Result<(), std::
 
     for line in reader.lines() {
         num += 1;
-        let line = line.unwrap();
+        let line = match line {
+            Ok(l) => l,
+            Err(e) => {
+                eprintln!(
+                    "Error reading line {} in word file {}: {}",
+                    num, filename, e
+                );
+                continue;
+            }
+        };
         if line.starts_with('#') {
             continue;
         }


### PR DESCRIPTION
# [FIX] Fix #1990: Handle I/O errors in Rust word file parser
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [x] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

## Description
This Pull Request addresses a stability issue in the Rust-based parser where the application would **panic and terminate** if it encountered a reading error in an external word file (such as a capitalization or profanity list).
### Changes:
* **Modified `process_word_file` in `src/rust/src/parser.rs`**: Replaced the `.unwrap()` call on `reader.lines()` with an explicit `match` statement. 
* **Error Recovery**: Instead of crashing, the program now catches the `Err`, prints a descriptive message to `stderr` including the line number and filename, and uses `continue` to proceed with the rest of the file.

This ensures that a single corrupted line or an I/O hiccup does not interrupt the entire extraction process, making the tool significantly more robust for automated workflows.

## Related Issue
Fixes #1990

## Checklist
- [x] Verified code change with `cargo check`.
- [x] Updated `docs/CHANGES.TXT` with a brief description of the fix.
