### PR TITLE
Fix Vec::from_raw_parts UB in string_to_c_chars

### DIFF
--- a/src/rust/src/utils.rs
+++ b/src/rust/src/utils.rs
@@ -69,10 +69,11 @@ pub fn null_pointer<T>() -> *mut T {
 use std::os::raw::c_char;
 
 pub fn string_to_c_chars(strs: Vec<String>) -> *mut *mut c_char {
-    let mut c_strs: Vec<*mut c_char> = Vec::new();
+    let mut c_strs: Vec<*mut c_char> = Vec::with_capacity(strs.len());
     for s in strs {
         c_strs.push(string_to_c_char(&s));
     }
+    c_strs.shrink_to_fit();
     let ptr = c_strs.as_mut_ptr();
     std::mem::forget(c_strs);
     ptr


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

### Describtion
Hey! I noticed a small but real UB risk here and wanted to fix it while working around the FFI ownership code.

string_to_c_chars creates a Vec<*mut c_char>, then we later reconstruct it using Vec::from_raw_parts in free_rust_c_string_array. The problem is that from_raw_parts requires the original capacity, not just the length.

If the Vec ever grows with reallocation,len !=capacity, and reconstructing it using only len becomes undefined behavior. This is subtle, but it’s exactly the kind of thing that can blow up later or only on certain platforms.

The fix is intentionally minimal:
I pre-allocate with with_capacity(strs.len()) and call shrink_to_fit() before forgetting the Vec, so we guarantee len ==capacity.

No behavior change, no performance regression , just making the ownership contract explicit and safe.

Since this is FFI boundary code, I felt it was better to make it robust now rather than rely on assumptions that might break later.