### PR TITLE
Add safety checks to ccxr_verify_crc32 to prevent invalid pointer/length access

### DIFF
--- a/src/rust/src/libccxr_exports/mod.rs
+++ b/src/rust/src/libccxr_exports/mod.rs
@@ -77,6 +77,10 @@ pub unsafe extern "C" fn ccxr_update_logger_target() {
 /// or less than `len`.
 #[no_mangle]
 pub unsafe extern "C" fn ccxr_verify_crc32(buf: *const u8, len: c_int) -> c_int {
+    // Safety: avoid NULL pointer and negative length causing usize wraparound
+    if buf.is_null() || len < 0 {
+        return 0;
+    }
     let buf = std::slice::from_raw_parts(buf, len as usize);
     if verify_crc32(buf) {
         1


### PR DESCRIPTION
…rc32

<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---


### Description
ccxr_verify_crc32 is an extern "C" function that receives a raw pointer and a signed length from external (C) callers.
Previously, the function directly converted the inputs into a Rust slice using:
```rust
std::slice::from_raw_parts(buf, len as usize)
```


This is unsafe if:
- buf is NULL
- len is negative
A negative length cast to usize can wrap to a very large value, causing undefined behavior and potential crashes.

### Fix

- Added minimal input validation at the beginning of the function:
- Return failure (0) if the buffer pointer is NULL
- Return failure (0) if the length is negative
```rust
if buf.is_null() || len < 0 {
    return 0;
}
```

This prevents invalid inputs from reaching from_raw_parts and avoids potential crashes or memory safety issues.


