### PR TITLE
fix: 2182 - Heap OOB Read in switch_to_next_file()

### DIFF
--- a/src/rust/src/common.rs
+++ b/src/rust/src/common.rs
@@ -255,7 +255,7 @@ pub unsafe fn copy_from_rust(ccx_s_options: *mut ccx_s_options, options: Options
     // Subsequent calls from ccxr_demuxer_open/close should NOT modify inputfile because
     // C code holds references to those strings throughout processing.
     // Freeing them would cause use-after-free and double-free errors.
-    if let Some(ref inputfile) = options.inputfile {
+    if let Some(ref _inputfile) = options.inputfile {
         if (*ccx_s_options).inputfile.is_null() {
             let non_empty: Vec<String> = options
                 .inputfile


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [x] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---
fixes #2182 

I moved the empty string filter *before* allocating the C array. Now, string_to_c_chars()  only receives the exact number of valid paths, ensuring the memory allocation size perfectly matches the `num_input_files` limit given to the C codebase.

