### PR TITLE
Fix PTS rollover detection using per-stream state instead of shared s…

### DIFF
--- a/src/lib_ccx/ccx_demuxer.c
+++ b/src/lib_ccx/ccx_demuxer.c
@@ -452,6 +452,7 @@ struct demuxer_data *alloc_demuxer_data(void)
 	data->len = 0;
 	data->pts = CCX_NOPTS;
 	data->rollover_bits = 0;
+	data->prev_pts_33 = 0;
 	data->tb.num = 1;
 	data->tb.den = 90000;
 	data->next_stream = 0;

--- a/src/lib_ccx/ccx_demuxer.h
+++ b/src/lib_ccx/ccx_demuxer.h
@@ -174,6 +174,7 @@ struct demuxer_data
 	unsigned char *buffer;
 	size_t len;
 	unsigned int rollover_bits; // The PTS rolls over every 26 hours and that can happen in the middle of a stream.
+	LLONG prev_pts_33;          // Previous 33-bit PTS for this stream's rollover detection (per-stream, not shared)
 	LLONG pts;
 	struct ccx_rational tb;
 	struct demuxer_data *next_stream;

--- a/src/lib_ccx/stream_functions.c
+++ b/src/lib_ccx/stream_functions.c
@@ -297,7 +297,6 @@ int read_video_pes_header(struct ccx_demuxer *ctx, struct demuxer_data *data, un
 	long long result;
 	unsigned peslen = nextheader[4] << 8 | nextheader[5];
 	unsigned payloadlength = 0;	 // Length of packet data bytes
-	static LLONG current_pts_33 = 0; // Last PTS from the header, without rollover bits
 
 	if (!sbuflen)
 	{
@@ -437,14 +436,14 @@ int read_video_pes_header(struct ccx_demuxer *ctx, struct demuxer_data *data, un
 
 		if (data->pts != CCX_NOPTS) // Otherwise can't check for rollovers yet
 		{
-			if (!bits_9 && ((current_pts_33 >> 30) & 7) == 7) // PTS about to rollover
+			if (!bits_9 && ((data->prev_pts_33 >> 30) & 7) == 7) // PTS about to rollover
 				data->rollover_bits++;
-			if ((bits_9 >> 30) == 7 && ((current_pts_33 >> 30) & 7) == 0) // PTS rollback? Rare and if happens it would mean out of order frames
+			if ((bits_9 >> 30) == 7 && ((data->prev_pts_33 >> 30) & 7) == 0) // PTS rollback? Rare and if happens it would mean out of order frames
 				data->rollover_bits--;
 		}
 
-		current_pts_33 = bits_9 | bits_10 | bits_11 | bits_12 | bits_13;
-		data->pts = (LLONG)data->rollover_bits << 33 | current_pts_33;
+		data->prev_pts_33 = bits_9 | bits_10 | bits_11 | bits_12 | bits_13;
+		data->pts = (LLONG)data->rollover_bits << 33 | data->prev_pts_33;
 
 		/* The user data holding the captions seems to come between GOP and
 		 * the first frame. The sync PTS (sync_pts) (set at picture 0)


### PR DESCRIPTION
[FIX] Fix PTS rollover detection using per-stream state instead of shared static

**In raising this pull request, I confirm the following:**
- [x] I have read and understood the [[contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md)](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [[changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT)](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**
- [ ] I have never used CCExtractor.
- [x] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

`read_video_pes_header()` used a `static` local variable (`current_pts_33`) to track the previous PTS for rollover detection. Since it's static, it was shared across all PIDs and across all input files in a batch run.

When file 1 ends with a high PTS (top bits = 7) and file 2 starts fresh with a low PTS, the rollover detector incorrectly treats this as a legitimate wrap and increments `rollover_bits`. Every subtitle in file 2 then gets its timestamp shifted forward by ~26.5 hours. CCExtractor exits 0, the output file looks valid, but all timestamps are completely wrong.

Fixed by moving `current_pts_33` into `demuxer_data` as `prev_pts_33` so each stream independently tracks its own previous PTS. 3 files, 5 lines changed. No logic changes.