### PR TITLE
fix(608): only apply pop-on→roll-up EOF fallback when start time is unset

### DIFF
--- a/src/lib_ccx/ccx_decoders_608.c
+++ b/src/lib_ccx/ccx_decoders_608.c
@@ -317,18 +317,18 @@ int write_cc_buffer(ccx_decoder_608_context *context, struct cc_subtitle *sub)
 	if (context->mode == MODE_FAKE_ROLLUP_1 && // Use the actual start of data instead of last buffer change
 	    context->ts_start_of_current_line != -1)
 		context->current_visible_start_ms = context->ts_start_of_current_line;
-
 	// Pop-on -> roll-up transition that never saw a scrolling CR (e.g. EOF
 	// with fewer lines than the roll-up window). The CR handler never ran,
 	// so back-fill current_visible_start_ms from the first-char FTS instead
 	// of emitting a caption starting at 0.
-	if (context->rollup_from_popon && context->ts_first_char_rollup_transition > 0)
+	if (context->rollup_from_popon &&
+	    context->ts_first_char_rollup_transition > 0 &&
+	    context->current_visible_start_ms <= 0)
 	{
 		context->current_visible_start_ms = context->ts_first_char_rollup_transition;
 		context->rollup_from_popon = 0;
 		context->ts_first_char_rollup_transition = -1;
 	}
-
 	start_time = context->current_visible_start_ms;
 	end_time = get_visible_end(context->timing, context->my_field);
 	sub->type = CC_608;


### PR DESCRIPTION
<!-- Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**. -->

**In raising this pull request, I confirm the following (please check boxes):**

Reason for this PR:

- [ ] This PR adds new functionality.
- [X] This PR fixes a bug that I have personally experienced or that a real user has reported and for which a sample exists.
- [ ] This PR is porting code from C to Rust.

Sanity check:
- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] If the PR adds new functionality, I've added it to the changelog. If it's just a bug fix, I have NOT added it to the changelog.
- [X] I am NOT adding new C code unless it's to fix an existing, reproducible bug.

Repro instructions:

This PR fixes [Regression Test 11](https://sampleplatform.ccextractor.org/test/9351), which fails on master on both Windows and Linux. On Linux, it currently shows a separate “No output generated but there should be” issue that is still under investigation; Reference test run - [Windows](https://sampleplatform.ccextractor.org/test/9351), [Linux](https://sampleplatform.ccextractor.org/test/9350).

---

## Problem

A 608 regression caused incorrect cue start times on a WTV sample, while subtitle text and end times remained correct.

## Root cause

[`689b27ce`](https://github.com/CCExtractor/ccextractor/commit/689b27ce2f0bf9c5ffac54ca7f14ef0ef2c642f5) added an EOF fallback for pop-on -> roll-up transitions by back-filling `current_visible_start_ms` from `ts_first_char_rollup_transition`.

That fallback was too broad: if `rollup_from_popon` was still set when `write_cc_buffer()` ran, it could overwrite an already valid `current_visible_start_ms` with the first-character FTS.

## Fix

Only apply the EOF fallback when `current_visible_start_ms` is still unset:

```c
if (context->rollup_from_popon &&
    context->ts_first_char_rollup_transition > 0 &&
    context->current_visible_start_ms <= 0)
```

This keeps the EOF fix from [`689b27ce`](https://github.com/CCExtractor/ccextractor/commit/689b27ce2f0bf9c5ffac54ca7f14ef0ef2c642f5) while avoiding clobbering valid cue start times on normal paths.

## Testing

- Reproduced the regression on the affected WTV sample - `611b4a9235c08....`
- Applied the guard above in `write_cc_buffer()`.
- Rebuilt CCExtractor and compared the generated SRT against the reference file.
- Verified that the diff between current output and the reference file (`2af8168380d0...`) is clean.