### PR TITLE
chore: clean up #2168 merge nits

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,6 +1,5 @@
 0.96.7 (unreleased)
 -------------------
-- Fix: Remove unconditional VBI_DEBUG define — add CMake option -DVBI_DEBUG=ON for opt-in debug builds (#2167)
 - Fix: Remove strdup() memory leaks in WebVTT styling encoder, fix invalid CSS rgba(0,256,0) green value, fix missing free(unescaped) on write-error path (#2154)
 - Fix: Prevent crash in Rust timing module when logging out-of-range PTS/FTS timestamps from malformed streams.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required (VERSION 3.24.0)
 project (CCExtractor)
+
 include (CTest)
 
 option (WITH_FFMPEG "Build using FFmpeg demuxer and decoder" OFF)
@@ -247,7 +248,6 @@ if (PKG_CONFIG_FOUND AND WITH_HARDSUBX)
   set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${TESSERACT_INCLUDE_DIRS})
   set (EXTRA_INCLUDES ${EXTRA_INCLUDES} ${LEPTONICA_INCLUDE_DIRS})
 endif (PKG_CONFIG_FOUND AND WITH_HARDSUBX)
-
 
 add_executable (ccextractor ${SOURCEFILE} ${FREETYPE_SOURCE} ${UTF8PROC_SOURCE})
 


### PR DESCRIPTION
## Summary
- Remove CHANGES.TXT entry for #2168 (internal fix, not user-facing)
- Restore blank line between `project()` and `include()` in CMakeLists.txt
- Remove stray extra blank line before `add_executable` in CMakeLists.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)