### PR TITLE
fix(rust): correct mkvlang test to use MkvLangFilter type

### DIFF
--- a/src/rust/src/parser.rs
+++ b/src/rust/src/parser.rs
@@ -1660,7 +1660,7 @@ pub mod tests {
     use crate::{args::*, parser::*};
     use clap::Parser;
     use lib_ccxr::{
-        common::{OutputFormat, SelectCodec, StreamMode, StreamType},
+        common::{MkvLangFilter, OutputFormat, SelectCodec, StreamMode, StreamType},
         util::{encoding::Encoding, log::DebugMessageFlag},
     };
 
@@ -2737,7 +2737,7 @@ pub mod tests {
     #[test]
     fn test_mkvlang_sets_mkv_language() {
         let (options, _) = parse_args(&["--mkvlang", "eng"]);
-        assert_eq!(options.mkvlang.unwrap(), Language::Eng);
+        assert_eq!(options.mkvlang.unwrap(), "eng".parse::<MkvLangFilter>().unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix type mismatch in `test_mkvlang_sets_mkv_language` test
- The test was comparing against `Language::Eng`, but `mkvlang` field type changed to `MkvLangFilter` after BCP 47 support was added in PR #2038

## Test plan
- [x] `cargo test --workspace` passes (395 tests in ccx_rust + 91 in lib_ccxr)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)