### PR TITLE
fix: Skip moov box if buffer too small to verify mvhd

### DIFF
--- a/src/rust/src/demuxer/stream_functions.rs
+++ b/src/rust/src/demuxer/stream_functions.rs
@@ -428,17 +428,21 @@ pub fn is_valid_mp4_box(
                 )
             );
 
-            // If the box type is "moov", we need to check if it contains "mvhd".
-            // We must check the buffer length first to avoid an out-of-bounds panic.
-            if idx == 2
-                && position + 15 < buffer.len()
-                && !(buffer[position + 12] == b'm'
+            // If the box type is "moov", it must contain "mvhd" to be valid.
+            // We need 16 bytes from position to check bytes 12-15 for "mvhd".
+            if idx == 2 {
+                if position + 16 > buffer.len() {
+                    // Not enough bytes to verify mvhd - skip this box
+                    continue;
+                }
+                if !(buffer[position + 12] == b'm'
                     && buffer[position + 13] == b'v'
                     && buffer[position + 14] == b'h'
                     && buffer[position + 15] == b'd')
-            {
-                // If "moov" doesn't have "mvhd", skip it.
-                continue;
+                {
+                    // moov without mvhd is not valid - skip it
+                    continue;
+                }
             }
 
             // Box name matches. Do a crude validation of possible box size,


### PR DESCRIPTION
## Summary

Follow-up to #1996. Fixes incorrect behavior where a "moov" box was accepted without verifying it contains "mvhd" when the buffer was too small.

## The Problem

PR #1996 fixed a panic but introduced a logic error:

```rust
// Before #1996 - would panic if buffer too small
if idx == 2 && !(bytes == "mvhd") { continue; }

// After #1996 - accepts moov without verification if buffer too small!
if idx == 2 && position + 15 < buffer.len() && !(bytes == "mvhd") { continue; }
```

With the #1996 fix, if `position + 15 >= buffer.len()`:
- The condition short-circuits
- The box is NOT skipped
- **An unverified "moov" is accepted as valid**

## The Fix

```rust
if idx == 2 {
    if position + 16 > buffer.len() {
        continue;  // Can't verify mvhd - skip this box
    }
    if !(bytes == "mvhd") {
        continue;  // No mvhd - skip this box
    }
}
```

Now:
- If buffer too small → skip (safe)
- If moov has mvhd → accept (valid)
- If moov lacks mvhd → skip (invalid)

## Why This Is Safe

This code runs in `detect_stream_type` - a one-shot format probe that reads up to 1MB. For format detection:
1. Skipping an unverifiable box is safer than accepting it
2. The scoring system requires multiple valid boxes to claim MP4
3. Real MP4 files have moov+mvhd well within the first 1MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)