### PR TITLE
docs: Clarify PS probe limit calculation (explain magic number)

### DIFF
--- a/src/rust/src/demuxer/stream_functions.rs
+++ b/src/rust/src/demuxer/stream_functions.rs
@@ -331,11 +331,15 @@ unsafe fn detect_stream_type_common(ctx: &mut CcxDemuxer, ccx_options: &mut Opti
             }
 
             // Now check for PS (Needs PACK header)
-            // We use saturating_sub to avoid underflow if the buffer is tiny.
+            // The loop below checks 4 consecutive bytes (i, i+1, i+2, i+3), so we need
+            // to stop 3 bytes before the end to avoid out-of-bounds access.
+            // - If buffer < 50000: limit = buffer_size - 3 (scan entire buffer)
+            // - If buffer >= 50000: limit = 49997 (= 50000 - 3, cap the scan range)
+            // We use saturating_sub to safely handle tiny buffers (< 3 bytes).
             let limit = if ctx.startbytes_avail < 50000 {
                 ctx.startbytes_avail.saturating_sub(3)
             } else {
-                49997
+                50000 - 3 // Don't scan huge buffers entirely; 50KB is enough
             } as usize;
             for i in 0..limit {
                 if ctx.startbytes[i] == 0x00


### PR DESCRIPTION
## Summary

Replaces the magic number `49997` with `50000 - 3` and adds a clear inline comment explaining the PS stream probe limit calculation.

## Changes

```rust
// Before:
} else {
    49997
}

// After:
} else {
    50000 - 3 // Don't scan huge buffers entirely; 50KB is enough
}
```

## Why This Matters

The number 49997 appears arbitrary without context. The new code makes it clear that:

1. **Why subtract 3**: The loop checks `startbytes[i], [i+1], [i+2], [i+3]`, so we must stop 3 bytes before the end to avoid out-of-bounds access

2. **Why 50000**: We cap the scan range for large buffers (no need to scan megabytes when 50KB is sufficient to detect the format)

3. **Why saturating_sub**: Handles edge case of tiny buffers (< 3 bytes) without underflow

## Testing

- Build passes
- No functional change (50000 - 3 = 49997)

🤖 Generated with [Claude Code](https://claude.com/claude-code)