### PR TITLE
fix: resolve dangling pointer in switch_output_file

### DIFF
--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -1352,35 +1352,47 @@ unsigned int get_font_encoded(struct encoder_ctx *ctx, unsigned char *buffer, in
 
 void switch_output_file(struct lib_ccx_ctx *ctx, struct encoder_ctx *enc_ctx, int track_id)
 {
-	// Do nothing when in "report" mode
 	if (enc_ctx == NULL || enc_ctx->out == NULL)
+		return;
+
+	const char *ext = get_file_extension(ctx->write_format);
+
+	char suffix[32];
+
+	snprintf(suffix, sizeof(suffix), "_%d", track_id);
+	// Prepare new values BEFORE freeing old ones
+	char *basename = get_basename(enc_ctx->out->original_filename);
+
+	if (basename == NULL)
+		return;
+	char *new_filename = create_outfilename(basename, suffix, ext);
+
+	free(basename);
+
+	if (new_filename == NULL)
+		return;
+	int new_fh = open(new_filename, O_RDWR | O_CREAT | O_TRUNC | O_BINARY, S_IREAD | S_IWRITE);
+
+	if (new_fh == -1)
 	{
+		free(new_filename);
 		return;
 	}
-
+	// Only now is it safe to free and replace the old values
 	if (enc_ctx->out->filename != NULL)
-	{ // Close and release the previous handle
-		free(enc_ctx->out->filename);
-		close(enc_ctx->out->fh);
-	}
-	const char *ext = get_file_extension(ctx->write_format);
-	char suffix[32];
-	snprintf(suffix, sizeof(suffix), "_%d", track_id);
-	char *basename = get_basename(enc_ctx->out->original_filename);
-	if (basename != NULL)
 	{
-		enc_ctx->out->filename = create_outfilename(basename, suffix, ext);
-		enc_ctx->out->fh = open(enc_ctx->out->filename, O_RDWR | O_CREAT | O_TRUNC | O_BINARY, S_IREAD | S_IWRITE);
-		free(basename);
+		free(enc_ctx->out->filename);
+		enc_ctx->out->filename = NULL;
+		close(enc_ctx->out->fh);
+		enc_ctx->out->fh = -1;
 	}
 
+	enc_ctx->out->filename = new_filename;
+	enc_ctx->out->fh = new_fh;
 	write_subtitle_file_header(enc_ctx, enc_ctx->out);
-
-	// Reset counters as we switch output file.
 	enc_ctx->cea_708_counter = 0;
 	enc_ctx->srt_counter = 0;
 }
-
 /**
  * Get or create the output file for a specific teletext page (issue #665)
  * Creates output files on-demand with suffix _pNNN (e.g., output_p891.srt)


### PR DESCRIPTION
Free old filename/fh only after new file is successfully opened. Uses prepare-then-swap pattern to avoid partial state where encoder has no valid output. Fixes #2273

<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

Reason for this PR:

- [ ] This PR adds new functionality.
- [x] This PR fixes a bug that I have personally experienced or that a real user has reported and for which a sample exists.
- [ ] This PR is porting code from C to Rust.

Sanity check:
- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] If the PR adds new functionality, I've added it to the changelog. If it's just a bug fix, I have NOT added it to the changelog.
- [x] I am NOT adding new C code unless it's to fix an existing, reproducible bug.

Repro instructions:

This is *essential*. We will not merge ANY PR that doesn't come with detailed instructions, *including a sample*. We don't want
"fixes" for theoretical issues that an AI agent found, without context. If you can't reproduce the bug, don't send a PR. 

Creating PRs with AI is very quick, but we still have humans (even if AI assisted) going over each.

Be mindful of reviewers' time.

---

Fixes #2273

Problem:

In switch_output_file, enc_ctx->out->filename was freed before confirming a new file could be successfully opened. If get_basename() or open() failed, the function would proceed with a dangling pointer being passed to write_subtitle_file_header(), causing undefined behavior.

Fix:

Uses a prepare-then-swap approach — the new filename and file descriptor are fully prepared first. The old values are only freed and replaced after the new file is confirmed open. If any step fails, the function returns early leaving the encoder context in its original valid state.
Testing:

Tested on multiprogram_spain.ts (multiprogram transport stream with 7 programs) — processed all programs without crashing and produced expected output.
