### PR TITLE
[IMPROVEMENT]: Derive snap version from git release tag at build time

### DIFF
--- a/.github/workflows/build_snap.yml
+++ b/.github/workflows/build_snap.yml
@@ -32,6 +32,35 @@ jobs:
       - name: Show Snapcraft version
         run: snapcraft --version
 
+      - name: Set Snap version from tag
+        if: github.event_name == 'release'
+        run: |
+          # Extract version from GITHUB_REF (handles both v0.96.6 and 0.96.6 tags)
+          VERSION="${GITHUB_REF#refs/tags/}"
+          VERSION="${VERSION#v}"
+          VERSION="${VERSION%%-*}"
+          VERSION="${VERSION//[[:space:]]/}"
+
+          if [ -z "$VERSION" ]; then
+            echo "ERROR: Version is empty after parsing GITHUB_REF: $GITHUB_REF" >&2
+            exit 1
+          fi
+
+          if [ ${#VERSION} -gt 32 ]; then
+            echo "Snap version too long: $VERSION" >&2
+            exit 1
+          fi
+
+          # Verify snapcraft.yaml has a version line before modifying
+          if ! grep -q '^version:' snap/snapcraft.yaml; then
+            echo "ERROR: No version line found in snap/snapcraft.yaml" >&2
+            exit 1
+          fi
+
+          echo "Setting snap version to: $VERSION"
+          sed -i "s/^version: .*/version: '${VERSION}'/" snap/snapcraft.yaml
+          grep -m1 '^version:' snap/snapcraft.yaml
+
       - name: Build snap
         run: sudo snapcraft --destructive-mode
 


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

Reason for this PR:

- [ ] This PR adds new functionality.
- [ ] This PR fixes a bug that I have personally experienced or that a real user has reported and for which a sample exists.
- [ ] This PR is porting code from C to Rust.

Sanity check:
- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [ ] If the PR adds new functionality, I've added it to the changelog. If it's just a bug fix, I have NOT added it to the changelog.
- [X] I am NOT adding new C code unless it's to fix an existing, reproducible bug.

Repro instructions:

#### This PR only changes the Snap CI workflow behavior; there is no runtime bug to reproduce in the binary.
---

# Description

This PR updates the Snap packaging workflow to derive the version at build time from the Git release tag, instead of relying solely on the hardcoded value in `snap/snapcraft.yaml`.

## Background

The `v0.96.6` [GitHub release](https://github.com/CCExtractor/ccextractor/releases) currently ships a Snap asset named `ccextractor_0.96.5_amd64.snap`, because `snap/snapcraft.yaml` still contains `version: '0.96.5'`.

That hardcoded value was originally chosen to avoid Snapcraft's 32-character version limit issues when using `version: git` ([#1998](https://github.com/CCExtractor/ccextractor/pull/1998)) , and it is still useful as a safe default for local and manual builds.

For official releases, however, the Snap artifact version should match the release tag, in line with how the existing Windows release workflow derives artifact names from the tag.

There is one other place in CCExtractor's CI that already uses this "parse version from tag" pattern: the Windows release workflow (`.github/workflows/release.yml`, step "Get the version"). That step reads `GITHUB_REF`, strips the `refs/tags/v` prefix and any suffix after `-`, and uses the result when naming the Windows installer and portable artifacts.

## Changes

Extend the existing "get version from tag" pattern from `.github/workflows/release.yml` to the Snap workflow (`.github/workflows/build_snap.yml`):

Add a `Set Snap version from tag` step that:

- Runs only on `release` events (`if: github.event_name == 'release'`).
- Extracts the version from `GITHUB_REF`:
  - Strips the `refs/tags/` prefix.
  - Strips an optional leading `v` (supports both `v0.96.6` and `0.96.6` tags).
  - Drops any suffix after `-` (e.g. `v0.96.6-rc1` → `0.96.6`).
  - Removes whitespace and enforces a maximum length of 32 characters to respect Snapcraft version constraints.
- Verifies that `snap/snapcraft.yaml` contains a `version:` line before editing.
- Rewrites the `version:` line in `snap/snapcraft.yaml` to the parsed version in the CI workspace, immediately before running `snapcraft --destructive-mode`.

## Behaviour 

**Repository state:**

`snap/snapcraft.yaml` in Git remains unchanged with `version: '0.96.5'`. This continues to act as a default for local builds and any CI jobs that are not release builds.

**Release builds:**

For a tag such as `v0.96.6`, the workflow checkout starts with the hardcoded version: from `snap/snapcraft.yaml` (currently `0.96.5`). The new step updates it in the CI workspace to `version: '0.96.6'`, Snapcraft builds the Snap, and the resulting artifact is named `ccextractor_0.96.6_amd64.snap`. The modified file exists only in the CI workspace; no changes are committed back to the repository.

**Manual / local builds:**

Manual `workflow_dispatch` runs skip the version-rewrite step and continue to use `version: '0.96.5'`. Local `snapcraft` runs also use `version: '0.96.5'` from the file as before.

This keeps the hardcoded version as a safe fallback, but ensures that official release artifacts are aligned with the tagged version.

## Testing

Local testing of the parsing and rewrite logic against `snap/snapcraft.yaml`:

Verified version extraction for different tag formats:

- `GITHUB_REF=refs/tags/v0.96.6` → `version: '0.96.6'`
- `GITHUB_REF=refs/tags/0.96.6` → `version: '0.96.6'`
- `GITHUB_REF=refs/tags/v0.96.6-rc1` → `version: '0.96.6'`
- `GITHUB_REF=refs/tags/v1.0` → `version: '1.0'`

Confirmed that:

- The script exits with an error if the parsed version is empty or longer than 32 characters.
- The script exits with an error if no `version:` line is present in `snap/snapcraft.yaml`.
- For valid tags, only the `version:` line is updated; the rest of `snap/snapcraft.yaml` remains unchanged.