### PR TITLE
fix: Correct progress time display for multi-program TS files

### DIFF
--- a/src/lib_ccx/file_functions.c
+++ b/src/lib_ccx/file_functions.c
@@ -66,6 +66,7 @@ void prepare_for_new_file(struct lib_ccx_ctx *ctx)
 {
 	// Init per file variables
 	ctx->last_reported_progress = -1;
+	ctx->min_global_timestamp_offset = -1; // -1 means not yet initialized
 	ctx->stat_numuserheaders = 0;
 	ctx->stat_dvdccheaders = 0;
 	ctx->stat_scte20ccheaders = 0;

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -1508,7 +1508,24 @@ int general_loop(struct lib_ccx_ctx *ctx)
 		}
 		if (ctx->live_stream)
 		{
-			int cur_sec = (int)(get_fts(dec_ctx->timing, dec_ctx->current_field) / 1000);
+			LLONG t = get_fts(dec_ctx->timing, dec_ctx->current_field);
+			if (!t && ctx->demux_ctx->global_timestamp_inited)
+				t = ctx->demux_ctx->global_timestamp - ctx->demux_ctx->min_global_timestamp;
+			// Handle multi-program TS timing
+			if (ctx->demux_ctx->global_timestamp_inited)
+			{
+				LLONG offset = ctx->demux_ctx->global_timestamp - ctx->demux_ctx->min_global_timestamp;
+				if (ctx->min_global_timestamp_offset < 0 || offset < ctx->min_global_timestamp_offset)
+					ctx->min_global_timestamp_offset = offset;
+				// Only use timestamps from the program with the lowest base
+				if (offset - ctx->min_global_timestamp_offset < 60000)
+					t = offset - ctx->min_global_timestamp_offset;
+				else
+					t = ctx->min_global_timestamp_offset > 0 ? 0 : t;
+				if (t < 0)
+					t = 0;
+			}
+			int cur_sec = (int)(t / 1000);
 			int th = cur_sec / 10;
 			if (ctx->last_reported_progress != th)
 			{
@@ -1526,6 +1543,28 @@ int general_loop(struct lib_ccx_ctx *ctx)
 					LLONG t = get_fts(dec_ctx->timing, dec_ctx->current_field);
 					if (!t && ctx->demux_ctx->global_timestamp_inited)
 						t = ctx->demux_ctx->global_timestamp - ctx->demux_ctx->min_global_timestamp;
+					// For multi-program TS files, different programs can have different
+					// PCR bases (e.g., one at 25h, another at 23h). This causes the
+					// global_timestamp to jump between different bases, resulting in
+					// wildly different offset values. Track the minimum offset seen
+					// and only display times from the program with the lowest base.
+					if (ctx->demux_ctx->global_timestamp_inited)
+					{
+						LLONG offset = ctx->demux_ctx->global_timestamp - ctx->demux_ctx->min_global_timestamp;
+						// Track minimum offset (this is the PCR base of the program
+						// with the lowest timestamp, which represents true file time)
+						if (ctx->min_global_timestamp_offset < 0 || offset < ctx->min_global_timestamp_offset)
+							ctx->min_global_timestamp_offset = offset;
+						// Only use timestamps from the program with the lowest base.
+						// If current offset is significantly larger than minimum (by > 60s),
+						// it's from a program with a higher PCR base - use minimum instead.
+						if (offset - ctx->min_global_timestamp_offset < 60000)
+							t = offset - ctx->min_global_timestamp_offset;
+						else
+							t = ctx->min_global_timestamp_offset > 0 ? 0 : t; // fallback to minimum-based time
+						if (t < 0)
+							t = 0;
+					}
 					int cur_sec = (int)(t / 1000);
 					activity_progress(progress, cur_sec / 60, cur_sec % 60);
 					ctx->last_reported_progress = progress;

--- a/src/lib_ccx/lib_ccx.h
+++ b/src/lib_ccx/lib_ccx.h
@@ -90,6 +90,7 @@ struct lib_ccx_ctx
 	LLONG total_past; // Only in binary concat mode
 
 	int last_reported_progress;
+	LLONG min_global_timestamp_offset; // Track minimum (global - min) for multi-program TS
 
 	/* Stats */
 	int stat_numuserheaders;


### PR DESCRIPTION
## Summary
- Fixes incorrect progress time display for multi-program transport stream files
- Times now show correctly relative to file start instead of wildly jumping values

## Problem
Multi-program TS files can have different PCR (Program Clock Reference) bases for each program. For example:
- Program A: PCR base at 23 hours  
- Program B: PCR base at 25 hours

When processing such files, the progress time would jump between values based on which program's data was being processed:
```
1%  |  265:45  (from Program B)
2%  |  00:00   (from Program A)
3%  |  263:11  (from Program B)
...
```

This was confusing for a 6-second file!

## Solution
Track the minimum timestamp offset seen across all programs and use that as the baseline:

1. Add `min_global_timestamp_offset` field to track minimum (global_timestamp - min_global_timestamp)
2. When displaying progress, use `current_offset - min_offset` as the time
3. If current offset is > 60 seconds larger than minimum (indicating a different program with higher PCR base), fall back to showing time relative to the minimum baseline

## Test Results

**Multi-program DVB teletext sample (dvbt.ts, 6 seconds):**
- Before: `1% | 265:45`, `2% | 00:00`, `3% | 263:11` ... (jumping wildly)
- After: `1% | 00:00`, `2% | 00:00` ... `87% | 00:05`, `100% | 00:00` (stable 0-5 second range)

**Single-program DVB subtitle sample:**
- Before and after: `0% | 00:00` ... `100% | 00:34` (no change, still works correctly)

## Test plan
- [x] Build succeeds
- [x] Multi-program TS file shows reasonable times
- [x] Single-program TS file timing unaffected
- [x] Live stream mode updated with same fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)