### PR TITLE
FIX: Flush pending EIT sections in EPG_free() before freeing buffers

### DIFF
--- a/src/lib_ccx/ts_tables_epg.c
+++ b/src/lib_ccx/ts_tables_epg.c
@@ -1630,6 +1630,24 @@ void EPG_free(struct lib_ccx_ctx *ctx)
 {
 	if (ctx->epg_inited)
 	{
+		// Flush any pending EIT sections not triggered by a subsequent
+		// payload_start_indicator packet (e.g. last section in stream)
+		for (int i = 0; i <= 0xfff; i++)
+		{
+			if (ctx->epg_buffers[i].buffer != NULL && ctx->epg_buffers[i].ccounter > 0)
+			{
+				if (ctx->epg_buffers[i].buffer_length > 0)
+				{
+					unsigned char pointer_field = (unsigned char)ctx->epg_buffers[i].buffer[0];
+					if ((size_t)pointer_field + 1 < (size_t)ctx->epg_buffers[i].buffer_length)
+					{
+						EPG_parse_table(ctx, ctx->epg_buffers[i].buffer, ctx->epg_buffers[i].buffer_length);
+					}
+				}
+				free(ctx->epg_buffers[i].buffer);
+				ctx->epg_buffers[i].buffer = NULL;
+			}
+		}
 		if (ccx_options.xmltv == 2 || ccx_options.xmltv == 3 || ccx_options.send_to_srv)
 		{
 			if (ccx_options.send_to_srv)


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**
- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**
- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

## Summary

Fixes #2165 — the last EIT section in any stream was silently discarded.

## Root Cause

`parse_EPG_packet()` accumulates TS packets into `epg_buffers[]` and only
calls `EPG_parse_table()` when a new section starts (`payload_start_indicator=1`).
This means the **last accumulated section is never parsed** — there is no
following packet to trigger the flush.

`EPG_free()` then freed the buffers without processing them, silently
discarding the last EIT section in every stream.

## Fix

`EPG_free()` now iterates over all `epg_buffers` slots before freeing and
flushes any with `ccounter > 0`:
```c
// Flush any pending EIT sections not triggered by a subsequent
// payload_start_indicator packet (e.g. last section in stream)
for (int i = 0; i <= 0xfff; i++)
{
    if (ctx->epg_buffers[i].buffer != NULL && ctx->epg_buffers[i].ccounter > 0)
    {
        EPG_parse_table(ctx, ctx->epg_buffers[i].buffer, ctx->epg_buffers[i].buffer_length);
        free(ctx->epg_buffers[i].buffer);
        ctx->epg_buffers[i].buffer = NULL;
    }
}
```

## Impact

- Fixes missing EPG/XMLTV data for the last program entry in streams
- Particularly impactful for short streams or streams with few EIT sections
  where the last section represents a significant portion of the EPG data

## Testing

Built and verified locally on macOS. All existing CI tests pass.

Fixes #2165