### PR TITLE
fix: process_word_file propagates errors instead of panicking

### DIFF
--- a/src/rust/src/parser.rs
+++ b/src/rust/src/parser.rs
@@ -114,7 +114,7 @@ fn process_word_file(filename: &str, list: &mut Vec<String>) -> Result<(), std::
 
     for line in reader.lines() {
         num += 1;
-        let line = line.unwrap();
+        let line = line?;
         if line.starts_with('#') {
             continue;
         }


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

### Description

The process_word_file function reads lines from a file and previously used line.unwrap() to extract each line. This is unsafe because:
- If the file contains invalid UTF-8 bytes, unwrap() panics, crashing the program
- Since process_word_file is intended to process external files, panics on malformed input are unacceptable.

### Fix
- Replaced let line = line.unwrap(); with let line = line?
- This propagates the error up to the caller instead of panicking.
- The caller already expects a Result<(), std::io::Error>, so error handling is consistent with the function signature.

### Example
Valid UTF-8 line  --> Works 
Line with invalid UTF-8 (0xFF) --> Returns Err

