### PR TITLE
Fix unsafe temporary Vec pointer usage in userdata.rs

### DIFF
--- a/src/rust/src/es/userdata.rs
+++ b/src/rust/src/es/userdata.rs
@@ -278,7 +278,8 @@ pub unsafe fn user_data(
 
                 if !proceed {
                     debug!(msg_type = DebugMessageFlag::VERBOSE; "\rThe following payload is not properly terminated.");
-                    dump(cc_data.to_vec().as_mut_ptr(), (cc_count * 3 + 1) as _, 0, 0);
+                    let mut cc_data_copy = cc_data.to_vec();
+                    dump(cc_data_copy.as_mut_ptr(), (cc_count * 3 + 1) as _, 0, 0);
                 }
                 debug!(msg_type = DebugMessageFlag::VERBOSE; "Reading {} HD CC blocks", cc_count);
 
@@ -292,7 +293,7 @@ pub unsafe fn user_data(
                 store_hdcc(
                     enc_ctx,
                     dec_ctx,
-                    cc_data.to_vec().as_mut_ptr(),
+                    cc_data.as_ptr() as *mut u8,
                     cc_count as _,
                     (*dec_ctx.timing).current_tref,
                     (*dec_ctx.timing).fts_now,
@@ -535,7 +536,8 @@ pub unsafe fn user_data(
         }
 
         let vbi_data = &ustream.data[ustream.pos..ustream.pos + 720];
-        decode_vbi(dec_ctx, field, vbi_data.to_vec().as_mut_ptr(), 720, sub);
+        let mut vbi_data_copy = vbi_data.to_vec();
+        decode_vbi(dec_ctx, field, vbi_data_copy.as_mut_ptr(), 720, sub);
         debug!(msg_type = DebugMessageFlag::VERBOSE; "GXF (vbi line {}) user data:", line_nb);
     } else {
         // Some other user data


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

### Description
While working on the Rust FFI code in userdata.rs, I noticed that a few calls were passing pointers created from temporary Vecs (to_vec().as_mut_ptr()) directly into C functions.

This is unsafe because the temporary Vec is dropped immediately after the statement, which can leave the C side with a dangling pointer and result in undefined behavior.

### Fix
- Keep copied Vecs alive for the duration of the corresponding FFI calls where needed
- Reuse existing slice pointers when the C code immediately copies the data

This change does not alter behavior and is limited to fixing lifetime safety at the FFI boundary.



### Proposed Changes
- Store the Vec in a variable so it remains alive until after the dump() call completes
- Since `cc_data` is already a slice returned from `read_bytes()`, use its pointer directly.  
  The C function `store_hdcc()` copies the data using `memcpy()` (see `sequencing.c:70`), so the pointer only needs to be valid during the call
- Store the Vec in a variable so it remains alive until after the decode_vbi() call completes