### PR TITLE
prevent unsafe Vec::set_len causing heap corruption

### DIFF
--- a/src/rust/src/avc/sei.rs
+++ b/src/rust/src/avc/sei.rs
@@ -226,12 +226,10 @@ pub fn user_data_registered_itu_t_t35(ctx: &mut AvcContextRust, userbuf: &[u8]) 
                         }
 
                         // Save the data and process once we know the sequence number
-                        if ((ctx.cc_count as usize + local_cc_count) * 3) + 1 > ctx.cc_databufsize {
+                        let required_size = ((ctx.cc_count as usize + local_cc_count) * 3) + 1;
+                        if required_size > ctx.cc_data.len() {
                             let new_size = ((ctx.cc_count as usize + local_cc_count) * 6) + 1;
-                            unsafe {
-                                ctx.cc_data.set_len(new_size);
-                            }
-                            ctx.cc_data.reserve(new_size);
+                            ctx.cc_data.resize(new_size, 0);
                             ctx.cc_databufsize = new_size;
                         }
 


### PR DESCRIPTION
**In raising this pull request, I confirm the following:**

- [x] I have read and understood the contributors guide.
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] I have mentioned this change in the changelog.

**My familiarity with the project is as follows:**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

### Summary

fixes an unsafe memory handling issue in `avc/sei.rs` where `Vec::set_len`
was used without ensuring sufficient capacity, which could lead to heap
corruption and undefined behavior.

### Details

- Replaced unsafe `Vec::set_len` + `reserve` logic with safe `Vec::resize`
- Ensures capacity is allocated and memory is initialized before use
- Removes unsafe code while preserving existing behavior

### Impact

- Prevents potential heap corruption
- Improves memory safety in AVC SEI parsing
- No functional or behavioral change expected

### Testing

- Code builds successfully
- No existing tests are affected
