### PR TITLE
[FIX] Preserve git commit hash in Homebrew and tarball-based builds

### DIFF
--- a/linux/build
+++ b/linux/build
@@ -33,6 +33,13 @@ while [[ $# -gt 0 ]]; do
       USE_SYSTEM_LIBS=true
       shift
       ;;
+    -commit-hash)
+      # Inject build provenance for tarball builds (Homebrew, released source tarball, etc.)
+      # where no .git directory is present. Passed through to pre-build.sh
+      # via the exported env var GIT_COMMIT_HASH_OVERRIDE.
+      export GIT_COMMIT_HASH_OVERRIDE="$2"
+      shift 2
+      ;;
     -*)
       echo "Unknown option $1"
       exit 1

--- a/linux/pre-build.sh
+++ b/linux/pre-build.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 echo "Obtaining Git commit"
-commit=(`git rev-parse HEAD 2>/dev/null`)
+if [ -n "$GIT_COMMIT_HASH_OVERRIDE" ]; then
+    commit="$GIT_COMMIT_HASH_OVERRIDE"
+    echo "Using injected commit hash: $commit"
+else
+    commit=(`git rev-parse HEAD 2>/dev/null`)
+fi
 if [ -z "$commit" ]; then
 	echo "Git command not present, trying folder approach"
 	if [ -d "../.git" ]; then 

--- a/mac/build.command
+++ b/mac/build.command
@@ -35,6 +35,13 @@ while [[ $# -gt 0 ]]; do
       USE_SYSTEM_LIBS=true
       shift
       ;;
+    -commit-hash)
+      # Inject build provenance for tarball builds (Homebrew, released source tarball, etc.)
+      # where no .git directory is present. Passed through to pre-build.sh
+      # via the exported env var GIT_COMMIT_HASH_OVERRIDE.
+      export GIT_COMMIT_HASH_OVERRIDE="$2"
+      shift 2
+      ;;
     -*)
       echo "Unknown option $1"
       exit 1

--- a/mac/pre-build.sh
+++ b/mac/pre-build.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 echo "Obtaining Git commit"
-commit=(`git rev-parse HEAD 2>/dev/null`)
+if [ -n "$GIT_COMMIT_HASH_OVERRIDE" ]; then
+    commit="$GIT_COMMIT_HASH_OVERRIDE"
+    echo "Using injected commit hash: $commit"
+else
+    commit=(`git rev-parse HEAD 2>/dev/null`)
+fi
 if [ -z "$commit" ]; then
 	echo "Git command not present, trying folder approach"
 	if [ -d "../.git" ]; then 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,18 +21,25 @@ set (CCEXTRACTOR_VERSION_MINOR 96)
 # Get project directory
 get_filename_component(BASE_PROJ_DIR ../ ABSOLUTE)
 
-# Get the latest commit hash of the working branch
-IF(EXISTS "${BASE_PROJ_DIR}/.git")
-    execute_process(
-            COMMAND git rev-parse HEAD
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-            OUTPUT_VARIABLE GIT_COMMIT_HASH
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-ELSE(EXISTS "${BASE_PROJ_DIR}/.git")
-    set(GIT_BRANCH "Unknown")
-    set(GIT_COMMIT_HASH "Unknown")
-ENDIF(EXISTS "${BASE_PROJ_DIR}/.git")
+# GIT_COMMIT_HASH can be injected via -DGIT_COMMIT_HASH=<value> for Homebrew
+# or any tarball-based build where no .git directory is present.
+# Source builds fall through to git rev-parse automatically.
+set(GIT_COMMIT_HASH "" CACHE STRING
+    "Build provenance override for tarball-based builds (Homebrew, released source tarball)")
+
+if(GIT_COMMIT_HASH STREQUAL "")
+    IF(EXISTS "${BASE_PROJ_DIR}/.git")
+        execute_process(
+                COMMAND git rev-parse HEAD
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                OUTPUT_VARIABLE GIT_COMMIT_HASH
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+    ELSE(EXISTS "${BASE_PROJ_DIR}/.git")
+        set(GIT_BRANCH "Unknown")
+        set(GIT_COMMIT_HASH "Unknown")
+    ENDIF(EXISTS "${BASE_PROJ_DIR}/.git")
+endif()
 
 #Get the date
 string(TIMESTAMP COMPILATION_DATE %Y-%m-%d)


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

Reason for this PR:

- [ ] This PR adds new functionality.
- [X] This PR fixes a bug that I have personally experienced or that a real user has reported and for which a sample exists.
- [ ] This PR is porting code from C to Rust.

Sanity check:
- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] If the PR adds new functionality, I've added it to the changelog. If it's just a bug fix, I have NOT added it to the changelog.
- [X] I am NOT adding new C code unless it's to fix an existing, reproducible bug.

Repro instructions:
## Homebrew
```bash
brew install ccextractor
ccextractor --version
# Git commit: Unknown  ← every macOS user sees this
```

---

## Problem

Tarball-based builds (Homebrew, or any manual build from the released source tarball) have no .git directory at build time. The existing logic in `pre-build.sh` calls `git rev-parse HEAD` unconditionally — when `.git` is absent, this fails silently:


```
$ brew install ccextractor && ccextractor --version
Version: 0.96.5
Git commit: Unknown  ← broken
```
Every user installing via Homebrew or building from the released source tarball loses build provenance entirely.

## Fix

Add explicit override path at the metadata generation point (`pre-build.sh`), not post-build output patching.

- **`mac/pre-build.sh`, `linux/pre-build.sh`**
Check `GIT_COMMIT_HASH_OVERRIDE` env var first. If set, use it directly. Otherwise fall through to existing git logic unchanged.

- **`mac/build.command`, `linux/build`**
New `-commit-hash <value>` argument exports `GIT_COMMIT_HASH_OVERRIDE` for `pre-build.sh`. Matches existing `-system-libs` pattern.

- **`src/CMakeLists.txt`**
`GIT_COMMIT_HASH` CMake `CACHE STRING` for `-DGIT_COMMIT_HASH=<value>`. Falls through to git when empty. Placed after `BASE_PROJ_DIR` definition.

- **Source builds unaffected** — override only taken when explicitly provided.

## Testing

**1. Normal source build (unchanged):**

```
cd build && cmake ../src && ./ccextractor --version
Git commit: 6f0b781491fa7d6e646ce9a4c714bd5f1f7100c4  → real SHA
```

**2. Tarball simulation (no .git, no override):**

```
cd mac && mv ../.git ../.git.bak && bash pre-build.sh
Git command not present, trying folder approach
Commit: Unknown  → correct fallback
```

**3. Override injection:**

```
cd mac && GIT_COMMIT_HASH_OVERRIDE="v0.96.6" bash pre-build.sh
# Using injected commit hash: v0.96.6
# Commit: v0.96.6  → override works
```

**4. Full Homebrew end-to-end (production path):**

```
## Local tap with modified formula calling:
./build.command -system-libs -commit-hash v0.96.6
brew install local/test/ccextractor
ccextractor --version
Version: 0.96.5
Git commit: v0.96.6  → FIXED
```
---
**Next step:** Once this merges and a new release is cut, a Homebrew-core PR will add `"-commit-hash", "v#{version}"` to the formula's `install` block — at which point every future Homebrew bottle will carry the correct build provenance automatically.

