### PR TITLE
[FIX] Use dynamic current_fps in CEA-708 SCC frame delay calculations

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -4,6 +4,7 @@
 - Fix: Remove strdup() memory leaks in WebVTT styling encoder, fix invalid CSS rgba(0,256,0) green value, fix missing free(unescaped) on write-error path (#2154)
 - Fix: Prevent crash in Rust timing module when logging out-of-range PTS/FTS timestamps from malformed streams.
 - Fix: Resolve Windows MSVC debug build crash caused by cross-CRT invalid free on Rust-allocated output_filename (#2126)
+- Fix: Use dynamic current_fps instead of hardcoded 29.97 in CEA-708 SCC frame delay calculations (#2172)
 
 0.96.6 (2026-02-19)
 -------------------

--- a/src/lib_ccx/ccx_decoders_708_output.c
+++ b/src/lib_ccx/ccx_decoders_708_output.c
@@ -550,11 +550,11 @@ void dtvcc_write_scc(dtvcc_writer_ctx *writer, dtvcc_service_decoder *decoder, s
 	if (tv->old_cc_time_end > time_show.time_in_ms)
 	{
 		// Correct the frame delay
-		time_show.time_in_ms -= 1000 / 29.97;
+		time_show.time_in_ms -= 1000 / current_fps;
 		print_scc_time(time_show, buf);
 		buf_len = strlen(buf);
 		SCC_SNPRINTF("\t942c 942c");
-		time_show.time_in_ms += 1000 / 29.97;
+		time_show.time_in_ms += 1000 / current_fps;
 		// Clear the buffer and start pop on caption
 		SCC_SNPRINTF("94ae 94ae 9420 9420");
 	}
@@ -566,20 +566,20 @@ void dtvcc_write_scc(dtvcc_writer_ctx *writer, dtvcc_service_decoder *decoder, s
 		buf_len = strlen(buf);
 		SCC_SNPRINTF("\t942c 942c \n\n");
 		// Correct the frame delay
-		time_show.time_in_ms -= 1000 / 29.97;
+		time_show.time_in_ms -= 1000 / current_fps;
 		// Clear the buffer and start pop on caption in new time
 		print_scc_time(time_show, buf + buf_len);
 		buf_len = strlen(buf);
 		SCC_SNPRINTF("\t94ae 94ae 9420 9420");
-		time_show.time_in_ms += 1000 / 29.97;
+		time_show.time_in_ms += 1000 / current_fps;
 	}
 	else
 	{
-		time_show.time_in_ms -= 1000 / 29.97;
+		time_show.time_in_ms -= 1000 / current_fps;
 		print_scc_time(time_show, buf);
 		buf_len = strlen(buf);
 		SCC_SNPRINTF("\t942c 942c 94ae 94ae 9420 9420");
-		time_show.time_in_ms += 1000 / 29.97;
+		time_show.time_in_ms += 1000 / current_fps;
 	}
 
 	int total_subtitle_count = count_captions_lines_scc(tv);


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

## Summary

`dtvcc_write_scc()` in `ccx_decoders_708_output.c` uses hardcoded `1000 / 29.97` in 6 places to calculate frame delay offsets for CEA-708 SCC output. This causes incorrect subtitle timing on non-NTSC streams (25fps PAL, 23.976 film, 24fps, etc.).

This is the same class of bug fixed for CEA-608 in #2146, but in the CEA-708 (DTVCC) output path.

## Fix

Replaced all 6 instances of `1000 / 29.97` with `1000 / current_fps`. The `current_fps` global is already accessible via the existing include chain — no new headers needed.

## Changes

- `src/lib_ccx/ccx_decoders_708_output.c` — 6 lines changed in `dtvcc_write_scc()`
- `docs/CHANGES.TXT` — added changelog entry

Fixes #2172
