### PR TITLE
Fix/cea 708 c1 bounds check

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,6 @@
 0.96.7 (unreleased)
 -------------------
+- Fix: Move C0 bounds check before match in CEA-708 Rust decoder to prevent process_p16 index-out-of-bounds panic on truncated ATSC1.0 TS blocks; improve C1 warn message with command code and lengths (#1407)
 - New: Allow output \0 terminated frames via --null-terminated
 - New: Added ASS/SSA \pos-based positioning for CEA-608 captions when layout is simple (1–2 rows) (#1726)
 - Fix: Remove strdup() memory leaks in WebVTT styling encoder, fix invalid CSS rgba(0,256,0) green value, fix missing free(unescaped) on write-error path (#2154)

--- a/src/rust/lib_ccxr/src/teletext.rs
+++ b/src/rust/lib_ccxr/src/teletext.rs
@@ -1004,16 +1004,8 @@ impl<'a> TeletextContext<'a> {
         let mut line_count: u8 = 0;
         let mut time_reported = false;
         // Negative timestamps occur with wrap-around/uninitialized PTS in broadcast captures
-        let timecode_show = self
-            .page_buffer
-            .show_timestamp
-            .to_srt_time()
-            .ok()?;
-        let timecode_hide = self
-            .page_buffer
-            .hide_timestamp
-            .to_srt_time()
-            .ok()?;
+        let timecode_show = self.page_buffer.show_timestamp.to_srt_time().ok()?;
+        let timecode_hide = self.page_buffer.hide_timestamp.to_srt_time().ok()?;
 
         // process data
         for row in 1..25 {

--- a/src/rust/src/decoder/service_decoder.rs
+++ b/src/rust/src/decoder/service_decoder.rs
@@ -77,6 +77,15 @@ impl dtvcc_service_decoder {
         let code = block[0];
         let C0Command { command, length } = C0Command::new(code);
         debug!("C0: [{:?}] ({})", command, block.len());
+        if length as usize > block.len() {
+            warn!(
+                "dtvcc_handle_C0: command {:#04X} needs {} bytes but block only has {}; skipping",
+                code,
+                length,
+                block.len()
+            );
+            return -1;
+        }
         match command {
             // NUL command does nothing
             C0CodeSet::NUL => {}
@@ -89,14 +98,6 @@ impl dtvcc_service_decoder {
             C0CodeSet::EXT1 => {}
             C0CodeSet::P16 => self.process_p16(&block[1..]),
             C0CodeSet::RESERVED => {}
-        }
-        if length as usize > block.len() {
-            warn!(
-                "dtvcc_handle_C0: command is {} bytes long but we only have {}",
-                length,
-                block.len()
-            );
-            return -1;
         }
         length as i32
     }
@@ -286,7 +287,13 @@ impl dtvcc_service_decoder {
         } = C1Command::new(code);
 
         if length as usize > block.len() {
-            warn!("Warning: Not enough bytes for command.");
+            warn!(
+                "dtvcc_handle_C1: command {:#04X} ({}) needs {} bytes but block only has {}; skipping",
+                code,
+                name,
+                length,
+                block.len()
+            );
             return -1;
         }
 


### PR DESCRIPTION
Addresses the index-out-of-bounds panic in the CEA-708 Rust decoder on ATSC1.0 TS files (originally reported in #1407).
Root cause:
In handle_C0, the bounds check (if length as usize > block.len()) was placed after the match block. This meant C0CodeSet::P16 => self.process_p16(&block[1..]) could be called on a block with only 1 byte, causing an index-out-of-bounds panic before the guard ever ran.
Changes:

handle_C0: moved the bounds check to before the match block, with an improved warn message that includes the command code, expected length, and actual block length.
handle_C1: improved the existing warn message to include command code, name, expected length, and actual block length for easier debugging.

Testing:

cargo build passes cleanly.
The original panic scenario (truncated ATSC1.0 TS block reaching process_p16) is now safely caught and logged before any slice indexing occurs.