### PR TITLE
fix(rust): Remove dead code returning pointer to stack variable

### DIFF
--- a/src/rust/src/ctorust.rs
+++ b/src/rust/src/ctorust.rs
@@ -615,50 +615,6 @@ impl FromCType<ccx_demux_report> for CcxDemuxReport {
     }
 }
 
-/// # Safety
-/// This function is unsafe because it takes a raw pointer to a C struct.
-impl FromCType<*mut PMT_entry> for *mut PMTEntry {
-    unsafe fn from_ctype(buffer_ptr: *mut PMT_entry) -> Option<Self> {
-        if buffer_ptr.is_null() {
-            return None;
-        }
-
-        let buffer = unsafe { &*buffer_ptr };
-
-        let program_number = if buffer.program_number != 0 {
-            buffer.program_number
-        } else {
-            0
-        };
-
-        let elementary_pid = if buffer.elementary_PID != 0 {
-            buffer.elementary_PID
-        } else {
-            0
-        };
-
-        let stream_type = if buffer.stream_type != 0 {
-            StreamType::from_ctype(buffer.stream_type as u32).unwrap_or(StreamType::Unknownstream)
-        } else {
-            StreamType::Unknownstream
-        };
-
-        let printable_stream_type = if buffer.printable_stream_type != 0 {
-            buffer.printable_stream_type
-        } else {
-            0
-        };
-
-        let mut pmt_entry = PMTEntry {
-            program_number,
-            elementary_pid,
-            stream_type,
-            printable_stream_type,
-        };
-
-        Some(&mut pmt_entry as *mut PMTEntry)
-    }
-}
 impl FromCType<ccx_bufferdata_type> for BufferdataType {
     unsafe fn from_ctype(c_value: ccx_bufferdata_type) -> Option<Self> {
         let rust_value = match c_value {


### PR DESCRIPTION
## Summary

Removes unused `impl FromCType<*mut PMT_entry> for *mut PMTEntry` which contained a critical bug: returning a pointer to a stack-allocated value (undefined behavior).

## Problem

The deleted code did this:
```rust
let mut pmt_entry = PMTEntry { ... };
Some(&mut pmt_entry as *mut PMTEntry)  // BUG: dangling pointer!
```

When the function returns, `pmt_entry` is destroyed and the pointer becomes dangling.

## Why delete instead of fix?

This code was **never called anywhere** in the codebase:
- The actual usage in `demuxer.rs:279` uses the **value-returning** variant: `PMTEntry::from_ctype(*buffer_ptr)`
- That call site already wraps it properly: `Box::into_raw(Box::new(PMTEntry::from_ctype(...)?))`

Rather than fix dead buggy code (and introduce memory ownership complexity), just delete it.

## Verification

- Build passes ✓
- All 265 Rust tests pass ✓
- No code references this implementation

## Related

Supersedes #1988 which attempted to fix this bug rather than delete the dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)