### PR TITLE
Fix: Add missing SCTE-20 marker bit syntax check (resolves TODO)

### DIFF
--- a/src/lib_ccx/es_userdata.c
+++ b/src/lib_ccx/es_userdata.c
@@ -161,10 +161,16 @@ int user_data(struct encoder_ctx *enc_ctx, struct lib_cc_decode *dec_ctx, struct
 				skip_bits(ustream, 5); // line_offset - unused
 				cc_data1 = (unsigned int)read_bits(ustream, 8);
 				cc_data2 = (unsigned int)read_bits(ustream, 8);
-				read_bits(ustream, 1); // TODO: Add syntax check */
+				unsigned char marker_bit = read_bits(ustream, 1);
 
 				if (ustream->bitsleft < 0)
 					fatal(CCX_COMMON_EXIT_BUG_BUG, "In user_data: ustream->bitsleft < 0. Cannot continue.");
+
+				if (marker_bit == 0)
+				{
+					dbg_print(CCX_DMT_VERBOSE, "user_data: SCTE-20 syntax error - marker bit is 0\n");
+					continue; // Skip processing this corrupted block
+				}
 
 				// Field_number is either
 				//  0 .. forbidden

--- a/src/rust/src/es/userdata.rs
+++ b/src/rust/src/es/userdata.rs
@@ -180,9 +180,13 @@ pub unsafe fn user_data(
                 ustream.skip_bits(5)?; // line_offset - unused
                 let cc_data1 = ustream.read_bits(8)? as u32;
                 let cc_data2 = ustream.read_bits(8)? as u32;
-                ustream.read_bits(1)?; // TODO: Add syntax check */
+                let marker_bit = ustream.read_bits(1)?;
                 if ustream.bits_left < 0 {
                     fatal!(cause = ExitCause::Bug; "In user_data: ustream->bitsleft < 0. Cannot continue.");
+                }
+                if marker_bit == 0 {
+                    debug!(msg_type = DebugMessageFlag::VERBOSE; "user_data: SCTE-20 syntax error - marker bit is 0");
+                    continue; // Skip processing this corrupted block
                 }
 
                 // Field_number is either


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

### Description
This PR resolves an outstanding `TODO: Add syntax check` within the SCTE-20 parsing loop, improving the parser's resilience against corrupted or malformed video streams. 

According to the SCTE-20 broadcast specification, each caption block is encoded in a 26-bit structure (containing priority, field number, line offset, and two bytes of caption data). The specification mandates that this 26-bit sequence must strictly end with a trailing 1-bit, which acts as a synchronization and marker bit.

Previously, the parser read this trailing bit to advance the stream but discarded it without evaluation. If a stream suffered from corruption or misalignment, causing the marker bit to evaluate to `0`, the parser would blindly accept the corrupted `cc_data1` and `cc_data2` payloads, potentially resulting in garbage characters being sent to the subtitle decoder.

### Changes Made
I have synchronized this fix across both the original C codebase and the Rust port to maintain parity.

* **Captured the Marker Bit:** Instead of discarding the final bit of the SCTE-20 block, it is now explicitly stored and evaluated.
* **Added Syntax Validation:** If `marker_bit == 0`, the stream is locally corrupted. The parser now logs a verbose debug warning (`user_data: SCTE-20 syntax error - marker bit is 0`).
* **Safe Error Recovery:** When a `0` is detected, the parser triggers a `continue` to skip processing the current corrupted block. 
* **Zero-State Safety:** Because the `cc_data` array is pre-initialized with zeros at the start of the function (`[0u8; 3 * 31 + 1]`), skipping the block execution safely leaves those specific bytes as `0x00 0x00 0x00`. The caption decoding engine natively recognizes `0x00` as an invalid/empty payload and will safely ignore it without crashing or rendering garbage text.

### Files Modified
* **C Core:** `src/lib_ccx/es_userdata.c`
* **Rust Port:** `src/rust/src/es/userdata.rs`

### Testing
* **Rust:** `cargo check` passes successfully with no warnings.
* **C:** Compiled cleanly without warnings or errors using the Linux `./build` script.
* Confirmed that standard stream parsing continues normally and only malformed blocks trigger the skip condition.
