### PR TITLE
Fix: Heap OOB buffer over-read in MP4 atom parsing (#2179)

### DIFF
--- a/src/lib_ccx/mp4.c
+++ b/src/lib_ccx/mp4.c
@@ -891,7 +891,7 @@ int processmp4(struct lib_ccx_ctx *ctx, struct ccx_s_mp4Cfg *cfg, char *file)
 	if (enc_ctx)
 		enc_ctx->timing = dec_ctx->timing;
 
-	// WARN: otherwise cea-708 will not work
+		// WARN: otherwise cea-708 will not work
 #ifndef DISABLE_RUST
 	ccxr_dtvcc_set_encoder(dec_ctx->dtvcc_rust, enc_ctx);
 #else


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [x] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [x] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---

Fixes #2179 

I have updated the calls to [process_tx3g] to pass `sample->dataLength - atomStart` as the proper upper boundary limit data size.

Which prevent the forging of the manipulative atoms that may read the OOB memory leading to the data leak or crash.
