### PR TITLE
Fix use-after-free bugs in Rust userdata handling

### DIFF
--- a/src/rust/src/es/userdata.rs
+++ b/src/rust/src/es/userdata.rs
@@ -342,6 +342,10 @@ pub unsafe fn user_data(
         let dcd_pos = ustream.pos; // dish caption data position
         match pattern_type {
             0x02 => {
+                if ustream.data.len() - ustream.pos < 4 {
+                    info!("Dish Network caption: insufficient data");
+                    return Ok(1);
+                }
                 // Two byte caption - always on B-frame
                 // The following 4 bytes are:
                 // 0  :  0x09
@@ -389,6 +393,10 @@ pub unsafe fn user_data(
                 // Ignore 3 (0x0A, followed by two unknown) bytes.
             }
             0x04 => {
+                if ustream.data.len() - ustream.pos < 5 {
+                    info!("Dish Network caption: insufficient data");
+                    return Ok(1);
+                }
                 // Four byte caption - always on B-frame
                 // The following 5 bytes are:
                 // 0  :  0x09
@@ -425,6 +433,10 @@ pub unsafe fn user_data(
                 // Ignore 4 (0x020A, followed by two unknown) bytes.
             }
             0x05 => {
+                if ustream.data.len() - ustream.pos < 12 {
+                    info!("Dish Network caption: insufficient data");
+                    return Ok(1);
+                }
                 // Buffered caption - always on I-/P-frame
                 // The following six bytes are:
                 // 0  :  0x04
@@ -432,7 +444,7 @@ pub unsafe fn user_data(
                 // 1  : prev dcd[2]
                 // 2-3: prev dcd[3-4]
                 // 4-5: prev dcd[5-6]
-                let dcd_data = &ustream.data[dcd_pos..dcd_pos + 10]; // Need more bytes for this case
+                let dcd_data = &ustream.data[dcd_pos..dcd_pos + 12]; // Need more bytes for this case
                 debug!(msg_type = DebugMessageFlag::PARSE; " - {:02X}  pch: {:02X} {:5} {:02X}:{:02X}",
                           dcd_data[0], dcd_data[1],
                           (dcd_data[2] as u32) * 256 + (dcd_data[3] as u32),
@@ -534,6 +546,7 @@ pub unsafe fn user_data(
 
         if udatalen < 720 {
             info!("MPEG:VBI: Minimum 720 bytes in luma line required");
+            return Ok(1);
         }
 
         let vbi_data = &ustream.data[ustream.pos..ustream.pos + 720];


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

### Description
While reviewing userdata.rs, I found another instance of the same use-after-free pattern in the Unrecognized user data handling.

The current code creates a temporary Vec using .to_vec() and immediately extracts a raw pointer from it using .as_mut_ptr().
Because the temporary Vec is dropped right after .as_mut_ptr(), the pointer passed to dump() becomes dangling, resulting in use-after-free undefined behavior.

This is the same issue that was fixed earlier in this file.

### Fix
Store the Vec in a local variable so its lifetime extends until after the dump() call:
```rust
let mut data_copy =
    ustream.data[ustream.pos..ustream.pos + dump_len].to_vec();
dump(data_copy.as_mut_ptr(), dump_len as _, 0, 0);
```
This guarantees the backing memory remains valid for the duration of the call.
