### PR TITLE
[FIX] docker build on ARM/Apple Silicon

### DIFF
--- a/src/rust/src/demuxer/common_types.rs
+++ b/src/rust/src/demuxer/common_types.rs
@@ -2,6 +2,7 @@ use crate::bindings::{lib_ccx_ctx, list_head};
 use crate::ffi_alloc;
 use lib_ccxr::common::{Codec, Decoder608Report, DecoderDtvccReport, StreamMode, StreamType};
 use lib_ccxr::time::Timestamp;
+use std::ffi::c_char;
 use std::ptr::null_mut;
 
 // Size of the Startbytes Array in CcxDemuxer - const 1MB
@@ -79,7 +80,7 @@ pub struct CapInfo {
     pub prev_counter: i32,
     pub codec_private_data: *mut std::ffi::c_void,
     pub ignore: i32,
-    pub lang: [i8; 4],
+    pub lang: [c_char; 4],
 
     /**
      * List joining all streams in TS


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

Reason for this PR:

- [ ] This PR adds new functionality.
- [x] This PR fixes a bug that I have personally experienced or that a real user has reported and for which a sample exists.
- [ ] This PR is porting code from C to Rust.

Sanity check:
- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] If the PR adds new functionality, I've added it to the changelog. If it's just a bug fix, I have NOT added it to the changelog.
- [x] I am NOT adding new C code unless it's to fix an existing, reproducible bug.

Repro instructions:

1. try to build CCExtractor using Docker on any ARM/AArch64 machine (e.g., a Mac with Apple Silicon):

    ```bash
    docker build --build-arg USE_LOCAL_SOURCE=1 -f docker/Dockerfile -t ccextractor .
    ```

    and the Rust compilation step fails with the following error:
    
    ```bash
    error[E0308]: mismatched types
        --> src/common.rs:1040:19
         |
    1040 |             lang: self.lang,
         |                   ^^^^^^^^^ expected `[u8; 4]`, found `[i8; 4]`
    
    error[E0308]: mismatched types
       --> src/ctorust.rs:571:19
         |
    571  |             lang: info.lang,
         |                   ^^^^^^^^^ expected `[i8; 4]`, found `[u8; 4]`
    ```
  
    You can also reproduce on an x86 machine by targeting the ARM64 platform in Docker:
    
    ```bash
    docker build --platform linux/arm64 --build-arg USE_LOCAL_SOURCE=1 -f docker/Dockerfile -t ccextractor .
    ```

---

I ran into this while building locally with Docker on my M4 Mac. The Rust build was failing because the `lang` field in `CapInfo` (`src/rust/src/demuxer/common_types.rs`) was hardcoded as `[i8; 4]`.

on ARM, `c_char` is `u8` instead of `i8`, so it didn’t match the bindgen-generated C bindings and caused the build to fail.

so, I changed it to `[c_char; 4]`, which works on both x86 and ARM.



### How can we test this

try to build on ARM (or simulate it from x86) and confirm it compiles:

```bash
# on an ARM machine (Mac with Apple Silicon, etc)
docker build --build-arg USE_LOCAL_SOURCE=1 -f docker/Dockerfile -t ccextractor .

# or from x86, target ARM to reproduce the original error
docker build --platform linux/arm64 --build-arg USE_LOCAL_SOURCE=1 -f docker/Dockerfile -t ccextractor .

# also make sure x86 still works
docker build --platform linux/amd64 --build-arg USE_LOCAL_SOURCE=1 -f docker/Dockerfile -t ccextractor .
```