### PR TITLE
Fix Miri-reported UB in window row deallocation and tests

### DIFF
--- a/src/rust/src/decoder/window.rs
+++ b/src/rust/src/decoder/window.rs
@@ -167,7 +167,9 @@ impl dtvcc_window {
                 } else {
                     let layout = layout.unwrap();
                     // deallocate previous memory
-                    dealloc(self.rows[row_index] as *mut u8, layout);
+                    if !self.rows[row_index].is_null() {
+                        dealloc(self.rows[row_index] as *mut u8, layout);
+                    }
 
                     // allocate new zero initialized memory
                     let ptr = alloc_zeroed(layout);


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

### Description
fixing undefined behavior reported by Miri in the
`test_process_ff` and `test_process_hcr` service decoder tests.

### Root Cause
- `clear_row` could call `dealloc` on null row pointers when
  `memory_reserved` was set but rows were not fully initialized.
- Tests manually allocated rows using `Box`, causing layout
  mismatches (`Layout::new` vs `Layout::array`) and UB during deallocation.

### Fix
1. Added a null-pointer check before deallocating rows in
   `window::clear_row`.
2. Updated tests to allocate all rows using the correct
   `Layout::array::<dtvcc_symbol>` and added proper cleanup.

### Verification
- `cargo +nightly miri test decoder::service_decoder::test`
- All related tests pass under Miri with no UB reported.

This change makes the window memory handling more robust and
aligns test allocation with production behavior.

