### PR TITLE
fix: add default X-TIMESTAMP-MAP header when timing info is unavailable

### DIFF
--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -239,7 +239,7 @@ void write_webvtt_header(struct encoder_ctx *context)
 		// {
 		// 	write_wrapped(context->out->fh, "\r\n", 2);
 		// }
-		    // Issue #1743: write default X-TIMESTAMP-MAP when timing info is unavailable
+		// Issue #1743: write default X-TIMESTAMP-MAP when timing info is unavailable
     if (ccx_options.timestamp_map)
     {
         const char *default_header =


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

{pull request content here}
