### PR TITLE
Fix configuration file parsing bugs and typos

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -26,6 +26,11 @@
 - Fix: Spurious numbers printed to console during processing
 - Fix: Heap overflow in Transport Stream PAT/PMT parsing (security fix)
 - Fix: Various memory safety and stability fixes in demuxers (MP4, PS, MKV, DVB)
+- Fix: Configuration file parser bugs — heap buffer overflow on long lines, broken EOF
+  detection due to incorrect fgetc() return type, and last line dropped if file lacks
+  trailing newline
+- Fix: Typos in configuration keys: FIX_PADDINDG → FIX_PADDING,
+  INVASTIGATE_PACKET → INVESTIGATE_PACKET
 
 0.96.5 (2026-01-05)
 -------------------


### PR DESCRIPTION
## Summary
- Fix heap buffer overflow in `parse_file()` — 128-byte buffer written with no bounds check on long config lines
- Fix broken EOF detection — `fgetc()` return stored in `char` instead of `int`, causing infinite loop on unsigned-char platforms or premature EOF on `0xFF` bytes
- Fix missing NULL check after `malloc(128)` — immediate dereference on allocation failure
- Fix missing null-terminator on accumulated string buffer
- Fix last config line silently dropped if file lacks trailing newline
- Fix typos in `configuration_map[]`: `FIX_PADDINDG` → `FIX_PADDING`, `INVASTIGATE_PACKET` → `INVESTIGATE_PACKET`

## Test plan
- [ ] Build the project and verify no compilation errors
- [ ] Create a test `ccextractor.cnf` with a line longer than 127 chars (should be truncated, not overflow)
- [ ] Create a test config file not ending with `\n` (last line should be parsed)
- [ ] Verify corrected key names `FIX_PADDING` and `INVESTIGATE_PACKET` are recognized