### PR TITLE
Fix WiX installer conditional for x86/x64 directory

### DIFF
--- a/windows/installer.wxs
+++ b/windows/installer.wxs
@@ -40,10 +40,11 @@
         </Component>
     </StandardDirectory>
 		<?if $(sys.BUILDARCH) = x86 ?>
-		<StandardDirectory Id="ProgramFilesFolder">
+		<?define ProgramFilesDir = "ProgramFilesFolder" ?>
 		<?else ?>
-		<StandardDirectory Id="ProgramFiles64Folder">
+		<?define ProgramFilesDir = "ProgramFiles64Folder" ?>
 		<?endif ?>
+		<StandardDirectory Id="$(var.ProgramFilesDir)">
 			<Directory Id="INSTALLFOLDER" Name="CCExtractor">
 				<Directory Id="CCX_tessdata" Name="tessdata"/>
 				<Directory Id="CCX_data" Name="data">


### PR DESCRIPTION
## Summary
- The Win32 support PR introduced a `<?if>`/`<?else?>` around `<StandardDirectory>` opening tags in `installer.wxs`
- WiX parses XML structure before evaluating preprocessor directives, so it saw two opening tags but one closing tag → `WIX0104` error
- Fix: use a `<?define>` variable for the directory ID, keeping valid XML structure
- This is why the v0.96.6 release build failed to produce MSIs

## Test plan
- [ ] After merge, re-run the "Upload releases" workflow for v0.96.6
- [ ] Verify both x64 and x86 MSIs are produced and uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)