### PR TITLE
[FIX] Guard against NULL timing context when reporting decoder statistics

### DIFF
--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -259,8 +259,8 @@ int start_ccx()
 		}
 		list_for_each_entry(dec_ctx, &ctx->dec_ctx_head, list, struct lib_cc_decode)
 		{
-                        if (!dec_ctx->timing)
-                                continue;
+			if (!dec_ctx->timing)
+				continue;
 
 			mprint("\n");
 			dbg_print(CCX_DMT_DECODER_608, "\nTime stamps after last caption block was written:\n");


### PR DESCRIPTION
[FIX] Guard against NULL timing context when reporting decoder statistics

In raising this pull request, I confirm the following (please check boxes):

- [x] I have read and understood the contributors guide.
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] I have mentioned this change in the changelog.

My familiarity with the project is as follows (check one):

- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

### Summary

This PR adds a defensive null check for dec_ctx->timing in the decoder reporting loop at the end of start_ccx().

Under certain execution paths, decoder contexts present in ctx->dec_ctx_head may not have an associated timing context. The current code assumes timing is always present and unconditionally dereferences dec_ctx->timing, which can lead to undefined behavior or crashes.

This change safely skips such decoder entries during reporting only.

### Problem Description

The reporting loop in start_ccx() assumes that every decoder in ctx->dec_ctx_head has a valid timing structure.

While decoders created via init_cc_decode() always initialize timing, decoder contexts created via copy_decoder_context() explicitly set timing = NULL. These copied decoder contexts may still be present in dec_ctx_head, making the assumption invalid.

### Fix

Add a simple guard before accessing timing fields:

```c
if (!dec_ctx->timing)
    continue;
