### PR TITLE
fix: Prevent NULL pointer dereference in DVB subtitle decoder

### DIFF
--- a/src/lib_ccx/dvb_subtitle_decoder.c
+++ b/src/lib_ccx/dvb_subtitle_decoder.c
@@ -1712,7 +1712,7 @@ static int write_dvb_sub(struct lib_cc_decode *dec_ctx, struct cc_subtitle *sub)
 		ctx->ocr_ctx = init_ocr(ctx->lang_index);
 		ctx->ocr_initialized = 1; // Mark as initialized even if init_ocr returns NULL
 	}
-	if (ctx->ocr_ctx)
+	if (ctx->ocr_ctx && region)
 	{
 		int ret = ocr_rect(ctx->ocr_ctx, rect, &ocr_str, region->bgcolor, dec_ctx->ocr_quantmode);
 		if (ret >= 0)


### PR DESCRIPTION
## Summary

- Add NULL check for `region` before accessing `region->bgcolor` in the OCR processing block of `write_dvb_sub()`

## Problem

When processing DVB subtitles, the `write_dvb_sub()` function iterates through display items calling `get_region()`. After the loop, if all regions returned NULL, the `region` variable remains NULL. The code then attempts to access `region->bgcolor` in the OCR block, causing a segmentation fault.

**Crash details:**
- Valgrind: "Invalid read of size 4 at address 0x18"
- The 0x18 offset (24 bytes) corresponds to the `bgcolor` field in `DVBSubRegion` struct

## Root Cause

```c
for (display = ctx->display_list; display; display = display->next)
{
    region = get_region(ctx, display->region_id);
    if (!region)
        continue;  // region is still NULL here
    // ...
}
// After loop: region may be NULL

if (ctx->ocr_ctx)  // Missing check for region != NULL
{
    int ret = ocr_rect(..., region->bgcolor, ...);  // CRASH if region is NULL
}
```

## Fix

Add `&& region` to the condition before the OCR block.

## Test Plan

- [x] Build completes successfully
- [x] bbc_small.ts: Before fix = SIGSEGV crash, After fix = 100% processed, 50+ subtitles extracted
- [x] No regressions expected - the change only adds a NULL guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)