### PR TITLE
fix(matroska): add NULL check for strdup return value

### DIFF
--- a/src/lib_ccx/matroska.c
+++ b/src/lib_ccx/matroska.c
@@ -880,6 +880,8 @@ void parse_segment_track_entry(struct matroska_ctx *mkv_ctx)
 	ULLONG track_number = 0;
 	enum matroska_track_entry_type track_type = MATROSKA_TRACK_TYPE_VIDEO;
 	char *lang = strdup("eng");
+	if (lang == NULL)
+		fatal(EXIT_NOT_ENOUGH_MEMORY, "In parse_segment_track_entry: Out of memory allocating lang.");
 	char *header = NULL;
 	char *lang_ietf = NULL;
 	char *codec_id_string = NULL;
@@ -1045,6 +1047,8 @@ void parse_segment_track_entry(struct matroska_ctx *mkv_ctx)
 					if (lang == NULL)
 					{
 						lang = strdup("eng");
+						if (lang == NULL)
+							fatal(EXIT_NOT_ENOUGH_MEMORY, "In parse_segment_track_entry: Out of memory allocating lang.");
 					}
 				}
 				else


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

{pull request content here}
