### PR TITLE
Fix: Add NULL check after strdup in parse_segment_track_entry

### DIFF
--- a/src/lib_ccx/matroska.c
+++ b/src/lib_ccx/matroska.c
@@ -1033,7 +1033,7 @@ void parse_segment_track_entry(struct matroska_ctx *mkv_ctx)
 			case MATROSKA_SEGMENT_TRACK_LANGUAGE_IETF:
 				lang_ietf = read_vint_block_string(file);
 				mprint("    Language IETF: %s\n", lang_ietf);
-				// We'll store this for later use rather than freeing it immediately
+							// We'll store this for later use rather than freeing it immediately
 				if (track_type == MATROSKA_TRACK_TYPE_SUBTITLE)
 				{
 					// Don't free lang_ietf here, store in track
@@ -1043,20 +1043,22 @@ void parse_segment_track_entry(struct matroska_ctx *mkv_ctx)
 						free(lang);
 						lang = NULL;
 					}
+
 					// Default to "eng" if we somehow don't have a language yet
 					if (lang == NULL)
-                     {
-                 	lang = strdup("eng");
-	                 if (!lang)
-	         	fatal(EXIT_NOT_ENOUGH_MEMORY, "In parse_segment_track_entry: Out of memory allocating lang.");
-                     }
+					{
+						lang = strdup("eng");
+						if (!lang)
+							fatal(EXIT_NOT_ENOUGH_MEMORY,
+							      "In parse_segment_track_entry: Out of memory allocating lang.");
+					}
+				}
 				else
 				{
 					free(lang_ietf); // Free if not a subtitle track
 					lang_ietf = NULL;
 				}
 				MATROSKA_SWITCH_BREAK(code, code_len);
-
 				/* Misc ids */
 			case MATROSKA_VOID:
 				read_vint_block_skip(file);


### PR DESCRIPTION
strdup("eng") may return NULL if memory allocation fails.

This patch adds a NULL check after strdup and calls
fatal(EXIT_NOT_ENOUGH_MEMORY) to prevent a potential
NULL pointer dereference.