### PR TITLE
fix(avc): prevent segfault in report-only mode (-out=report)

### DIFF
--- a/src/rust/src/avc/mod.rs
+++ b/src/rust/src/avc/mod.rs
@@ -21,6 +21,19 @@ pub unsafe extern "C" fn ccxr_process_avc(
         return 0;
     }
 
+    // In report-only mode (-out=report), enc_ctx is NULL because no encoder is created.
+    // Skip AVC processing in this case since we can't output captions without an encoder.
+    // Return the full buffer length to indicate we've "consumed" the data.
+    if enc_ctx.is_null() {
+        return avcbuflen;
+    }
+
+    // dec_ctx and sub should never be NULL in normal operation, but check defensively
+    if dec_ctx.is_null() || sub.is_null() {
+        info!("Warning: dec_ctx or sub is NULL in ccxr_process_avc");
+        return avcbuflen;
+    }
+
     // Create a safe slice from the raw pointer
     let avc_slice = std::slice::from_raw_parts_mut(avcbuf, avcbuflen);
 


### PR DESCRIPTION
## Summary
- Fixes segmentation fault when using `-out=report` on transport streams with AVC/H.264 or HEVC video
- Adds NULL pointer checks at the Rust FFI boundary in `ccxr_process_avc()`

## Root Cause
When using `-out=report` mode, the encoder context (`enc_ctx`) is intentionally NULL because no output file needs to be created. The Rust FFI function was dereferencing this NULL pointer without validation.

## Test plan
- [x] Verified `-out=report` no longer segfaults on H.264 streams
- [x] Verified `-out=report` works on HEVC streams  
- [x] Verified normal caption extraction still works

Fixes #2023

🤖 Generated with [Claude Code](https://claude.ai/code)