### PR TITLE
fix: Remove debug println that printed spurious numbers during processing

### DIFF
--- a/src/rust/lib_ccxr/src/time/units.rs
+++ b/src/rust/lib_ccxr/src/time/units.rs
@@ -225,9 +225,6 @@ impl Timestamp {
         let m = millis / 60000 - 60 * h;
         let s = millis / 1000 - 3600 * h - 60 * m;
         let u = millis - 3600000 * h - 60000 * m - 1000 * s;
-        if h > 24 {
-            println!("{h}")
-        }
         Ok((h.try_into()?, m as u8, s as u8, u as u16))
     }
 


### PR DESCRIPTION
## Summary
- Removes a debug `println!` statement in the Rust timestamp conversion code (`src/rust/lib_ccxr/src/time/units.rs`)
- This debug code was printing the hours value when it exceeded 24, causing spurious numbers (like "25") to appear in the output

## Problem
When processing files with PTS timestamps exceeding 24 hours (e.g., DVB teletext streams where the PCR/PTS base is set to 25+ hours), the debug statement would print just the hours value on its own line, polluting the output:

```
VBI/teletext stream ID 439 (0x1b7) for SID 16411 (0x401b)
25
25
  1%  |  265:45
25
...
```

## Fix
Remove the leftover debug code:
```rust
// REMOVED:
if h > 24 {
    println!("{h}")
}
```

## Test plan
- [x] Build succeeds
- [x] Tested with DVB teletext sample (`dvbt.ts`) - no more spurious numbers in output
- [x] Normal file processing unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)