### PR TITLE
Fix memory safety bug in copy_demuxer_data_from_rust

### DIFF
--- a/src/rust/src/libccxr_exports/demuxerdata.rs
+++ b/src/rust/src/libccxr_exports/demuxerdata.rs
@@ -4,7 +4,6 @@ use crate::ctorust::FromCType;
 use crate::demuxer::common_types::CcxRational;
 use crate::demuxer::demuxer_data::DemuxerData;
 use lib_ccxr::common::{BufferdataType, Codec};
-use std::os::raw::c_uchar;
 use std::os::raw::{c_int, c_uint};
 
 /// Convert from C demuxer_data to Rust DemuxerData
@@ -254,7 +253,11 @@ mod tests {
         };
 
         unsafe {
+            let original_ptr = c_data.buffer;
             copy_demuxer_data_from_rust(&mut c_data, &rust_data);
+
+            // Verify the pointer was NOT reassigned (the bug we're fixing)
+            assert_eq!(c_data.buffer, original_ptr);
 
             // Verify all fields were copied correctly
             assert_eq!(c_data.program_number, rust_data.program_number);

--- a/src/rust/src/libccxr_exports/demuxerdata.rs
+++ b/src/rust/src/libccxr_exports/demuxerdata.rs
@@ -256,7 +256,6 @@ mod tests {
             let original_ptr = c_data.buffer;
             copy_demuxer_data_from_rust(&mut c_data, &rust_data);
 
-         
             assert_eq!(c_data.buffer, original_ptr);
 
             // Verify all fields were copied correctly

--- a/src/rust/src/libccxr_exports/demuxerdata.rs
+++ b/src/rust/src/libccxr_exports/demuxerdata.rs
@@ -37,6 +37,10 @@ pub unsafe fn copy_demuxer_data_to_rust(c_data: *const demuxer_data) -> DemuxerD
 /// - This function copies the buffer content, not just the pointer
 #[allow(clippy::unnecessary_cast)]
 pub unsafe fn copy_demuxer_data_from_rust(c_data: *mut demuxer_data, rust_data: &DemuxerData) {
+    if c_data.is_null() {
+        return;
+    }
+
     (*c_data).program_number = rust_data.program_number as c_int;
     (*c_data).stream_pid = rust_data.stream_pid as c_int;
     if let Some(codec) = rust_data.codec {
@@ -44,8 +48,13 @@ pub unsafe fn copy_demuxer_data_from_rust(c_data: *mut demuxer_data, rust_data: 
     }
     (*c_data).bufferdatatype = rust_data.bufferdatatype.to_ctype();
 
-    (*c_data).buffer = rust_data.buffer as *mut c_uchar;
-    (*c_data).len = rust_data.len;
+    if !rust_data.buffer.is_null() && !(*c_data).buffer.is_null() {
+        let copy_len = std::cmp::min((*c_data).len, rust_data.len);
+        std::ptr::copy_nonoverlapping(rust_data.buffer, (*c_data).buffer, copy_len);
+        (*c_data).len = copy_len;
+    } else {
+        (*c_data).len = 0;
+    }
 
     (*c_data).rollover_bits = rust_data.rollover_bits as c_uint;
     (*c_data).pts = rust_data.pts as i64;
@@ -257,6 +266,8 @@ mod tests {
             // Verify buffer content was copied
             let copied_buffer = std::slice::from_raw_parts(c_data.buffer, c_data.len);
             assert_eq!(copied_buffer, test_buffer);
+            // Verify the underlying C buffer received the copied data
+            assert_eq!(c_buffer[0], 0xDE);
         }
     }
 
@@ -332,14 +343,13 @@ mod tests {
 
     #[test]
     fn test_copy_demuxer_from_rust_buffer_size_limits() {
-        let mut large_buffer = vec![0x42; 1000]; // Large buffer
+        let mut large_buffer = vec![0x42; 1000];
         let rust_data = DemuxerData {
             buffer: large_buffer.as_mut_ptr(),
             len: 100,
             ..Default::default()
         };
 
-        // Create smaller C buffer
         let mut small_c_buffer = vec![0u8; 100];
         let mut c_data = unsafe {
             demuxer_data {
@@ -351,12 +361,10 @@ mod tests {
 
         unsafe {
             copy_demuxer_data_from_rust(&mut c_data, &rust_data);
-
-            // Should only copy what fits
-            assert_eq!(c_data.len, 100);
-            let copied_buffer = std::slice::from_raw_parts(c_data.buffer, c_data.len);
-            assert_eq!(copied_buffer, &vec![0x42; 100]);
         }
+        
+        assert_eq!(c_data.len, 100);
+        assert_eq!(small_c_buffer, vec![0x42; 100]);
     }
 
     #[test]

--- a/src/rust/src/libccxr_exports/demuxerdata.rs
+++ b/src/rust/src/libccxr_exports/demuxerdata.rs
@@ -256,7 +256,7 @@ mod tests {
             let original_ptr = c_data.buffer;
             copy_demuxer_data_from_rust(&mut c_data, &rust_data);
 
-            // Verify the pointer was NOT reassigned (the bug we're fixing)
+         
             assert_eq!(c_data.buffer, original_ptr);
 
             // Verify all fields were copied correctly

--- a/src/rust/src/libccxr_exports/demuxerdata.rs
+++ b/src/rust/src/libccxr_exports/demuxerdata.rs
@@ -362,7 +362,7 @@ mod tests {
         unsafe {
             copy_demuxer_data_from_rust(&mut c_data, &rust_data);
         }
-        
+
         assert_eq!(c_data.len, 100);
         assert_eq!(small_c_buffer, vec![0x42; 100]);
     }


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

Reason for this PR:

- [ ] This PR adds new functionality.
- [x] This PR fixes a bug that I have personally experienced or that a real user has reported and for which a sample exists.
- [ ] This PR is porting code from C to Rust.

Sanity check:
- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] If the PR adds new functionality, I've added it to the changelog. If it's just a bug fix, I have NOT added it to the changelog.
- [x] I am NOT adding new C code unless it's to fix an existing, reproducible bug.

---

### Problem

The function `copy_demuxer_data_from_rust` is documented to copy buffer contents, but the implementation was incorrectly reassigning the buffer pointer:

```rust
(*c_data).buffer = rust_data.buffer as *mut c_uchar;
```

This leads to:
- Use-after-free if the Rust buffer is deallocated
- Dangling pointers in the C layer
- Corrupted demuxed data (affecting subtitle extraction)

### Reproduction 

1. Build the project:
```bash
mkdir build && cd build
cmake ..
make -j
```

2. Run with any TS/MKV input that triggers Rust → C demuxer data transfer.
3. Before this fix:
- Buffer pointer is reassigned instead of copied
- Leads to undefined behavior depending on memory lifecycle
- Tests do not guarantee actual memory copy into C buffer

### Fix
- Replaced pointer reassignment with safe memory copy using:
 ```rust 
std::ptr::copy_nonoverlapping
```

- Ensured safe copy using:
```rust
min(source_len, dest_len)
```

- Added null pointer checks
- Set length to 0 when buffers are invalid


### Test Improvements

Previously, the tests for copy_demuxer_data_from_rust only validated high-level properties such as buffer length. They did not verify whether the buffer contents were actually copied into the destination C memory.

As a result, the incorrect implementation:

```rust
(*c_data).buffer = rust_data.buffer as *mut c_uchar; 
```

could still pass the tests despite not performing a real memory copy.

### Changes Made
The tests have been improved to explicitly validate the contents of the destination buffer. For example:
```rust
assert_eq!(small_c_buffer, vec![0x42; 100]);
```

### Impact
- Ensures that data is properly copied into C-managed memory
- Detects incorrect pointer reassignment behavior
- Prevents similar issues in future changes
- Aligns test coverage with the documented behavior of the function
