### PR TITLE
fix(rust): Correct version number in CLI parser

### DIFF
--- a/src/rust/src/args.rs
+++ b/src/rust/src/args.rs
@@ -28,7 +28,7 @@ const BURNEDIN_SUBTITLE_EXTRACTION: &str = "Burned-in subtitle extraction";
 #[derive(Debug, Parser)]
 #[command(name = "CCExtractor")]
 #[command(author = "Carlos Fernandez Sanz, Volker Quetschke.")]
-#[command(version = "1.0")]
+#[command(version = "0.96.5")]
 #[command(about = "Teletext portions taken from Petr Kutalek's telxcc
 --------------------------------------------------------------------------
 Originally based on McPoodle's tools. Check his page for lots of information


### PR DESCRIPTION
## Summary

The Rust CLI parser was showing "CCExtractor 1.0" instead of the actual version (0.96.5). 

**Before:**
```
$ ccextractor --help
CCExtractor 1.0, Carlos Fernandez Sanz, Volker Quetschke..
```

**After:**
```
$ ccextractor --help
CCExtractor 0.96.5, Carlos Fernandez Sanz, Volker Quetschke..
```

## Root Cause

This was a placeholder value (`#[command(version = "1.0")]`) from when the parser was first ported to Rust in August 2024 (commit 9340cc7d) that was never updated to match the actual CCExtractor version.

## Fix

Changed the hardcoded version in `src/rust/src/args.rs` from "1.0" to "0.96.5" to match the version defined in `src/lib_ccx/lib_ccx.h`.

## Testing

- Built successfully
- Verified `--version` and `--help` now show correct version

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)