### PR TITLE
[FIX] Use dynamic current_fps instead of hardcoded 29.97 in SCC timecodes

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -6,6 +6,7 @@
 -------------------
 - Fix: Prevent startup OOM on 32-bit (x86) Windows by lazily allocating CEA-708 service decoders and adding proper alloc error handling.
 - New: Add 23.98fps as valid --scc-framerate value; clarify help text covers input and output (#2147)
+- Fix: Use dynamic current_fps instead of hardcoded 29.97 in SCC timecode generation across C and Rust (#2145)
 - FIX: spupng start numbering at sub0000, avoid index advance on empty EOD, normalize header filename
 - New: 32-bit (x86) Windows build and installer (#2116)
 - New: Add optional machine-readable JSON output for -out=report via --report-format json

--- a/src/lib_ccx/ccx_common_timing.c
+++ b/src/lib_ccx/ccx_common_timing.c
@@ -19,7 +19,7 @@ unsigned pts_big_change;
 
 // PTS timing related stuff
 
-double current_fps = (double)30000.0 / 1001; /* 29.97 */ // TODO: Get from framerates_values[] instead
+double current_fps = (double)30000.0 / 1001; /* 29.97 — default, updated at runtime from stream NAL data */
 
 int frames_since_ref_time = 0;
 unsigned total_frames_count;

--- a/src/lib_ccx/ccx_common_timing.c
+++ b/src/lib_ccx/ccx_common_timing.c
@@ -122,7 +122,7 @@ size_t print_scc_time(struct ccx_boundary_time time, char *buf)
 	// Format produces "HH:MM:SS;FF" = 11 chars + null, use 32 for safety
 	const size_t max_time_len = 32;
 
-	frame = ((double)(time.time_in_ms - 1000 * (time.ss + 60 * (time.mm + 60 * time.hh))) * 29.97 / 1000);
+	frame = ((double)(time.time_in_ms - 1000 * (time.ss + 60 * (time.mm + 60 * time.hh))) * current_fps / 1000);
 
 	return (size_t)snprintf(buf + time.set, max_time_len, fmt, time.hh, time.mm, time.ss, (unsigned)frame);
 }

--- a/src/rust/lib_ccxr/src/time/units.rs
+++ b/src/rust/lib_ccxr/src/time/units.rs
@@ -390,11 +390,11 @@ impl Timestamp {
     }
 
     /// SCC time formatting
-    pub fn to_scc_time(&self) -> Result<String, TimestampError> {
+    pub fn to_scc_time(&self, fps: f64) -> Result<String, TimestampError> {
         let mut result = String::new();
 
         let (h, m, s, _) = self.as_hms_millis()?;
-        let frame = (self.millis - 1000 * (s + 60 * (m + 60 * h)) as i64) as f64 * 29.97 / 1000.0;
+        let frame = (self.millis - 1000 * (s + 60 * (m + 60 * h)) as i64) as f64 * fps / 1000.0;
 
         write!(result, "{h:02}:{m:02}:{s:02};{frame:02}")?;
 

--- a/src/rust/src/decoder/timing.rs
+++ b/src/rust/src/decoder/timing.rs
@@ -88,10 +88,11 @@ impl PartialEq for ccx_boundary_time {
 /// Returns a hh:mm:ss;frame string of time for SCC format
 pub fn get_scc_time_str(time: ccx_boundary_time) -> String {
     // Feel sorry for formatting:(
+    let fps = unsafe { crate::current_fps };
     let frame: u8 = (((time.time_in_ms
         - 1000 * ((time.ss as i64) + 60 * ((time.mm as i64) + 60 * (time.hh as i64))))
         as f64)
-        * 29.97
+        * fps
         / 1000.0) as u8;
     format!("{:02}:{:02}:{:02};{:02}", time.hh, time.mm, time.ss, frame)
 }


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

## Summary

The `print_scc_time()` function in `ccx_common_timing.c` and its Rust equivalents (`get_scc_time_str` in `timing.rs`, `to_scc_time` in `units.rs`) were computing SCC timecode frame numbers using a hardcoded `29.97`, ignoring the `current_fps` global that is dynamically updated from stream NAL data at runtime.

## Fix

Replaced the hardcoded `29.97` with `current_fps` across both C and Rust so that SCC output uses the correct frame rate for the source material.

## Changes

- `src/lib_ccx/ccx_common_timing.c` — removed stale TODO comment on `current_fps` initialization
- `src/rust/src/decoder/timing.rs` — `get_scc_time_str` now reads `crate::current_fps` instead of `29.97`
- `src/rust/lib_ccxr/src/time/units.rs` — `to_scc_time` now accepts `fps: f64` parameter instead of hardcoding `29.97`
- `docs/CHANGES.TXT` — added changelog entry

## Impact

- **Before**: All non-NTSC sources (24fps, 25fps, 30fps) produced SCC timecodes with incorrect frame numbers
- **After**: Frame numbers are now accurate for all frame rates

## CI Notes

The Linux regression tests (`General`, `Options`, `DVB` suites) show failures because the byte-for-byte golden baselines were generated with the old hardcoded `29.97` logic. The corrected frame calculations produce different (correct) output for non-NTSC sources, so the baselines will need to be refreshed.

Fixes #2145
