### PR TITLE
Fix publish workflows: wait for release build to finish

### DIFF
--- a/.github/workflows/publish_chocolatey.yml
+++ b/.github/workflows/publish_chocolatey.yml
@@ -10,8 +10,9 @@
 name: Publish to Chocolatey
 
 on:
-  release:
-    types: [released]
+  workflow_run:
+    workflows: ["Upload releases"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       release_tag:
@@ -22,6 +23,9 @@ on:
 jobs:
   publish:
     runs-on: windows-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -30,7 +34,7 @@ jobs:
         id: version
         shell: bash
         run: |
-          TAG="${{ github.event.inputs.release_tag || github.event.release.tag_name }}"
+          TAG="${{ github.event.inputs.release_tag || github.event.workflow_run.head_branch }}"
           # Strip 'v' prefix if present
           VERSION="${TAG#v}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish_winget.yml
+++ b/.github/workflows/publish_winget.yml
@@ -16,8 +16,9 @@
 name: Publish to WinGet
 
 on:
-  release:
-    types: [released]
+  workflow_run:
+    workflows: ["Upload releases"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       release_tag:
@@ -28,6 +29,9 @@ on:
 jobs:
   publish:
     runs-on: windows-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Publish to WinGet
         uses: vedantmgoyal9/winget-releaser@v2
@@ -35,4 +39,4 @@ jobs:
           identifier: CCExtractor.CCExtractor
           installers-regex: '\.msi$'  # Only use the MSI installer
           token: ${{ secrets.WINGET_TOKEN }}
-          release-tag: ${{ github.event.inputs.release_tag || github.event.release.tag_name }}
+          release-tag: ${{ github.event.inputs.release_tag || github.event.workflow_run.head_branch }}


### PR DESCRIPTION
## Summary
- Chocolatey and WinGet publish workflows previously triggered on `release: [released]`, which fires at the same time as the release build workflow
- Since MSIs take ~45 minutes to build, publish workflows would fail with 404 errors trying to download non-existent MSIs
- Switch both to `workflow_run` trigger so they wait for the "Upload releases" workflow to complete successfully before publishing
- Also verified artifact naming is correct for both x64 (`CCExtractor.<ver>.msi`) and x86 (`CCExtractor.<ver>_x86.msi`)

## Changes
- `publish_chocolatey.yml`: trigger → `workflow_run`, add success check, update tag source
- `publish_winget.yml`: trigger → `workflow_run`, add success check, update tag source

## Test plan
- [ ] After merge, manually trigger both workflows via `workflow_dispatch` with tag `v0.96.6` to publish the already-built release
- [ ] Verify Chocolatey package is submitted successfully
- [ ] Verify WinGet manifest PR is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)