### PR TITLE
Add notes that sample-platform depends on artifact names

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -42,6 +42,9 @@ jobs:
       run: mkdir ./linux/artifacts
     - name: Copy release artifact
       run: cp ./linux/ccextractor ./linux/artifacts/
+    # NOTE: The sample-platform test runner (CCExtractor/sample-platform)
+    # matches artifact names exactly. Update Artifact_names in
+    # mod_ci/controllers.py there if you rename this artifact.
     - uses: actions/upload-artifact@v6
       with:
         name: CCExtractor Linux build

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -129,6 +129,9 @@ jobs:
         run: ./ccextractorwinfull.exe --version
         working-directory: ./windows/${{ matrix.outdir }}Release-Full
 
+      # NOTE: The sample-platform test runner (CCExtractor/sample-platform)
+      # matches artifact names exactly. Update Artifact_names in
+      # mod_ci/controllers.py there if you rename these artifacts.
       - name: Upload Release artifact
         uses: actions/upload-artifact@v6
         with:


### PR DESCRIPTION
## Summary
- Adds comments to `build_windows.yml` and `build_linux.yml` warning that the sample-platform test runner (`CCExtractor/sample-platform`) does exact string matching on artifact names.
- This prevents a repeat of the issue where renaming artifacts in PR #2119 silently broke Windows CI tests (see CCExtractor/sample-platform#1029).

## Test plan
- [ ] No functional change — comments only

🤖 Generated with [Claude Code](https://claude.com/claude-code)