### PR TITLE
Fix out-of-bounds panic in GXF VBI parsing

### DIFF
--- a/src/rust/src/es/userdata.rs
+++ b/src/rust/src/es/userdata.rs
@@ -529,7 +529,6 @@ pub unsafe fn user_data(
     }
     // GXF vbi OEM code
     else if ud_header.starts_with(&[0x73, 0x52, 0x21, 0x06]) {
-        let udatalen = ustream.data.len() - ustream.pos;
         ustream.read_bytes(4)?; // skip header code
         ustream.read_bytes(2)?; // skip data length
         let line_nb = ustream.read_bits(16)? as u16;
@@ -544,7 +543,7 @@ pub unsafe fn user_data(
             info!("MPEG:VBI: only support Luma line");
         }
 
-        if udatalen < 720 {
+        if ustream.bits_left < 720 * 8 {
             info!("MPEG:VBI: Minimum 720 bytes in luma line required");
             return Ok(1);
         }


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---
### Description

In userdata.rs, the GXF VBI parser was using an old data length after moving through the bitstream, which could crash on some files. This update checks the actual remaining bits instead, keeping things safe and stopping those crashes.


