### PR TITLE
fix: use absolute paths in bframe_pts regression test script

### DIFF
--- a/tests/regression/bframe_pts/run_test.sh
+++ b/tests/regression/bframe_pts/run_test.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CCX="$SCRIPT_DIR/../../../mac/ccextractor"
+SAMPLE="$SCRIPT_DIR/bframe_pts_regression_small.ts"
+EXPECTED="$SCRIPT_DIR/bframe_pts_expected.srt"
+OUTPUT="$SCRIPT_DIR/out.srt"
+
+$CCX $SAMPLE -o $OUTPUT > /dev/null 2>&1
+
+diff $EXPECTED $OUTPUT > /dev/null 2>&1
+
+if [ $? -eq 0 ]; then
+    echo "PASS"
+    exit 0
+else
+    echo "FAIL"
+    exit 1
+fi


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

{pull request content here}
The test script used a relative path ../../mac/ccextractor which only worked when run from a specific directory. Fixed by using $SCRIPT_DIR to construct absolute paths so the script works correctly from any location.