### PR TITLE
docs: fix typo in tests README

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -34,7 +34,7 @@ gdb runtest
 # start under debugger:
 (gdb) run
 
-# if segfault occured:
+# if segfault occurred:
 (gdb) where
 ```
 


### PR DESCRIPTION
Fixes a small spelling typo in the tests README: `occured` -> `occurred`.

This PR was made using the GitHub API without cloning the repository locally.