### PR TITLE
[FIX] Fix incorrect strlen argument for end timestamps in MKV subtitle output

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 0.96.6 (unreleased)
 -------------------
+- Fix: Incorrect strlen argument when writing end timestamps in MKV subtitle extraction (WebVTT, SRT, ASS/SSA)
 - Fix: DVB EIT start time BCD decoding in XMLTV output causing invalid timestamps (#1835)
 - New: Add Snap packaging support with Snapcraft configuration and GitHub Actions CI workflow. 
 - Fix: Clear status line output on Linux/WSL to prevent text artifacts (#2017)

--- a/src/lib_ccx/matroska.c
+++ b/src/lib_ccx/matroska.c
@@ -1795,7 +1795,7 @@ void save_sub_track(struct matroska_ctx *mkv_ctx, struct matroska_sub_track *tra
 
 			write_wrapped(desc, timestamp_start, strlen(timestamp_start));
 			write_wrapped(desc, " --> ", 5);
-			write_wrapped(desc, timestamp_end, strlen(timestamp_start));
+			write_wrapped(desc, timestamp_end, strlen(timestamp_end));
 
 			// writing cue settings list
 			if (blockaddition != NULL)
@@ -1836,7 +1836,7 @@ void save_sub_track(struct matroska_ctx *mkv_ctx, struct matroska_sub_track *tra
 			write_wrapped(desc, "\n", 1);
 			write_wrapped(desc, timestamp_start, strlen(timestamp_start));
 			write_wrapped(desc, " --> ", 5);
-			write_wrapped(desc, timestamp_end, strlen(timestamp_start));
+			write_wrapped(desc, timestamp_end, strlen(timestamp_end));
 			write_wrapped(desc, "\n", 1);
 			int size = 0;
 			while (*(sentence->text + size) == '\n' || *(sentence->text + size) == '\r')
@@ -1866,7 +1866,7 @@ void save_sub_track(struct matroska_ctx *mkv_ctx, struct matroska_sub_track *tra
 			write_wrapped(desc, "Dialogue: Marked=0,", strlen("Dialogue: Marked=0,"));
 			write_wrapped(desc, timestamp_start, strlen(timestamp_start));
 			write_wrapped(desc, ",", 1);
-			write_wrapped(desc, timestamp_end, strlen(timestamp_start));
+			write_wrapped(desc, timestamp_end, strlen(timestamp_end));
 			write_wrapped(desc, ",", 1);
 			char *text = ass_ssa_sentence_erase_read_order(sentence->text);
 			char *text_to_free = text; // Save original pointer for freeing


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [x] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Hey! I was going through the codebase and found a small but real bug in `src/lib_ccx/matroska.c`, in the `save_sub_track()` function.

### The issue

When writing the end timestamp for subtitle output, the code was using `strlen(timestamp_start)` instead of `strlen(timestamp_end)` as the length argument to `write_wrapped()`. This is a copy-paste oversight — the start timestamp line right above it correctly uses `strlen(timestamp_start)` for its own buffer, but when the end timestamp line was written (probably copied from the line above), the `strlen` argument wasn't updated to match.

This affects all three subtitle output formats in MKV extraction:
- **WebVTT** (line 1798)
- **SRT** (line 1839)
- **ASS/SSA** (line 1869)

For example, the SRT path had:
```c
write_wrapped(desc, timestamp_start, strlen(timestamp_start));
write_wrapped(desc, " --> ", 5);
write_wrapped(desc, timestamp_end, strlen(timestamp_start));  // <-- wrong buffer in strlen
```

Should be:
```c
write_wrapped(desc, timestamp_end, strlen(timestamp_end));
```

In practice, the start and end timestamps tend to be the same string length for a given format (e.g., `00:01:23.456` is always 12 chars), so this might not cause visible issues most of the time. But it's still incorrect — if the lengths ever diverge, the output would be silently truncated or could include extra bytes. It's the kind of thing that's easy to miss but worth fixing.

### What I changed
- Fixed all 3 occurrences in `save_sub_track()` to use `strlen(timestamp_end)` when writing `timestamp_end`
- Added an entry to the changelog

Since this is my first PR here, I've tried to go for a simpler issue to start with. I do have more than a year of experience in open source — I was with Open Science Labs at Google Summer of Code last year. Would love any feedback from the maintainers, happy to adjust anything if needed!