### PR TITLE
[FIX] Prevent MSVC cross-CRT invalid free on output_filename

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,6 +1,7 @@
 0.96.7 (unreleased)
 -------------------
 - Fix: Prevent crash in Rust timing module when logging out-of-range PTS/FTS timestamps from malformed streams.
+- Fix: Resolve Windows MSVC debug build crash caused by cross-CRT invalid free on Rust-allocated output_filename (#2126)
 
 0.96.6 (2026-02-19)
 -------------------

--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -1102,19 +1102,20 @@ void segment_output_file(struct lib_ccx_ctx *ctx, struct lib_cc_decode *dec_ctx)
 			ctx->segment_counter++;
 			if (enc_ctx)
 			{
+				struct encoder_cfg local_cfg = ccx_options.enc_cfg;
 				// list_del(&enc_ctx->list);
 				// dinit_encoder(&enc_ctx, t);
-				const char *extension = get_file_extension(ccx_options.enc_cfg.write_format);
+				const char *extension = get_file_extension(local_cfg.write_format);
 				// Format: "%s_%06d%s" needs: basefilename + '_' + up to 10 digits + extension + null
 				size_t needed_len = strlen(ctx->basefilename) + 1 + 10 + strlen(extension) + 1;
-				freep(&ccx_options.enc_cfg.output_filename);
-				ccx_options.enc_cfg.output_filename = malloc(needed_len);
-				if (!ccx_options.enc_cfg.output_filename)
+				local_cfg.output_filename = malloc(needed_len);
+				if (!local_cfg.output_filename)
 				{
 					fatal(EXIT_NOT_ENOUGH_MEMORY, "In segment handling: Out of memory allocating output filename.");
 				}
-				snprintf(ccx_options.enc_cfg.output_filename, needed_len, "%s_%06d%s", ctx->basefilename, ctx->segment_counter + 1, extension);
-				reset_output_ctx(enc_ctx, &ccx_options.enc_cfg);
+				snprintf(local_cfg.output_filename, needed_len, "%s_%06d%s", ctx->basefilename, ctx->segment_counter + 1, extension);
+				reset_output_ctx(enc_ctx, &local_cfg);
+				freep(&local_cfg.output_filename);
 			}
 		}
 	}


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [x] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

## Summary

Resolves the Windows MSVC Debug build crash reported in #2126. The root cause was a cross-CRT boundary bug: `ccx_options.enc_cfg.output_filename` is allocated by Rust (`CString::into_raw`), but C code was calling `freep()` on it — triggering the MSVC Debug allocator's invalid-free assertion.

## Fix

`update_encoder_list_cinfo()` and `segment_output_file()` now work with a local copy (`struct encoder_cfg local_cfg`) for dynamic multi-program file allocations, keeping the global Rust-allocated pointer untouched. The crash-inducing `freep()` call in `dinit_libraries()` was also removed.

## Changes

- `src/lib_ccx/general_loop.c` — use local `encoder_cfg` copy for multi-program output
- `src/lib_ccx/lib_ccx.c` — remove invalid `freep()` on Rust-allocated string, fix cleanup path
- `docs/CHANGES.TXT` — added changelog entry

## CI Notes

The 9 Linux sample platform failures (`--autoprogram`, `--out=spupng`, `--startcredits` tests) are pre-existing on upstream master and unrelated to this PR. The Windows sample platform confirms all 237/237 tests pass and this PR actually fixes those same 9 tests on Windows.

Fixes #2126
