### PR TITLE
test(dtvcc): add lazy decoder allocation lifecycle test

### DIFF
--- a/src/rust/src/decoder/mod.rs
+++ b/src/rust/src/decoder/mod.rs
@@ -860,7 +860,11 @@ pub mod test {
 
         // Verify: no decoders allocated at startup
         for i in 0..DTVCC_MAX_SERVICES {
-            assert!(dtvcc.decoders[i].is_none(), "decoder[{}] should be None before any data", i);
+            assert!(
+                dtvcc.decoders[i].is_none(),
+                "decoder[{}] should be None before any data",
+                i
+            );
         }
 
         // Build a minimal CEA-708 packet targeting service 1:
@@ -875,7 +879,10 @@ pub mod test {
         dtvcc.process_cc_data(1, 2, 0x00, 0x00); // packet complete: 4 bytes → triggers processing
 
         // After processing, decoder for service 1 (index 0) must be lazily allocated
-        assert!(dtvcc.decoders[0].is_some(), "decoder[0] should be allocated after receiving service 1 data");
+        assert!(
+            dtvcc.decoders[0].is_some(),
+            "decoder[0] should be allocated after receiving service 1 data"
+        );
 
         // Verify the allocated decoder's tv_screen has the correct service number
         let decoder = dtvcc.decoders[0].as_ref().unwrap();
@@ -885,7 +892,11 @@ pub mod test {
 
         // Other decoders should still be None (no data sent to them)
         for i in 1..DTVCC_MAX_SERVICES {
-            assert!(dtvcc.decoders[i].is_none(), "decoder[{}] should still be None", i);
+            assert!(
+                dtvcc.decoders[i].is_none(),
+                "decoder[{}] should still be None",
+                i
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds a test verifying the lazy allocation lifecycle introduced in #2151
- Confirms all CEA-708 service decoders start as `None` (no eager allocation)
- Sends a valid CEA-708 packet for service 1 and verifies the decoder is allocated on first use
- Checks `tv_screen.service_number` is correctly initialized
- Confirms all other service decoders remain unallocated

## Test plan
- [x] `cargo test test_dtvcc_lazy_decoder_allocation` passes
- [x] No compiler warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)