### PR TITLE
Fix 40ms gap in rolling teletext subtitles

### DIFF
--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -1054,8 +1054,11 @@ void process_telx_packet(struct TeletextCtx *ctx, data_unit_t data_unit_id, tele
 						ctx->page_buffer.text[yt][it] = telx_to_ucs2(ctx->page_buffer.text[yt][it]);
 				}
 			}
-			// it would be nice, if subtitle hides on previous video frame, so we contract 40 ms (1 frame @25 fps)
-			ctx->page_buffer.hide_timestamp = timestamp - 40;
+			// Previously subtracted 40ms (1 frame @ 25fps) to hide subtitle "early".
+			// This is wrong for non-25fps content and causes a visible ~41ms blink gap
+			// in rolling teletext subs, because the WebVTT exporter already subtracts
+			// 1ms to prevent timestamp boundary collisions. That 1ms is sufficient.
+			ctx->page_buffer.hide_timestamp = timestamp;
 			if (ctx->page_buffer.hide_timestamp > timestamp)
 			{
 				ctx->page_buffer.hide_timestamp = 0;

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -1054,16 +1054,12 @@ void process_telx_packet(struct TeletextCtx *ctx, data_unit_t data_unit_id, tele
 						ctx->page_buffer.text[yt][it] = telx_to_ucs2(ctx->page_buffer.text[yt][it]);
 				}
 			}
-			// Previously subtracted 40ms (1 frame @ 25fps) to hide subtitle "early".
-			// This produced a visible ~40ms blink gap in rolling teletext subs.
-			// It also caused zero-length cues when a page was displayed for exactly 40ms.
-			// Subtracting 1ms provides sufficient separation between adjacent cues
-			// to prevent overlap without causing a perceptible blink.
-			ctx->page_buffer.hide_timestamp = timestamp - 1;
-			if (ctx->page_buffer.hide_timestamp > timestamp)
-			{
-				ctx->page_buffer.hide_timestamp = 0;
-			}
+			// Previously subtracted 40ms (1 frame @ 25fps) to hide subtitle "early",
+			// but this produced a visible ~40ms blink gap in rolling teletext subs
+			// and caused zero-length cues when a page was displayed for exactly 40ms.
+			// WebVTT allows touching cues (where the end time of one cue perfectly matches
+			// the start time of the next), which makes rolling look continuous.
+			ctx->page_buffer.hide_timestamp = timestamp;
 			process_page(ctx, &ctx->page_buffer, sub);
 			de_ctr = 0;
 		}

--- a/src/lib_ccx/telxcc.c
+++ b/src/lib_ccx/telxcc.c
@@ -1055,10 +1055,11 @@ void process_telx_packet(struct TeletextCtx *ctx, data_unit_t data_unit_id, tele
 				}
 			}
 			// Previously subtracted 40ms (1 frame @ 25fps) to hide subtitle "early".
-			// This is wrong for non-25fps content and causes a visible ~41ms blink gap
-			// in rolling teletext subs, because the WebVTT exporter already subtracts
-			// 1ms to prevent timestamp boundary collisions. That 1ms is sufficient.
-			ctx->page_buffer.hide_timestamp = timestamp;
+			// This produced a visible ~40ms blink gap in rolling teletext subs.
+			// It also caused zero-length cues when a page was displayed for exactly 40ms.
+			// Subtracting 1ms provides sufficient separation between adjacent cues
+			// to prevent overlap without causing a perceptible blink.
+			ctx->page_buffer.hide_timestamp = timestamp - 1;
 			if (ctx->page_buffer.hide_timestamp > timestamp)
 			{
 				ctx->page_buffer.hide_timestamp = 0;


### PR DESCRIPTION
**[FIX]** Remove 40ms hide timestamp contraction in `telxcc` causing rolling subtitle blink and zero-length cues

---

**In raising this pull request, I confirm the following (please check boxes):**

Reason for this PR:
- [ ] This PR adds new functionality.
- [x] This PR fixes a bug that I have personally experienced or that a real user has reported and for which a sample exists.
- [ ] This PR is porting code from C to Rust.

Sanity check:
- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] If the PR adds new functionality, I've added it to the changelog. If it's just a bug fix, I have NOT added it to the changelog.
- [x] I am NOT adding new C code unless it's to fix an existing, reproducible bug.

---

## Fixes

Closes #2288

## Problem

When converting DVB teletext subtitles to WebVTT, rolling/scrolling subtitles that update every ~40ms produce a visible blink or flash between cues in players such as Infuse.

Additionally, teletext pages that are displayed for exactly 40ms collapse into zero-length cues (e.g., `00:00:00.997 --> 00:00:00.997`) and completely disappear from the output.

The root cause is in `src/lib_ccx/telxcc.c`. The `telxcc` component hardcodes a 40ms contraction on every subtitle hide timestamp:

```c
// it would be nice, if subtitle hides on previous video frame, so we contract 40 ms (1 frame @25 fps)
ctx->page_buffer.hide_timestamp = timestamp - 40;
```

This was originally intended to hide a subtitle one video frame early on 25fps content. This subtraction creates an explicit 40ms hole between the end of one cue and the start of the next. For rolling teletext that updates rapidly, this gap causes compliant players to assume the subtitle disappeared completely, resulting in a blink.

Furthermore, this 40ms subtraction is flawed because it incorrectly assumes all content is 25fps (which breaks for 24fps and 30fps video).

## Fix

Remove the 40ms contraction in `telxcc.c` entirely to allow touching boundaries (0ms gap).

```c
// Previously subtracted 40ms (1 frame @ 25fps) to hide subtitle "early",
// but this produced a visible ~40ms blink gap in rolling teletext subs
// and caused zero-length cues when a page was displayed for exactly 40ms.
// WebVTT allows touching cues (where the end time of one cue perfectly matches
// the start time of the next), which makes rolling look continuous.
ctx->page_buffer.hide_timestamp = timestamp;
```

(The dead unsigned underflow guard directly beneath it was also removed, as `hide_timestamp` can no longer underflow.)

Leaving the boundaries touching is completely valid in WebVTT and perfectly prevents the blink, allowing rolling text to render continuously. This also completely fixes the zero-length cues issue (a cue that previously vanished at 0ms duration will now correctly render with a 40ms duration).

## Repro Instructions

1. Take any DVB teletext stream containing rolling/scrolling subtitles (sample attached in issue #2288).
2. Convert to WebVTT using CCExtractor:

ccextractor input.ts -o output.vtt

3. Open the output in a player that renders WebVTT strictly.
4. Before fix: A visible 40ms blink is present between each rolling cue update, and cues that last exactly 40ms vanish entirely.
5. After fix: Subtitle rolls smoothly with no blink, and previously zero-length cues render correctly with a 40ms duration.