### PR TITLE
feat(transcript): Implement dictionary-based capitalization and censorship

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,6 +1,7 @@
 0.96.6 (unreleased)
 -------------------
 - New: Add Snap packaging support with Snapcraft configuration and GitHub Actions CI workflow. 
+- New: Implement dictionary-based capitalization and censorship for transcripts 
 - Fix: Clear status line output on Linux/WSL to prevent text artifacts (#2017)
 - Fix: Prevent infinite loop on truncated MKV files
 - Fix: Various memory safety and stability fixes in demuxers (MP4, PS, MKV, DVB)

--- a/src/lib_ccx/ccx_encoders_transcript.c
+++ b/src/lib_ccx/ccx_encoders_transcript.c
@@ -120,11 +120,8 @@ int write_cc_subtitle_as_transcript(struct cc_subtitle *sub, struct encoder_ctx 
 			start_time = sub->start_time;
 			end_time = sub->end_time;
 		}
-		if (context->sentence_cap)
-		{
-			// TODO capitalize (context, line_number,data);
-			// TODO correct_case_with_dictionary(line_number, data);
-		}
+		if (sub->data)
+			correct_spelling_and_censor_words(context, (unsigned char *)sub->data, strlen((char *)sub->data));
 
 		if (start_time == -1)
 		{


### PR DESCRIPTION
**[FIX]**

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

## Description
closes #2103 
This Pull Request introduces dictionary-based spelling correction and profanity censorship to the transcript encoder (`ccx_encoders_transcript.c`). It leverages the shared `correct_spelling_and_censor_words` helper function to process subtitle text before it is written to the transcript output. This aligns the transcript output quality with other subtitle formats.

## Changes

- **Enhanced Transcript Processing**: In `write_cc_subtitle_as_transcript`, the code now calls `correct_spelling_and_censor_words` to apply capitalization rules and censorship filters defined in the user's configuration.
 - **Improved Robustness**: Added a specific check to ensure sub->data is not NULL before attempting to process or read its length. This prevents potential null pointer dereferences and improves the stability of the application.
- Code Cleanup: Removed legacy placeholder comments and simplified the control flow for applying text corrections.