### PR TITLE
[BUG FIX] Add NULL check for fopen return value in process_hex()

### DIFF
--- a/src/lib_ccx/general_loop.c
+++ b/src/lib_ccx/general_loop.c
@@ -368,6 +368,12 @@ void process_hex(struct lib_ccx_ctx *ctx, char *filename)
 	}
 	/* const char *mpeg_header="00 00 01 b2 43 43 01 f8 "; // Always present */
 	FILE *fr = fopen(filename, "rt");
+	if (!fr)
+	{
+		mprint("Error: Could not open hex file %s\n", filename);
+		free(line);
+		return;
+	}
 	unsigned char *bytes = NULL;
 	unsigned byte_count = 0;
 	int warning_shown = 0;


### PR DESCRIPTION
## Summary
In process_hex() in src/lib_ccx/general_loop.c, fopen() was called without checking if the returned FILE pointer is NULL. If the file cannot be opened, the subsequent fgets() call would crash with a NULL pointer dereference.

## Changes
- src/lib_ccx/general_loop.c — added NULL check after fopen(), prints an error message and returns early if the file cannot be opened.

## Testing
Manually verified the fix compiles cleanly.