### PR TITLE
Fix potential out-of-bounds access in write_stringz_as_srt_to_output

### DIFF
--- a/src/lib_ccx/ccx_encoders_srt.c
+++ b/src/lib_ccx/ccx_encoders_srt.c
@@ -47,7 +47,7 @@ static int write_stringz_as_srt_to_output(char *string, struct encoder_ctx *cont
 	// Scan for \n in the string and replace it with a 0
 	while (pos_r < len)
 	{
-	    if (pos_r < len - 1 && string[pos_r] == '\\' && string[pos_r + 1] == 'n')		
+		if (pos_r < len - 1 && string[pos_r] == '\\' && string[pos_r + 1] == 'n')
 		{
 			unescaped[pos_w] = 0;
 			pos_r += 2;


### PR DESCRIPTION
This PR adds a bound check before accessing string[pos_r + 1] to prevent a potential out-of-bounds read when pos_r == len - 1.
and corrects the iteration boundary when processing the unescaped buffer by using the actual written length (pos_w) instead of the original string length (len)