### PR TITLE
Fix/dtvcc allocation panic

### DIFF
--- a/src/rust/src/decoder/mod.rs
+++ b/src/rust/src/decoder/mod.rs
@@ -287,7 +287,12 @@ impl DtvccRust {
                 let tv_layout = std::alloc::Layout::new::<dtvcc_tv_screen>();
                 let tv_ptr = unsafe { std::alloc::alloc_zeroed(tv_layout) } as *mut dtvcc_tv_screen;
                 if tv_ptr.is_null() {
-                    panic!("Failed to allocate dtvcc_tv_screen");
+                    debug!(
+                        msg_type = DebugMessageFlag::DECODER_708;
+                        "DTVCC: Failed to allocate tv_screen for service {}, disabling service",
+                         i + 1
+                    );
+                    continue;
                 }
                 let mut tv_screen = unsafe { Box::from_raw(tv_ptr) };
                 tv_screen.cc_count = 0;
@@ -299,9 +304,14 @@ impl DtvccRust {
                 let decoder_ptr = unsafe { std::alloc::alloc_zeroed(decoder_layout) }
                     as *mut dtvcc_service_decoder;
                 if decoder_ptr.is_null() {
-                    panic!("Failed to allocate dtvcc_service_decoder");
-                }
+                    debug!(
+                        msg_type = DebugMessageFlag::DECODER_708;
+                        "DTVCC: Failed to allocate service decoder {}, disabling service",
+                        i + 1
+                    );
 
+                    continue;
+                }
                 let mut decoder = unsafe { Box::from_raw(decoder_ptr) };
 
                 // Set the tv pointer


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

This PR removes panics from the CEA-708 decoder initialization path.

Previously, allocation failures for dtvcc_tv_screen or
dtvcc_service_decoder would cause a hard panic, crashing CCExtractor.

Instead, allocation failures are now handled gracefully by logging
a debug message and disabling the affected service decoder while
allowing processing to continue.

This improves robustness and aligns Rust behavior with the legacy C
implementation.

