### PR TITLE
fix(report): NULL guard and deduplicate call in teletext JSON report

### DIFF
--- a/src/lib_ccx/params_dump.c
+++ b/src/lib_ccx/params_dump.c
@@ -523,9 +523,9 @@ void print_file_report_json(struct lib_ccx_ctx *ctx)
 		printf("      },\n");
 
 		/* Teletext seen pages */
-		if (program_ci && get_sib_stream_by_type(program_ci, CCX_CODEC_TELETEXT))
+		struct cap_info *tlt_info = program_ci ? get_sib_stream_by_type(program_ci, CCX_CODEC_TELETEXT) : NULL;
+		if (tlt_info)
 		{
-			struct cap_info *tlt_info = get_sib_stream_by_type(program_ci, CCX_CODEC_TELETEXT);
 			struct lib_cc_decode *tlt_dec = update_decoder_list_cinfo(ctx, tlt_info);
 			if (tlt_dec && tlt_dec->codec == CCX_CODEC_TELETEXT)
 			{

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -1369,6 +1369,11 @@ int tlt_print_seen_pages_json(struct lib_cc_decode *dec_ctx)
 	}
 
 	ctx = dec_ctx->private_data;
+	if (!ctx)
+	{
+		printf("[]");
+		return CCX_OK;
+	}
 
 	printf("[");
 	int first = 1;


### PR DESCRIPTION
## Summary
Follow-up to #2137 — fixes two minor issues:

- Add NULL check on `private_data` in `tlt_print_seen_pages_json` to prevent potential segfault if teletext context is not initialized
- Remove duplicate `get_sib_stream_by_type(program_ci, CCX_CODEC_TELETEXT)` call in `print_file_report_json` — was called once in the `if` condition and again to assign `tlt_info`

## Test plan
- [x] Teletext sample produces identical JSON output (pages 888, 889, 890, 891)
- [x] Non-teletext sample unaffected (no `teletext_pages` field)
- [x] Builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)