### PR TITLE
Feature/timestamp map control

### DIFF
--- a/src/lib_ccx/ccx_common_option.c
+++ b/src/lib_ccx/ccx_common_option.c
@@ -41,7 +41,7 @@ void init_options(struct ccx_s_options *options)
 	options->live_stream = 0;     // 0 -> A regular file
 	options->messages_target = 1; // 1=stdout
 	options->print_file_reports = 0;
-	options->timestamp_map = 0; // Disable X-TIMESTAMP-MAP header by default
+	options->timestamp_map = 1; // Enable  X-TIMESTAMP-MAP header by default
 
 	/* Levenshtein's parameters, for string comparison */
 	options->dolevdist = 1;		  // By default attempt to correct typos

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -268,7 +268,8 @@ void print_usage(void)
 	mprint("                       less or equal than the max allowed..\n");
 	mprint("	   --analyzevideo  Analyze the video stream even if it's not used for\n");
 	mprint("                       subtitles. This allows to provide video information.\n");
-	mprint("  --timestamp-map      Enable the X-TIMESTAMP-MAP header for WebVTT (HLS)\n");
+	mprint("  --timestamp-map       Enable X-TIMESTAMP-MAP (default)\n");
+	mprint("  --no-timestamp-map    Disable X-TIMESTAMP-MAP header\n");
 	mprint("Levenshtein distance:\n");
 	mprint("           --no-levdist: Don't attempt to correct typos with Levenshtein distance.\n");
 	mprint(" --levdistmincnt value: Minimum distance we always allow regardless\n");

--- a/src/rust/src/args.rs
+++ b/src/rust/src/args.rs
@@ -425,6 +425,9 @@ pub struct Args {
     /// Enable the X-TIMESTAMP-MAP header for WebVTT (HLS)
     #[arg(long, verbatim_doc_comment, help_heading=OPTIONS_AFFECTING_INPUT_FILES)]
     pub timestamp_map: bool,
+    /// Disable the X-TIMESTAMP-MAP header for WebVTT
+    #[arg(long, verbatim_doc_comment, help_heading=OPTIONS_AFFECTING_INPUT_FILES)]
+    pub no_timestamp_map: bool,
     /// Don't attempt to correct typos with Levenshtein distance.
     #[arg(long, verbatim_doc_comment, help_heading=LEVENSHTEIN_DISTANCE)]
     pub no_levdist: bool,

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -730,7 +730,8 @@ pub unsafe extern "C" fn ccxr_parse_parameters(argc: c_int, argv: *mut *mut c_ch
         &mut _capitalization_list,
         &mut _profane,
     );
-
+    // Default is 1 (Enabled). If user says --no-timestamp-map, force it to false (0).
+    opt.timestamp_map = !args.no_timestamp_map;
     // Handle --list-tracks mode: list tracks and exit early
     if opt.list_tracks_only {
         use std::path::Path;


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

As discussed in the issue, the `X-TIMESTAMP-MAP` header is required for strict HLS compliance but was previously disabled by default, creating invalid WebVTT files unless the user manually added a flag.

This PR makes CCExtractor HLS-compliant out of the box by flipping the default behavior to **Enabled**. To satisfy the requirement for flexibility (for non-HLS use cases), I have also added a `--no-timestamp-map` flag to explicitly disable the header.

### Technical Changes
This implementation bridges the C core and the Rust argument parser:
* **`src/lib_ccx/ccx_common_option.c`**: Changed the default value of `timestamp_map` from `0` to `1`.
* **`src/lib_ccx/params.c`**: Updated the help text to reflect that the header is now default.
* **`src/rust/src/args.rs`**: Added the new `--no-timestamp-map` argument definition.
* **`src/rust/src/lib.rs`**: Added logic to override the default C option when the Rust negative flag is present.

### How to Use / Testing Commands
You can verify the behavior with any TS or MP4 file:

**1. Default Behavior (Header Enabled)**
*Command:*
`./ccextractor input.ts -out=webvtt -o default.vtt`
*Result:* The `X-TIMESTAMP-MAP` header is automatically included.

**2. Disable Header (New Flag)**
*Command:*
`./ccextractor input.ts -out=webvtt --no-timestamp-map -o disabled.vtt`
*Result:* The `X-TIMESTAMP-MAP` header is omitted.

### Evidence of Fix
*(See attached comparison screenshot below)*
<img width="1108" height="718" alt="image" src="https://github.com/user-attachments/assets/f58bcba0-53c2-420f-a240-48c516dd223d" />
