### PR TITLE
Fix use-after-free in switch_output_file on basename failure

### DIFF
--- a/src/lib_ccx/ccx_encoders_common.c
+++ b/src/lib_ccx/ccx_encoders_common.c
@@ -1361,18 +1361,25 @@ void switch_output_file(struct lib_ccx_ctx *ctx, struct encoder_ctx *enc_ctx, in
 	if (enc_ctx->out->filename != NULL)
 	{ // Close and release the previous handle
 		free(enc_ctx->out->filename);
+		enc_ctx->out->filename = NULL;
 		close(enc_ctx->out->fh);
 	}
 	const char *ext = get_file_extension(ctx->write_format);
 	char suffix[32];
 	snprintf(suffix, sizeof(suffix), "_%d", track_id);
 	char *basename = get_basename(enc_ctx->out->original_filename);
-	if (basename != NULL)
+	if (basename == NULL)
 	{
-		enc_ctx->out->filename = create_outfilename(basename, suffix, ext);
-		enc_ctx->out->fh = open(enc_ctx->out->filename, O_RDWR | O_CREAT | O_TRUNC | O_BINARY, S_IREAD | S_IWRITE);
-		free(basename);
+		// Without a basename there is no valid filename/handle to write
+		// to; bail out instead of falling through to write_subtitle_file_header()
+		// with the NULLed filename above (or, before that fix, a dangling
+		// pointer to the just-freed previous filename - see issue #2273).
+		mprint("WARNING: Unable to determine basename for output file when switching to track %d.\n", track_id);
+		return;
 	}
+	enc_ctx->out->filename = create_outfilename(basename, suffix, ext);
+	enc_ctx->out->fh = open(enc_ctx->out->filename, O_RDWR | O_CREAT | O_TRUNC | O_BINARY, S_IREAD | S_IWRITE);
+	free(basename);
 
 	write_subtitle_file_header(enc_ctx, enc_ctx->out);
 


### PR DESCRIPTION
## Why

`switch_output_file()` in `src/lib_ccx/ccx_encoders_common.c` frees the previous `enc_ctx->out->filename` unconditionally, then only reassigns it inside `if (basename != NULL)`:

```c
if (enc_ctx->out->filename != NULL)
{
    free(enc_ctx->out->filename);
    close(enc_ctx->out->fh);
}
...
char *basename = get_basename(enc_ctx->out->original_filename);
if (basename != NULL)
{
    enc_ctx->out->filename = create_outfilename(basename, suffix, ext);
    ...
}

write_subtitle_file_header(enc_ctx, enc_ctx->out);  // unconditional
```

If `get_basename()` returns `NULL` (allocation failure, or a `NULL`/unusual `original_filename`), `enc_ctx->out->filename` is left pointing at memory that was just freed, and `write_subtitle_file_header()` is called regardless — its call chain (`write_subtitle_file_header -> write_spumux_header -> spunpg_init`) dereferences `out->filename` (`strlen(out->filename)`, `memcpy(... out->filename ...)`), a use-after-free.

## Fix

- `enc_ctx->out->filename = NULL;` immediately after freeing it, so the pointer is never left dangling even momentarily.
- Return early (after an `mprint` warning, matching the existing logging convention in this file) when `basename` is `NULL`, instead of falling through to use a context with no valid filename/handle — there's nothing sensible to write a header for at that point anyway.

## Testing

I couldn't get a full build of this project running in my sandbox (no `cmake`, and the available MinGW toolchain doesn't have the FFmpeg/GPAC/etc. dev libraries this project links against), so I verified the logic two ways instead of guessing:

1. Confirmed the current `master` source matches the bug exactly as described (read `switch_output_file` and traced `write_subtitle_file_header -> write_spumux_header -> spunpg_init`'s use of `out->filename`).
2. Wrote a standalone, minimal C reproduction mirroring the exact pointer lifecycle (free → conditionally-skipped reassign → use), with an allocation between the free and the use to make the dangling read observably wrong instead of relying on undefined-but-coincidentally-OK behavior. Against the current logic this reliably shows the freed memory being read; against the patched logic it cleanly bails out with `filename == NULL` and never reads the dangling pointer.
3. Pasted the exact patched function (verbatim, with the real helper signatures stubbed to match `utility.h`) into a standalone file and compiled/ran it through both the normal and basename-failure paths to confirm no syntax issues and unchanged behavior on the happy path across repeated calls.

Happy to add this as a real unit test if there's an existing harness/fixture I should hook into - I didn't see one already covering `switch_output_file` or `get_basename` failure paths.

Fixes #2273.