### PR TITLE
[FIX]macOS: Fix hardsub pipeline failing due to arm64/x86_64 build mismatch

### DIFF
--- a/mac/build.command
+++ b/mac/build.command
@@ -42,7 +42,16 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-BLD_FLAGS="-std=gnu99 -Wno-write-strings -Wno-pointer-sign -D_FILE_OFFSET_BITS=64 -DVERSION_FILE_PRESENT -Dfopen64=fopen -Dopen64=open -Dlseek64=lseek"
+# Determine architecture based on cargo (to ensure consistency with Rust part)
+CARGO_ARCH=$(file $(which cargo) | grep -o 'x86_64\|arm64')
+if [[ "$CARGO_ARCH" == "x86_64" ]]; then
+    echo "Detected Intel (x86_64) Cargo. Forcing x86_64 build to match Rust and libraries..."
+    BLD_ARCH="-arch x86_64"
+else
+    BLD_ARCH="-arch arm64"
+fi
+
+BLD_FLAGS="$BLD_ARCH -std=gnu99 -Wno-write-strings -Wno-pointer-sign -D_FILE_OFFSET_BITS=64 -DVERSION_FILE_PRESENT -Dfopen64=fopen -Dopen64=open -Dlseek64=lseek"
 
 # Add flags for bundled libraries (not needed when using system libs)
 if [[ "$USE_SYSTEM_LIBS" != "true" ]]; then


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

PR Description

On macOS (Apple Silicon), hardsub (burned-in subtitle) OCR exited early with
“No captions were found in input”, even when subtitles were visible.

This was caused by an architecture mismatch:

C code built as arm64

Rust toolchain and Homebrew deps (FFmpeg/Tesseract) built as x86_64 (Rosetta)

The mixed build silently prevented the hardsub pipeline from reaching frame/OCR processing.

Fix

Update the macOS build script to:

detect Cargo’s architecture

force the C build to match it (-arch x86_64 or -arch arm64)

This restores proper hardsub OCR execution on macOS.

Files changed

mac/build.command

Feedback on any macOS CI / Sample Platform impact is welcome.

Fix ---------------------------------------

```
CARGO_ARCH=$(file $(which cargo) | grep -o 'x86_64\|arm64')

if [[ "$CARGO_ARCH" == "x86_64" ]]; then
    BLD_ARCH="-arch x86_64"
else
    BLD_ARCH="-arch arm64"

```








