### PR TITLE
[IMPROVEMENT] --out report now probes both EIA-608 fields by default

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -2,6 +2,7 @@
 -------------------
 - Fix: Prevent crash in Rust timing module when logging out-of-range PTS/FTS timestamps from malformed streams.
 - Fix: Use dynamic current_fps instead of hardcoded 29.97 in CEA-708 SCC frame delay calculations (#2172)
+- Improvement: --out report now probes both EIA-608 fields by default, so CC3/CC4 are correctly detected without requiring --output-field both (#2177)
 
 0.96.6 (2026-02-19)
 -------------------

--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,6 +1,7 @@
 0.96.7 (unreleased)
 -------------------
 - Fix: Prevent crash in Rust timing module when logging out-of-range PTS/FTS timestamps from malformed streams.
+- Fix: Use dynamic current_fps instead of hardcoded 29.97 in CEA-708 SCC frame delay calculations (#2172)
 
 0.96.6 (2026-02-19)
 -------------------

--- a/src/lib_ccx/ccx_decoders_708_output.c
+++ b/src/lib_ccx/ccx_decoders_708_output.c
@@ -550,11 +550,11 @@ void dtvcc_write_scc(dtvcc_writer_ctx *writer, dtvcc_service_decoder *decoder, s
 	if (tv->old_cc_time_end > time_show.time_in_ms)
 	{
 		// Correct the frame delay
-		time_show.time_in_ms -= 1000 / 29.97;
+		time_show.time_in_ms -= 1000 / current_fps;
 		print_scc_time(time_show, buf);
 		buf_len = strlen(buf);
 		SCC_SNPRINTF("\t942c 942c");
-		time_show.time_in_ms += 1000 / 29.97;
+		time_show.time_in_ms += 1000 / current_fps;
 		// Clear the buffer and start pop on caption
 		SCC_SNPRINTF("94ae 94ae 9420 9420");
 	}
@@ -566,20 +566,20 @@ void dtvcc_write_scc(dtvcc_writer_ctx *writer, dtvcc_service_decoder *decoder, s
 		buf_len = strlen(buf);
 		SCC_SNPRINTF("\t942c 942c \n\n");
 		// Correct the frame delay
-		time_show.time_in_ms -= 1000 / 29.97;
+		time_show.time_in_ms -= 1000 / current_fps;
 		// Clear the buffer and start pop on caption in new time
 		print_scc_time(time_show, buf + buf_len);
 		buf_len = strlen(buf);
 		SCC_SNPRINTF("\t94ae 94ae 9420 9420");
-		time_show.time_in_ms += 1000 / 29.97;
+		time_show.time_in_ms += 1000 / current_fps;
 	}
 	else
 	{
-		time_show.time_in_ms -= 1000 / 29.97;
+		time_show.time_in_ms -= 1000 / current_fps;
 		print_scc_time(time_show, buf);
 		buf_len = strlen(buf);
 		SCC_SNPRINTF("\t942c 942c 94ae 94ae 9420 9420");
-		time_show.time_in_ms += 1000 / 29.97;
+		time_show.time_in_ms += 1000 / current_fps;
 	}
 
 	int total_subtitle_count = count_captions_lines_scc(tv);

--- a/src/rust/src/parser.rs
+++ b/src/rust/src/parser.rs
@@ -204,6 +204,10 @@ impl OptionsExt for Options {
                 self.messages_target = OutputTarget::Quiet;
                 self.print_file_reports = true;
                 self.demux_cfg.ts_allprogram = true;
+                // Probe both EIA-608 fields so CC3/CC4 are correctly
+                // detected in the report (#2177).
+                self.extract = 12;
+                self.is_608_enabled = true;
             }
             OutFormat::Raw => self.write_format = OutputFormat::Raw,
             OutFormat::Smptett => self.write_format = OutputFormat::SmpteTt,
@@ -1566,6 +1570,7 @@ impl OptionsExt for Options {
         }
 
         if self.write_format != OutputFormat::DvdRaw
+            && self.write_format != OutputFormat::Null
             && self.cc_to_stdout
             && self.extract != 0
             && self.extract == 12
@@ -1914,6 +1919,18 @@ pub mod tests {
         assert_eq!(options.write_format, OutputFormat::Null);
         assert!(options.print_file_reports);
         assert!(options.demux_cfg.ts_allprogram);
+        // Report mode should probe both EIA-608 fields (#2177)
+        assert_eq!(options.extract, 12);
+        assert!(options.is_608_enabled);
+    }
+
+    #[test]
+    fn test_out_report_with_stdout_no_conflict() {
+        // Report mode uses Null output, so --stdout should not conflict
+        // even though extract == 12 (both fields)
+        let (options, _) = parse_args(&["--out", "report", "--stdout"]);
+        assert_eq!(options.write_format, OutputFormat::Null);
+        assert_eq!(options.extract, 12);
     }
 
     // =========================================================================


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [x] I give this submission freely, and claim no ownership to its content.
- [x] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [x] I am an active contributor to CCExtractor.

---

## Summary

`--out report` only probes EIA-608 **field 1** by default, so CC3/CC4 always show `No` even when captions exist in field 2. This is misleading — a user sees `CC3: No` and concludes the file has no CC3 content, when in reality the report just never looked at field 2.

## Root Cause

In the `OutFormat::Report` handler in `parser.rs`, `extract` is never set — it defaults to `1` (field 1 only). CC3/CC4 belong to field 2, so they are never decoded and the report always says `No` for them.

## Fix

1. **Set `extract = 12`** (both fields) and `is_608_enabled = true` in the report handler so both fields are probed.
2. **Exempt `OutputFormat::Null`** from the broadcast-mode stdout conflict check at the validation stage — report mode sets `write_format = Null`, so there is no actual stdout output and the "can't extract both fields to stdout" error does not apply.

## Changes

- `src/rust/src/parser.rs` — 3 locations:
  - Report handler: added `extract = 12` + `is_608_enabled = true`
  - Stdout conflict check: added `write_format != Null` guard
  - Tests: updated `test_out_report_enables_file_reports`, added `test_out_report_with_stdout_no_conflict`
- `docs/CHANGES.TXT` — added changelog entry

## Precedence

If a user explicitly passes `--output-field 1` alongside `--out report`, their choice wins — `--output-field` is parsed after `--out` and overwrites `extract`.

**AI disclosure:** 🟡 AI-assisted — I reviewed, tested, and understand every line.

Fixes #2177