### PR TITLE
[FIX] Fix file descriptor leak and missing open() check in save_sub_track()

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 0.96.6 (unreleased)
 -------------------
+- Fix: File descriptor leak and missing open() error check in MKV subtitle track saving
 - Fix: DVB EIT start time BCD decoding in XMLTV output causing invalid timestamps (#1835)
 - New: Add Snap packaging support with Snapcraft configuration and GitHub Actions CI workflow. 
 - Fix: Clear status line output on Linux/WSL to prevent text artifacts (#2017)

--- a/src/lib_ccx/matroska.c
+++ b/src/lib_ccx/matroska.c
@@ -1742,6 +1742,12 @@ void save_sub_track(struct matroska_ctx *mkv_ctx, struct matroska_sub_track *tra
 		free(filename);
 	}
 
+	if (desc < 0)
+	{
+		mprint("\nError: Cannot create output file for subtitle track\n");
+		return;
+	}
+
 	if (track->header != NULL)
 		write_wrapped(desc, track->header, strlen(track->header));
 
@@ -1880,6 +1886,9 @@ void save_sub_track(struct matroska_ctx *mkv_ctx, struct matroska_sub_track *tra
 			free(timestamp_end);
 		}
 	}
+
+	if (desc != 1)
+		close(desc);
 }
 
 void free_sub_track(struct matroska_sub_track *track)


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [x] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Found another issue while reading through `matroska.c` — the `save_sub_track()` function has two file descriptor problems:

### 1. Missing `open()` return value check

After opening the output file (line ~1740), the return value is never checked. If `open()` fails and returns `-1`, the code continues and passes it to `write_wrapped()`, which calls `write()` on an invalid descriptor — that triggers `fatal(1, "writing to file")` with a pretty confusing error message that doesn't tell you what actually went wrong.

### 2. File descriptor never closed

The opened file descriptor `desc` is never closed before the function returns. Every call to `save_sub_track()` leaks a file descriptor. For files with many subtitle tracks, this could add up.

### What I did

Both of these are already handled correctly in `save_vobsub_track()`, literally the function right above `save_sub_track()` in the same file — so I followed the exact same pattern:

- Added `if (desc < 0)` check after the open block, with `mprint` and early `return` (matches lines 1617-1624 in `save_vobsub_track`)
- Added `if (desc != 1) close(desc);` at the end of the function, guarding against closing stdout (matches lines 1699-1700 in `save_vobsub_track`)

The diff is small and only touches what's needed. Would love any feedback!