### PR TITLE
cmake: guard Unix-only linker flags on non-Windows platforms

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -157,7 +157,10 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
 
-set (EXTRA_LIBS ${EXTRA_LIBS} -lm -lpthread -ldl)
+# Unix-specific system libraries (not available on Windows)
+if(NOT WIN32)
+    set (EXTRA_LIBS ${EXTRA_LIBS} -lm -lpthread -ldl)
+endif()
 
 find_package (PkgConfig)
 


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

{pull request content here}
This PR guards Unix-only linker flags (-lm, -lpthread, -ldl) so they are not
applied on Windows builds.

These libraries do not exist on Windows, and unguarded usage can cause
linker warnings or failures depending on the toolchain.

This change is platform-scoped, CI-safe, and does not modify CRT strategy,
dependency resolution, or build pipelines.


Requested by maintainer feedback in #2143.