### PR TITLE
feat(rust): add --codec isdb CLI flag for ISDB/ARIB subtitle selection

### DIFF
--- a/src/rust/src/args.rs
+++ b/src/rust/src/args.rs
@@ -754,6 +754,7 @@ pub struct Args {
     ///     nothing is selected and no subtitle is generated
     /// --codec teletext
     ///     select the teletext subtitle from elementary stream
+    /// --codec isdb      select ISDB/ARIB subtitle stream (Japanese broadcast)
     #[arg(long, verbatim_doc_comment, value_name="value", help_heading=OUTPUT_AFFECTING_CODEC)]
     pub codec: Option<CCXCodec>,
     /// --no-codec dvbsub
@@ -977,6 +978,7 @@ pub struct Args {
 pub enum CCXCodec {
     Dvbsub,
     Teletext,
+    Isdb,
 }
 
 #[derive(Display, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]

--- a/src/rust/src/parser.rs
+++ b/src/rust/src/parser.rs
@@ -679,6 +679,9 @@ impl OptionsExt for Options {
                 CCXCodec::Dvbsub => {
                     self.demux_cfg.codec = SelectCodec::Some(Codec::Dvb);
                 }
+                CCXCodec::Isdb => {
+                    self.demux_cfg.codec = SelectCodec::Some(Codec::IsdbCc);
+                }
             }
         }
 
@@ -689,6 +692,9 @@ impl OptionsExt for Options {
                 }
                 CCXCodec::Teletext => {
                     self.demux_cfg.nocodec = SelectCodec::Some(Codec::Teletext);
+                }
+                CCXCodec::Isdb => {
+                    self.demux_cfg.nocodec = SelectCodec::Some(Codec::IsdbCc);
                 }
             }
         }


### PR DESCRIPTION
Extends CCXCodec enum with Isdb variant and wires it to Codec::IsdbCc in the demuxer config, enabling users to explicitly select ISDB/ARIB subtitle streams via:
  --codec isdb
  --no-codec isdb

The underlying C decoder (isdbsub_decode) and Rust Codec::IsdbCc were already present but had no CLI
entry point. This change completes the wiring.

Relevant for Japanese broadcast (ARIB B-24) support.

<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
- [ ] I give this submission freely, and claim no ownership to its content.
- [ ] **I have mentioned this change in the [changelog](https://github.com/CCExtractor/ccextractor/blob/master/docs/CHANGES.TXT).**

**My familiarity with the project is as follows (check one):**

- [ ] I have never used CCExtractor.
- [ ] I have used CCExtractor just a couple of times.
- [ ] I absolutely love CCExtractor, but have not contributed previously.
- [ ] I am an active contributor to CCExtractor.

---
## Summary
Extends `CCXCodec` enum with `Isdb` variant and wires it to
`Codec::IsdbCc` in the demuxer config, enabling users to explicitly
select ISDB/ARIB subtitle streams via:
  --codec isdb
  --no-codec isdb

## Motivation
The underlying C decoder (`isdbsub_decode`) and Rust `Codec::IsdbCc`
were already present but had no CLI entry point. This change completes
the wiring for Japanese broadcast (ARIB B-24) support.

## Testing
- `--codec isdb` is now accepted without error
- `--no-codec isdb` correctly excludes the ISDB stream
- All existing codec tests pass

