### PR TITLE
fix(608): anchor pop-on->roll-up transition start time to first character, not CR

### DIFF
--- a/src/lib_ccx/ccx_decoders_608.c
+++ b/src/lib_ccx/ccx_decoders_608.c
@@ -854,7 +854,10 @@ void handle_command(unsigned char c1, const unsigned char c2, ccx_decoder_608_co
 			// not the character typing time. This matches FFmpeg's timing behavior.
 			if (context->rollup_from_popon && !changes)
 			{
-				context->ts_start_of_current_line = get_fts(context->timing, context->my_field);
+				// Transcript: anchor to CR time for the next write_cc_line().
+				// SRT: preserve first-char time already set by write_char() for cvm at changes=1.
+				if (context->output_format == CCX_OF_TRANSCRIPT)
+					context->ts_start_of_current_line = get_fts(context->timing, context->my_field);
 			}
 			else
 			{

--- a/src/lib_ccx/ccx_encoders_common.h
+++ b/src/lib_ccx/ccx_encoders_common.h
@@ -238,7 +238,7 @@ void write_cc_buffer_to_gui(struct eia608_screen *data, struct encoder_ctx *cont
 int write_cc_buffer_as_g608(struct eia608_screen *data, struct encoder_ctx *context);
 int write_cc_buffer_as_transcript2(struct eia608_screen *data, struct encoder_ctx *context);
 
-void write_cc_line_as_transcript2(struct eia608_screen *data, struct encoder_ctx *context, int line_number);
+int write_cc_line_as_transcript2(struct eia608_screen *data, struct encoder_ctx *context, int line_number);
 
 int write_cc_subtitle_as_srt(struct cc_subtitle *sub, struct encoder_ctx *context);
 int write_cc_subtitle_as_ssa(struct cc_subtitle *sub, struct encoder_ctx *context);

--- a/src/lib_ccx/ccx_encoders_transcript.c
+++ b/src/lib_ccx/ccx_encoders_transcript.c
@@ -236,7 +236,7 @@ int write_cc_subtitle_as_transcript(struct cc_subtitle *sub, struct encoder_ctx 
 }
 
 // TODO Convert CC line to TEXT format and remove this function
-void write_cc_line_as_transcript2(struct eia608_screen *data, struct encoder_ctx *context, int line_number)
+int write_cc_line_as_transcript2(struct eia608_screen *data, struct encoder_ctx *context, int line_number)
 {
 	int ret = 0;
 	int length = get_str_basic(context->subline, data->characters[line_number],
@@ -255,7 +255,7 @@ void write_cc_line_as_transcript2(struct eia608_screen *data, struct encoder_ctx
 			// is set for example by the write_char function, it possible that we don't have one in empty lines (unclear)
 			// For now, let's not consider this a bug as before and just return.
 			// fatal (EXIT_BUG_BUG, "Bug in timedtranscript (ts_start_of_current_line==-1). Please report.");
-			return;
+			return 0;
 		}
 
 		if (context->transcript_settings->showStartTime)
@@ -333,7 +333,9 @@ void write_cc_line_as_transcript2(struct eia608_screen *data, struct encoder_ctx
 		{
 			mprint("Warning:Loss of data\n");
 		}
+		return 1;
 	}
+	return 0;
 	// fprintf (wb->fh,encoded_crlf);
 }
 
@@ -356,8 +358,7 @@ int write_cc_buffer_as_transcript2(struct eia608_screen *data, struct encoder_ct
 				}
 			}
 
-			write_cc_line_as_transcript2(data, context, i);
-			wrote_something = 1;
+			wrote_something |= write_cc_line_as_transcript2(data, context, i);
 		}
 	}
 


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

Reason for this PR:

- [ ] This PR adds new functionality.
- [x] This PR fixes a bug that I have personally experienced or that a real user has reported and for which a sample exists.
- [ ] This PR is porting code from C to Rust.

Sanity check:
- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] If the PR adds new functionality, I've added it to the changelog. If it's just a bug fix, I have NOT added it to the changelog.
- [x] I am NOT adding new C code unless it's to fix an existing, reproducible bug.

Repro instructions:

This PR fixes Regression Test 84 which is currently failing on both linux and windows. Reference Test Run - [Windows](https://github.com/CCExtractor/ccextractor/pull/2290), [Linux](https://github.com/CCExtractor/ccextractor/pull/2290).

**Problem**
Regression test 84 (sample 79, `f23a544b...`, `--out=srt --latin1`) fails exact SHA-256 comparison against reference `e5c9d9ec...` Confirmed via CI history (sample-platform DB) failing continuously since test_id 6698 (Dec 2025, shortly after `54df50f` merged), including at the v0.96.6 release build (test 8446/8447).

8 caption entries in an 11,000-line file show incorrect start times when a 608 stream transitions from pop-on to roll-up mode mid-broadcast:

| Entry | Reference (correct) | Current output |
|-------|--------------------|--------------:|
| 20 | 00:01:06,499 | 00:01:09,102 |
| 2164 | 00:19:03,299 | 00:19:05,768 |
| (6 more, same pattern) | | |

End times match exactly in all 8 cases; only start times diverge, by 2-4.5s.

**Root cause**
The bug is in `COM_CARRIAGERETURN`'s handling of the `rollup_from_popon` transition-timing mechanism, added by PR #1808.

`54df50f` ("preserve CR time during pop-on to roll-up transition") added:

```c
if (context->rollup_from_popon && !changes)
    context->ts_start_of_current_line = get_fts(...);
```

During a transition, CRs with `changes==0` fire repeatedly while lines accumulate; this reassigns on every one, not just the first — the eventual `changes==1` CR inherits the last CR's time instead of the transition's actual start (per `--608` trace on sample 79).

The correct anchor is the fts of the first character written after the transition, via `write_char()`'s guard: `if (ts_start_of_current_line == -1) ts_start_of_current_line = get_fts(...)`. This guard is not new either — present, unmodified, at least since this repo's first commit; its actual origin predates that and isn't determinable from git history.

**Fix**
Two changes, both required:

In the `COM_CARRIAGERETURN` handler: for the `rollup_from_popon && !changes` case, only set `ts_start_of_current_line` to the CR time when `output_format == CCX_OF_TRANSCRIPT`. For SRT, leave it untouched so `write_char()`'s existing `== -1` guard anchors to the first character typed — which is what the SRT reference corpus (RT84) anchors to. Transcript mode needs CR time (RT29/RT30); SRT needs first-char time (RT84). A single unconditional change breaks one or the other.

In `write_cc_buffer_as_transcript2`: change `write_cc_line_as_transcript2` from `void` to `int` (returns 1 if content was written, 0 if not) and use `wrote_something |=` in the caller. PR #2105 (`03ad9e8e`) set `wrote_something = 1` unconditionally even when nothing was written for a blank cursor row, causing a bare newline to be emitted for every blank row. The `--null-terminated` WebSocket feature introduced by #2105 is unaffected.

**Verification**
- `sha256sum` of full ccextractor output on sample 79 matches reference `e5c9d9ec...` exactly. Diff before fix: 8 lines. After: 0, full file.
- RT29 / RT30 (`--out=ttxt --latin1`): transcript timing restored. 0-line diff vs reference.
- RT41 (`01509...ts`, `--out=ttxt --latin1`): two spurious blank lines removed. Output is byte-identical to accepted variant ref `9f139b8c...`.
- RT11 (`--out=srt`): first-line timing error from current master (`00:00:06,173` vs reference `00:00:01,868`) is fixed. Two residual sub-frame deltas (~68ms, ~34ms) are pre-existing and unrelated to this PR.
- Regression test 98 (`725a49f871.mpg`) and 156 (`c83f765c.ts`), `54df50f`'s own motivating samples: neither currently hash-matches its stored reference, and this predates this PR (confirmed via CI history, both platforms). This PR does not regress either: test 98's affected line is restored to exact match; test 156's largest timing error improves from 1301ms to 67ms. Remaining deltas in both (an XDS-path timing offset, a `#` vs music-note character substitution from `300f8ca`, and an unexplained residual ~67ms/2-field offset) are unrelated to this fix and out of scope for this PR.
- Not a fix for the WTV 751ms global-offset limitation noted in fix(timing): correct caption start/end times to match video frame PTS #1808 — that's a uniform epoch mismatch across a whole file; this PR's target file hash-matches its reference in full, ruling out a uniform offset here. Different mechanism, likely addressed separately by `300f8ca`.