### PR TITLE
[FIX] Remove unconditional VBI_DEBUG define — add CMake option for opt-in debug builds

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 0.96.7 (unreleased)
 -------------------
+- Fix: Remove unconditional VBI_DEBUG define — add CMake option -DVBI_DEBUG=ON for opt-in debug builds (#2167)
 - Fix: Remove strdup() memory leaks in WebVTT styling encoder, fix invalid CSS rgba(0,256,0) green value, fix missing free(unescaped) on write-error path (#2154)
 - Fix: Prevent crash in Rust timing module when logging out-of-range PTS/FTS timestamps from malformed streams.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required (VERSION 3.24.0)
 project (CCExtractor)
-
 include (CTest)
 
 option (WITH_FFMPEG "Build using FFmpeg demuxer and decoder" OFF)
 option (WITH_OCR "Build with OCR (Optical Character Recognition) feature" OFF)
 option (WITH_HARDSUBX "Build with support for burned-in subtitles" OFF)
+option (VBI_DEBUG "Enable VBI decoder debug output" OFF)
 
 # Version number
 set (CCEXTRACTOR_VERSION_MAJOR 0)
@@ -145,6 +145,11 @@ else (MSVC)
 endif(MSVC)
 
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_FILE_OFFSET_BITS=64")
+
+if (VBI_DEBUG)
+  add_definitions(-DVBI_DEBUG)
+  message(STATUS "VBI debug output enabled")
+endif (VBI_DEBUG)
 add_subdirectory (lib_ccx)
 
 aux_source_directory(${PROJECT_SOURCE_DIR} SOURCEFILE)
@@ -242,6 +247,7 @@ if (PKG_CONFIG_FOUND AND WITH_HARDSUBX)
   set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${TESSERACT_INCLUDE_DIRS})
   set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${LEPTONICA_INCLUDE_DIRS})
 endif (PKG_CONFIG_FOUND AND WITH_HARDSUBX)
+
 
 add_executable (ccextractor ${SOURCEFILE} ${FREETYPE_SOURCE} ${UTF8PROC_SOURCE})
 

--- a/src/lib_ccx/ccx_decoders_vbi.h
+++ b/src/lib_ccx/ccx_decoders_vbi.h
@@ -2,7 +2,6 @@
 #define CCX_DECODER_VBI
 
 #include "zvbi/zvbi_decoder.h"
-#define VBI_DEBUG
 
 #include "ccx_decoders_structs.h"
 #include "ccx_decoders_common.h"
@@ -11,6 +10,8 @@ struct ccx_decoder_vbi_cfg
 {
 #ifdef VBI_DEBUG
 	char *debug_file_name;
+#else
+	int reserved; /* ensure non-empty struct in non-debug builds (MSVC C2016) */
 #endif
 };
 


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**
- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**
- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

## Summary

Fixes #2167 — `VBI_DEBUG` was unconditionally defined in `ccx_decoders_vbi.h`,
causing debug-only struct fields and code paths to always be compiled into
production builds.

## Root Cause
```c
// ccx_decoders_vbi.h:4 — before this fix
#define VBI_DEBUG   // ← always defined
```

This caused `debug_file_name` and `vbi_debug_dump` fields to be present in
every build of `ccx_decoder_vbi_cfg` and `ccx_decoder_vbi_ctx`, regardless
of whether debug output was needed.

## Fix

Removed the unconditional `#define VBI_DEBUG` from the header and added a
proper CMake option consistent with how other debug flags work in the project:
```cmake
option (VBI_DEBUG "Enable VBI decoder debug output" OFF)

if (VBI_DEBUG)
  add_definitions(-DVBI_DEBUG)
  message(STATUS "VBI debug output enabled")
endif (VBI_DEBUG)
```

Developers who need VBI debug output can now opt in explicitly:
```bash
cmake .. -DVBI_DEBUG=ON
```

## Comparison

Other debug flags in the codebase (`WTV_DEBUG`, `DEBUG_SAVE_TS_PACKETS`) are
never unconditionally defined — they require explicit opt-in. This fix brings
`VBI_DEBUG` in line with that pattern.

## Testing

Built and verified locally on macOS with both `VBI_DEBUG=OFF` (default)
and `VBI_DEBUG=ON`. All existing CI tests pass.

Fixes #2167