### PR TITLE
fix(rust): harden ccxr_process_cc_data against excessive cc_count

### DIFF
--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -394,8 +394,8 @@ pub extern "C" fn ccxr_dtvcc_set_active(dtvcc_ptr: *mut std::ffi::c_void, active
 /// data should point to cc_data of length cc_count
 /// dec_ctx.dtvcc_rust must point to a valid DtvccRust instance
 
+/// Maximum number of CC blocks accepted per call to prevent excessive allocation
 const MAX_CC_BLOCKS_PER_CALL: c_int = 10_000;
-
 #[no_mangle]
 extern "C" fn ccxr_process_cc_data(
     dec_ctx: *mut lib_cc_decode,


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

{pull request content here}
### Summary

Adds a defensive upper bound on `cc_count` in `ccxr_process_cc_data` to prevent
excessive allocations or misuse at the FFI boundary.

### Details
- Rejects calls where `cc_count` exceeds a sane limit
- Logs a warning instead of attempting allocation
- Adds a unit test to validate the guard
- No behavior change for valid inputs
