### PR TITLE
[IMPROVEMENT] ci: add manual checksum workflow for release artifacts

### DIFF
--- a/.github/workflows/create_release_checksums.yml
+++ b/.github/workflows/create_release_checksums.yml
@@ -1,0 +1,58 @@
+name: Create Release Checksums
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag (e.g., v0.96.6)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  checksums:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate release tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view "${{ github.event.inputs.release_tag }}" \
+            --repo ${{ github.repository }} \
+            --json tagName > /dev/null
+
+      - name: Download all release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p release_assets
+          gh release download "${{ github.event.inputs.release_tag }}" \
+            --repo ${{ github.repository }} \
+            --dir release_assets \
+            --skip-existing
+
+      - name: Sanity check asset count
+        run: |
+          COUNT=$(ls release_assets | wc -l)
+          echo "Downloaded $COUNT assets"
+          if [ "$COUNT" -lt 5 ]; then
+            echo "ERROR: Only $COUNT assets found. Not all builds may have completed yet."
+            exit 1
+          fi
+
+      - name: Generate checksums.sha256
+        run: |
+          cd release_assets
+          rm -f checksums.sha256
+          sha256sum * | sort -k2 > checksums.sha256
+          cat checksums.sha256
+
+      - name: Upload checksums.sha256 to Release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.event.inputs.release_tag }}
+          files: release_assets/checksums.sha256
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

Reason for this PR:

- [ ] This PR adds new functionality.
- [ ] This PR fixes a bug that I have personally experienced or that a real user has reported and for which a sample exists.
- [ ] This PR is porting code from C to Rust.

Sanity check:
- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [ ] If the PR adds new functionality, I've added it to the changelog. If it's just a bug fix, I have NOT added it to the changelog.
- [X] I am NOT adding new C code unless it's to fix an existing, reproducible bug.

Repro instructions:
#### This is a CI-only change — no runtime code modified, no binary behavior changed. No changelog entry added. Verification is the workflow run linked below.
---

## What this PR does

Adds `.github/workflows/create_release_checksums.yml` — a manual `workflow_dispatch` workflow that validates a release tag, downloads all its assets via `gh release download`, generates `checksums.sha256` via `sha256sum * | sort -k2`, and uploads it back to the same release.

## Why this is needed

GitHub Releases expose per-asset SHA256 digests in the release UI, but there is no downloadable `checksums.sha256` file that users can verify locally across all artifacts at once. With this PR, after downloading artifacts users can run:
```
    sha256sum -c checksums.sha256
```
and get a pass/fail for every artifact in one step. 

## Why workflow_dispatch (not automatic)

The repo has 7 release workflows all triggered independently on `release: published` (Windows, AppImage ×3, deb ×2, Debian 13 deb ×2, Snap, systemlibs ×2, macOS). `needs:` only works within the same workflow file — there is no cross-workflow fan-in primitive in GitHub Actions. An automatic trigger would race against the builds and produce a partial manifest.

`workflow_dispatch` means the release manager runs this once after confirming all packaging workflows are green. It is safe to rerun — `checksums.sha256` is removed from the runner before regenerating to prevent self-inclusion.

## How to trigger

After all packaging workflows complete successfully:

1. Actions → "Create Release Checksums" → "Run workflow"
2. Enter the release tag (e.g. `v0.96.6`)
3. `checksums.sha256` is attached to that release

## Implementation notes

- `gh release download` — downloads only GitHub Release assets, not CI artifacts
- `--repo ${{ github.repository }}` — fork-safe
- `--skip-existing` — idempotent on reruns
- `sort -k2` — sorts by filename, conventional checksum format
- `softprops/action-gh-release@v3` — same action/version used in all 7 packaging
  workflows in this repo
- `permissions: contents: write` — matches `release.yml` and
  `build_linux_systemlibs.yml`
- No `actions/checkout` — workflow never touches source code
- Zero changes to any existing workflow file

## Testing

**Local** — `gh release download v0.96.6 --repo CCExtractor/ccextractor`, then `sha256sum -c checksums.sha256` against all 14 assets. All returned OK.

**CI** — [fork run 27032822731](https://github.com/x15sr71/ccextractor/actions/runs/27032822731) via `workflow_dispatch` against `v0.96.6`. All 5 steps green (validate → download → sanity check → generate → upload). Fork run used a hardcoded repo reference for testing; PR version uses `${{ github.repository }}`.

Downloaded the generated `checksums.sha256` from the fork release and ran `sha256sum -c checksums.sha256` locally against all assets attached to `v0.96.6` at test time — all returned OK.