### PR TITLE
Fix empty WebVTT files for HLS compatibility (Issue #1743)

### DIFF
--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -176,6 +176,14 @@ int write_subtitle_file_footer(struct encoder_ctx *ctx, struct ccx_s_write *out)
 		case CCX_OF_CCD:
 			ret = write(out->fh, ctx->encoded_crlf, ctx->encoded_crlf_length);
 			break;
+		case CCX_OF_WEBVTT:
+			// Ensure WebVTT header is written even if no subtitles were found (issue #1743)
+			// This is required for HLS compatibility
+			if (!ctx->wrote_webvtt_header)
+			{
+				write_webvtt_header(ctx);
+			}
+			break;
 		default: // Nothing to do, no footer on this format
 			break;
 	}

--- a/src/lib_ccx/ccx_encoders_common.h
+++ b/src/lib_ccx/ccx_encoders_common.h
@@ -184,8 +184,8 @@ struct encoder_ctx
 	int nospupngocr;
 	int is_pal;
 
-	struct ccx_s_write *tlt_out[MAX_TLT_PAGES_EXTRACT]; // Output files per teletext page
-	uint16_t tlt_out_pages[MAX_TLT_PAGES_EXTRACT];       // Page numbers for each output slot
+	struct ccx_s_write *tlt_out[MAX_TLT_PAGES_EXTRACT];  // Output files per teletext page
+	uint16_t tlt_out_pages[MAX_TLT_PAGES_EXTRACT];	     // Page numbers for each output slot
 	unsigned int tlt_srt_counter[MAX_TLT_PAGES_EXTRACT]; // SRT counter per page
 	int tlt_out_count;				     // Number of teletext output files
 };
@@ -262,6 +262,9 @@ int write_cc_bitmap_as_libcurl(struct cc_subtitle *sub, struct encoder_ctx *cont
 
 void write_spumux_header(struct encoder_ctx *ctx, struct ccx_s_write *out);
 void write_spumux_footer(struct ccx_s_write *out);
+
+// WebVTT header writer (issue #1743 - ensures header is written even for empty files)
+void write_webvtt_header(struct encoder_ctx *context);
 
 struct cc_subtitle *reformat_cc_bitmap_through_sentence_buffer(struct cc_subtitle *sub, struct encoder_ctx *context);
 

--- a/src/lib_ccx/ccx_encoders_webvtt.c
+++ b/src/lib_ccx/ccx_encoders_webvtt.c
@@ -220,8 +220,9 @@ void write_webvtt_header(struct encoder_ctx *context)
 		millis_to_time(context->timing->sync_pts2fts_fts, &h1, &m1, &s1, &ms1);
 
 		// If the user has enabled X-TIMESTAMP-MAP
-		snprintf(header_string, sizeof(header_string), "X-TIMESTAMP-MAP=MPEGTS:%ld,LOCAL:%02u:%02u:%02u.%03u%s",
-			 context->timing->sync_pts2fts_pts, h1, m1, s1, ms1,
+		// LOCAL must come before MPEGTS for HLS compatibility (issue #1743)
+		snprintf(header_string, sizeof(header_string), "X-TIMESTAMP-MAP=LOCAL:%02u:%02u:%02u.%03u,MPEGTS:%ld%s",
+			 h1, m1, s1, ms1, context->timing->sync_pts2fts_pts,
 			 ccx_options.enc_cfg.line_terminator_lf ? "\n\n" : "\r\n\r\n");
 
 		used = encode_line(context, context->buffer, (unsigned char *)header_string);


### PR DESCRIPTION
This fixes issue #1743 where CCExtractor generates empty .webvtt files when processing content with no subtitles, breaking HLS compatibility.

Changes:
- Fixed X-TIMESTAMP-MAP field order (LOCAL before MPEGTS) per HLS specification 
- Added WebVTT case in write_subtitle_file_footer() to ensure header is always written
- Added function declaration for write_webvtt_header in header file

Fixes: #1743

<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

{pull request content here}
