### PR TITLE
Fix GXF VBI out-of-bounds panic in userdata.rs

### DIFF
--- a/src/rust/src/es/userdata.rs
+++ b/src/rust/src/es/userdata.rs
@@ -532,6 +532,7 @@ pub unsafe fn user_data(
 
         if udatalen < 720 {
             info!("MPEG:VBI: Minimum 720 bytes in luma line required");
+            return Ok(1); // Early return - not enough data
         }
 
         let vbi_data = &ustream.data[ustream.pos..ustream.pos + 720];


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

### Desciption

critical out-of-bounds panic when processing malformed GXF VBI data.

Previously, the code attempted to slice exactly 720 bytes from the stream, even if fewer bytes were available:
```rust
let vbi_data = &ustream.data[ustream.pos..ustream.pos + 720];
```
This caused the program to panic if the GXF packet was truncated, corrupted, or attacker-crafted. The check for udatalen < 720 only logged a message but did not prevent execution.

### Fix
- Return early (Ok(1)) when insufficient data (<720 bytes) is detected.
- This prevents out-of-bounds panics and allows the decoder to continue processing subsequent packets.
- Existing functionality for valid packets is unchanged.

We could consider returning a specific error variant instead of Ok(1) to indicate that the packet is malformed. This would allow higher level code to handle malformed packets explicitly (e.g., loging, skipping, or applying custom processing). The current approach is safe and ensures decoder stability.