### PR TITLE
Feat(rust): Implement base SubtitleEncoder trait and plug in g608 sink

### DIFF
--- a/src/rust/src/encoder/mod.rs
+++ b/src/rust/src/encoder/mod.rs
@@ -55,14 +55,13 @@ pub unsafe fn ccxr_get_str_basic(
     result
 }
 use crate::bindings::{eia608_screen, encoder_ctx};
-use std::os::raw::c_int;
 
 /// The foundational trait defining what any subtitle encoder must implement.
 /// This provides a clean API for the parser to send data to the encoder.
 pub trait SubtitleEncoder {
     /// Processes a CEA-608 screen and routes it to the correct output sink.
     fn encode_g608(&mut self, data: &eia608_screen) -> c_int;
-    
+
     // TODO (GSoC): Add `encode_708`, `encode_teletext`, etc., as the port progresses.
 }
 


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---
# Description: Wiring the Rust Encoder Base Architecture

This PR introduces the foundational object-oriented architecture for the Rust encoder module, addressing the missing pipeline connection for the `g608` output sink.

## 1. What We Changed

- **Defined the `SubtitleEncoder` Trait:** Created a new public trait in `src/rust/src/encoder/mod.rs` to serve as the standard contract for all future subtitle encoders. It currently defines `encode_g608`.
- **Created the `CoreEncoder` Struct:** Implemented a base struct that uses Rust lifetimes (`<'a>`) to safely hold a mutable reference to the legacy C `encoder_ctx`.
- **Wired the `g608` Engine:** Implemented the `SubtitleEncoder` trait for `CoreEncoder`. Inside the `encode_g608` method, we finally plugged in the `crate::encoder::g608::write_cc_buffer_as_g608` function, which was previously defined but never called in the execution pipeline.

## 2. Why We Made These Changes

- **Fixing the "Unplugged" State:** As discussed with the maintainers, the Rust `g608.rs` file was essentially dead code because the encoder module lacked a "base struct to stand on." This PR builds that structural foundation so the parser actually has a place to send the data.
- **Idiomatic Rust Design:** Instead of freely passing around a massive, messy C-style memory block (`encoder_ctx`) throughout the Rust codebase, this architecture introduces a clean, scalable trait.
- **Safe C-Bindings:** By wrapping the C context inside a native Rust struct with explicit lifetimes, we create a memory-safe boundary between the legacy pipeline and the new Rust components.

## 3. Future Goals & The GSoC Roadmap

This PR is **Step 1** of a larger architectural overhaul for my GSoC 2026 proposal (*"Add Japanese Support"*).

- **Immediate Future:** Expand the `SubtitleEncoder` trait to support `encode_708` and `encode_teletext`, eventually replacing the C `encoder_ctx` entirely with a pure-Rust state management system.
- **GSoC Goal (Phase 1):** Now that the WebVTT/g608 engine is actually wired to receive data, the next goal is to rip out the legacy pseudo-SRT timestamp formatting and replace it with a mathematical Grid-to-Fluid WebVTT positioning engine.
- **GSoC Goal (Phase 2):** Utilize this new encoder pipeline to parse and inject advanced IMSC/WebVTT layout tags (like `vertical:rl` and `line:xx%`) required to render vertical Japanese broadcast text.

{pull request content here}
