### PR TITLE
style: add missing braces in lib_ccx.c

### DIFF
--- a/src/lib_ccx/lib_ccx.c
+++ b/src/lib_ccx/lib_ccx.c
@@ -450,7 +450,9 @@ struct encoder_ctx *update_encoder_list_cinfo(struct lib_ccx_ctx *ctx, struct ca
 			enc_ctx = init_encoder(&local_cfg);
 			freep(&local_cfg.output_filename); // safely free the malloc'd string
 			if (!enc_ctx)
+			{
 				return NULL;
+			}
 			list_add_tail(&(enc_ctx->list), &(ctx->enc_ctx_head));
 		}
 		if (list_empty(&ctx->enc_ctx_head))
@@ -459,7 +461,9 @@ struct encoder_ctx *update_encoder_list_cinfo(struct lib_ccx_ctx *ctx, struct ca
 			ccx_options.enc_cfg.in_format = in_format;
 			enc_ctx = init_encoder(&ccx_options.enc_cfg);
 			if (!enc_ctx)
+			{
 				return NULL;
+			}
 			list_add_tail(&(enc_ctx->list), &(ctx->enc_ctx_head));
 		}
 	}


### PR DESCRIPTION
## Summary
- Add braces to two `if (!enc_ctx)` blocks in `update_encoder_list_cinfo` that were missing them after #2147 merge

## Test plan
- Build verified clean on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)