### PR TITLE
fix(decoder): handle insufficient bytes in process_p16 and add unit test

### DIFF
--- a/src/rust/src/decoder/service_decoder.rs
+++ b/src/rust/src/decoder/service_decoder.rs
@@ -262,7 +262,14 @@ impl dtvcc_service_decoder {
             warn!("dtvcc_process_p16: Window has to be defined first");
             return;
         }
-        let sym = dtvcc_symbol::new_16(block[0], block[1]);
+        let Some((&byte0, &byte1)) = block.get(0).zip(block.get(1)) else {
+            warn!(
+                "dtvcc_process_p16: P16 command needs 2 data bytes but block only has {}; skipping",
+                block.len()
+            );
+            return;
+        };
+        let sym = dtvcc_symbol::new_16(byte0, byte1);
         debug!("dtvcc_process_p16: [{:4X}]", sym.sym);
         self.process_character(sym);
     }
@@ -1474,6 +1481,16 @@ mod test {
 
         // 4..infinite -> Invalid print direction
         decoder.windows[1].attribs.print_direction = 4;
+    }
+
+    #[test]
+    fn test_process_p16_insufficient_bytes() {
+        let mut decoder = setup_test_decoder_with_memory();
+
+        decoder.process_p16(&[]);
+        decoder.process_p16(&[b'a']);
+
+        cleanup_test_decoder(&mut decoder);
     }
 
     #[test]

--- a/src/rust/src/decoder/service_decoder.rs
+++ b/src/rust/src/decoder/service_decoder.rs
@@ -262,14 +262,14 @@ impl dtvcc_service_decoder {
             warn!("dtvcc_process_p16: Window has to be defined first");
             return;
         }
-        let Some((&byte0, &byte1)) = block.get(0).zip(block.get(1)) else {
+        if block.len() < 2 {
             warn!(
-                "dtvcc_process_p16: P16 command needs 2 data bytes but block only has {}; skipping",
+                "dtvcc_process_p16: needs 2 data bytes but block only has {}; skipping",
                 block.len()
             );
             return;
-        };
-        let sym = dtvcc_symbol::new_16(byte0, byte1);
+        }
+        let sym = dtvcc_symbol::new_16(block[0], block[1]);
         debug!("dtvcc_process_p16: [{:4X}]", sym.sym);
         self.process_character(sym);
     }
@@ -1484,16 +1484,6 @@ mod test {
     }
 
     #[test]
-    fn test_process_p16_insufficient_bytes() {
-        let mut decoder = setup_test_decoder_with_memory();
-
-        decoder.process_p16(&[]);
-        decoder.process_p16(&[b'a']);
-
-        cleanup_test_decoder(&mut decoder);
-    }
-
-    #[test]
     fn test_process_p16() {
         let mut decoder = setup_test_decoder_with_memory();
         let block = [b'a', b'b'] as [c_uchar; 2];
@@ -1508,6 +1498,16 @@ mod test {
                 dtvcc_symbol::new_16(block[0], block[1])
             );
         }
+
+        cleanup_test_decoder(&mut decoder);
+    }
+
+    #[test]
+    fn test_process_p16_insufficient_bytes() {
+        let mut decoder = setup_test_decoder_with_memory();
+
+        decoder.process_p16(&[]);
+        decoder.process_p16(&[b'a']);
 
         cleanup_test_decoder(&mut decoder);
     }


### PR DESCRIPTION
Updated the `process_p16` method to check for sufficient data bytes before processing, logging a warning if the input is inadequate. Added a unit test to verify behavior when insufficient bytes are provided.

**In raising this pull request, I confirm the following (please check boxes):**

Reason for this PR:

- [ ] This PR adds new functionality.
- [x] This PR fixes a bug that I have personally experienced or that a real user has reported and for which a sample exists.
- [ ] This PR is porting code from C to Rust.

Sanity check:

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] If the PR adds new functionality, I've added it to the changelog. If it's just a bug fix, I have NOT added it to the changelog.
- [x] I am NOT adding new C code unless it's to fix an existing, reproducible bug.

Repro instructions:

The reproduction steps and the crashing MPEG-2 TS sample file are already provided by the original reporter in the linked issue.

---

Fixes #2278

This PR resolves the index out of bounds panic in service_decoder.rs that occurs when processing certain broadcast MPEG-2 files. Added a check to ensure sufficient data bytes exist in the block before processing p16, logging a warning instead of crashing. Also included a unit test to verify this behavior.