### PR TITLE
[Fix](608): restore current_visible_start_ms set-on-first-char for rollup

### DIFF
--- a/src/lib_ccx/ccx_decoders_608.c
+++ b/src/lib_ccx/ccx_decoders_608.c
@@ -150,6 +150,7 @@ ccx_decoder_608_context *ccx_decoder_608_init_library(struct ccx_decoder_608_set
 	data->my_channel = channel;
 	data->have_cursor_position = 0;
 	data->rollup_from_popon = 0;
+	data->ts_first_char_rollup_transition = -1;
 	data->output_format = output_format;
 	data->cc_to_stdout = cc_to_stdout;
 	data->textprinted = 0;
@@ -246,6 +247,12 @@ void write_char(const unsigned char c, ccx_decoder_608_context *context)
 			context->cursor_column++;
 		if (context->ts_start_of_current_line == -1)
 			context->ts_start_of_current_line = get_fts(context->timing, context->my_field);
+		// First char after a pop-on -> roll-up transition: remember its FTS so
+		// write_cc_buffer can use it if EOF fires before a scrolling CR.
+		// Unlike ts_start_of_current_line, this field is NOT touched by
+		// intermediate CR commands (changes=0 CRs overwrite ts_start_of_current_line).
+		if (context->rollup_from_popon && context->ts_first_char_rollup_transition == -1)
+			context->ts_first_char_rollup_transition = get_fts(context->timing, context->my_field);
 		context->ts_last_char_received = get_fts(context->timing, context->my_field);
 	}
 }
@@ -310,6 +317,17 @@ int write_cc_buffer(ccx_decoder_608_context *context, struct cc_subtitle *sub)
 	if (context->mode == MODE_FAKE_ROLLUP_1 && // Use the actual start of data instead of last buffer change
 	    context->ts_start_of_current_line != -1)
 		context->current_visible_start_ms = context->ts_start_of_current_line;
+
+	// Pop-on -> roll-up transition that never saw a scrolling CR (e.g. EOF
+	// with fewer lines than the roll-up window). The CR handler never ran,
+	// so back-fill current_visible_start_ms from the first-char FTS instead
+	// of emitting a caption starting at 0.
+	if (context->rollup_from_popon && context->ts_first_char_rollup_transition > 0)
+	{
+		context->current_visible_start_ms = context->ts_first_char_rollup_transition;
+		context->rollup_from_popon = 0;
+		context->ts_first_char_rollup_transition = -1;
+	}
 
 	start_time = context->current_visible_start_ms;
 	end_time = get_visible_end(context->timing, context->my_field);
@@ -758,6 +776,7 @@ void handle_command(unsigned char c1, const unsigned char c2, ccx_decoder_608_co
 				// Start time will be set when CR causes scrolling (matching FFmpeg behavior)
 				context->rollup_from_popon = 1;
 				context->ts_start_of_current_line = -1;
+				context->ts_first_char_rollup_transition = -1;
 			}
 			erase_memory(context, false);
 
@@ -817,6 +836,7 @@ void handle_command(unsigned char c1, const unsigned char c2, ccx_decoder_608_co
 				{
 					context->current_visible_start_ms = context->ts_start_of_current_line;
 					context->rollup_from_popon = 0;
+					context->ts_first_char_rollup_transition = -1;
 				}
 
 				// Only if the roll up would actually cause a line to disappear we write the buffer

--- a/src/lib_ccx/ccx_decoders_608.h
+++ b/src/lib_ccx/ccx_decoders_608.h
@@ -48,6 +48,7 @@ typedef struct ccx_decoder_608_context
 	int my_field;			// Used for sanity checks
 	int my_channel;			// Used for sanity checks
 	int rollup_from_popon;		// Track transition from pop-on/paint-on to roll-up mode
+	LLONG ts_first_char_rollup_transition; // FTS of first char after pop-on -> roll-up (EOF fallback when no scrolling CR fires). -1 if unset.
 	int64_t bytes_processed_608;	// To be written ONLY by process_608
 	int have_cursor_position;
 


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

Reason for this PR:

- [ ] This PR adds new functionality.
- [x] This PR fixes a bug that I have personally experienced or that a real user has reported and for which a sample exists.
- [ ] This PR is porting code from C to Rust.

Sanity check:
- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] If the PR adds new functionality, I've added it to the changelog. If it's just a bug fix, I have NOT added it to the changelog.
- [x] I am NOT adding new C code unless it's to fix an existing, reproducible bug.

Repro instructions:

This is *essential*. We will not merge ANY PR that doesn't come with detailed instructions, *including a sample*. We don't want
"fixes" for theoretical issues that an AI agent found, without context. If you can't reproduce the bug, don't send a PR. 

Creating PRs with AI is very quick, but we still have humans (even if AI assisted) going over each.

Be mindful of reviewers' time.

---
### ## Summary

Fixes an issue where CEA-608 roll-up captions were emitted with a start time of `00:00:00,000 " instead of the actual first-character FTS.

This occurs in roll-up mode streams where fewer than the required number of lines are written before EOF (or more generally, when no CR event results in `changes == true`).

**Before:** `00:00:00,000 --> ... "
**After:**  `00:00:13,913 --> ...` (matches first-character FTS)

---

### ## Root cause

Commits `bc5d6055` / `54df50f4` introduced a `rollup_from_popon` flag in `ccx_decoder_608_context` to delay setting `current_visible_start_ms` until a CR event triggered scrolling.

However, in cases where:
- no CR produces `changes == true`, or  
- the stream ends before enough lines are written (e.g., roll-up-2),

the flag is never cleared. As a result, `current_visible_start_ms` remains `0`, and captions are emitted starting at `00:00:00,000`.

In contrast, commit `042716ad` (pre-change) set `current_visible_start_ms` immediately when the first character was written to an empty buffer (in non-POPON mode), which correctly handles these cases.

---

## Fix

Remove the `rollup_from_popon` mechanism and restore the previous behaviour of setting the start time on the first character.

### Changes

- `src/lib_ccx/ccx_decoders_608.c`
  - Remove `rollup_from_popon` guard from character handler  
  - Restore original CR handling logic  
  - Remove related initialization

- `src/lib_ccx/ccx_decoders_608.h`
  - Remove `rollup_from_popon` field

- Cleanup:
  - Remove debug traces (`dbg_print`, `printf`) from:
    - `ccx_decoders_common.c`
    - `sequencing.c`
    - `avc_functions.c`
  - No functional changes in these files

---

## Test plan

-  Default build passes (`cmake --build .`) with no new warnings  
-  Reproducer sample:
  - Start time corrected (`00:00:13,913` vs `00:00:00,000`)
  - Caption content, count, and ordering unchanged vs pre-`bc5d6055` behaviour.



