### PR TITLE
Fix Windows argument encoding by fetching UTF-8 command line

### DIFF
--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -9,6 +9,10 @@ CI verification run: 2025-12-19T08:30 - Testing merged fixes from PRs #1847 and 
 #include <stdio.h>
 #include <locale.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#include <shellapi.h>
+#endif
 volatile int terminate_asap = 0;
 
 struct ccx_s_options ccx_options;
@@ -432,6 +436,24 @@ int start_ccx()
 
 int main(int argc, char *argv[])
 {
+#ifdef _WIN32
+	// On Windows, the standard argv is encoded in the local ANSI code page.
+	// We need it in UTF-8, so we fetch the Unicode command line and convert it.
+	int wargc;
+	wchar_t **wargv = CommandLineToArgvW(GetCommandLineW(), &wargc);
+	if (wargv)
+	{
+		argv = (char **)malloc(wargc * sizeof(char *));
+		argc = wargc;
+		for (int i = 0; i < wargc; i++)
+		{
+			int size = WideCharToMultiByte(CP_UTF8, 0, wargv[i], -1, NULL, 0, NULL, NULL);
+			argv[i] = (char *)malloc(size);
+			WideCharToMultiByte(CP_UTF8, 0, wargv[i], -1, argv[i], size, NULL, NULL);
+		}
+		LocalFree(wargv);
+	}
+#endif
 	setlocale(LC_ALL, ""); // Supports non-English CCs
 			       // Use POSIX locale for numbers so we get "." as decimal separator and no
 			       // thousands' groupoing instead of what the locale might say

--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -472,8 +472,8 @@ int main(int argc, char *argv[])
 	setlocale(LC_NUMERIC, "POSIX");
 #else
 	setlocale(LC_ALL, ""); // Supports non-English CCs
-		               // Use POSIX locale for numbers so we get "." as decimal separator and no
-		               // thousands' groupoing instead of what the locale might say
+			       // Use POSIX locale for numbers so we get "." as decimal separator and no
+			       // thousands' groupoing instead of what the locale might say
 	setlocale(LC_NUMERIC, "POSIX");
 #endif
 

--- a/src/ccextractor.c
+++ b/src/ccextractor.c
@@ -443,21 +443,39 @@ int main(int argc, char *argv[])
 	wchar_t **wargv = CommandLineToArgvW(GetCommandLineW(), &wargc);
 	if (wargv)
 	{
-		argv = (char **)malloc(wargc * sizeof(char *));
-		argc = wargc;
+		// +1 for the NULL terminator required by the C standard
+		char **new_argv = (char **)malloc((wargc + 1) * sizeof(char *));
+		if (!new_argv)
+			fatal(EXIT_NOT_ENOUGH_MEMORY, "In main: not enough memory for new_argv.\n");
 		for (int i = 0; i < wargc; i++)
 		{
 			int size = WideCharToMultiByte(CP_UTF8, 0, wargv[i], -1, NULL, 0, NULL, NULL);
-			argv[i] = (char *)malloc(size);
-			WideCharToMultiByte(CP_UTF8, 0, wargv[i], -1, argv[i], size, NULL, NULL);
+			if (size == 0)
+				fatal(EXIT_READ_ERROR, "In main: WideCharToMultiByte sizing failed.\n");
+			new_argv[i] = (char *)malloc(size);
+			if (!new_argv[i])
+				fatal(EXIT_NOT_ENOUGH_MEMORY, "In main: not enough memory for new_argv[i].\n");
+			WideCharToMultiByte(CP_UTF8, 0, wargv[i], -1, new_argv[i], size, NULL, NULL);
 		}
+		new_argv[wargc] = NULL;
 		LocalFree(wargv);
+		argv = new_argv;
+		argc = wargc;
 	}
-#endif
-	setlocale(LC_ALL, ""); // Supports non-English CCs
-			       // Use POSIX locale for numbers so we get "." as decimal separator and no
-			       // thousands' groupoing instead of what the locale might say
+	// Tell the UCRT to treat all narrow char* strings as UTF-8 so that
+	// C file APIs (_open, fopen, etc.) can open paths with non-ASCII characters.
+	setlocale(LC_ALL, ".UTF8");
+	// Ensure the console can display UTF-8 text correctly.
+	SetConsoleOutputCP(CP_UTF8);
+	// Use POSIX locale for numbers so we get "." as decimal separator and no
+	// thousands' grouping instead of what the locale might say
 	setlocale(LC_NUMERIC, "POSIX");
+#else
+	setlocale(LC_ALL, ""); // Supports non-English CCs
+		               // Use POSIX locale for numbers so we get "." as decimal separator and no
+		               // thousands' groupoing instead of what the locale might say
+	setlocale(LC_NUMERIC, "POSIX");
+#endif
 
 	init_options(&ccx_options);
 


### PR DESCRIPTION
**[FIX]** Resolve Windows ANSI argument mangling for non-ASCII paths

**In raising this pull request, I confirm the following (please check boxes):**
Reason for this PR:
- [ ] This PR adds new functionality.
- [x] This PR fixes a bug that I have personally experienced or that a real user has reported and for which a sample exists.
- [ ] This PR is porting code from C to Rust.

Sanity check:
- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] If the PR adds new functionality, I've added it to the changelog. If it's just a bug fix, I have NOT added it to the changelog.
- [x] I am NOT adding new C code unless it's to fix an existing, reproducible bug.

---

## Fixes
Closes #2284

## Problem

On Windows, the standard `main(int argc, char *argv[])` entry point receives arguments encoded in the system's local legacy ANSI code page (e.g., CP-1252), not UTF-8. 
indows ANSI argument mangling for non-ASCII paths

**In raising this pull request, I confirm the following (please check boxes):**
Reason for this PR:
- [ ] This PR adds new functionality.
- [x] This PR fixes a bug that I have personally experienced or that a real user has reported and for which a sample exists.
- [ ] This PR is porting code from C to Rust.

Sanity check:
- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] If the PR adds new functionality, I've added it to the changelog. If it's just a bug fix, I have NOT added it to the changelog.
- [x] I am NOT adding new C code unless it's to fix an existing, reproducible bug.

---

## Fixes
Closes #2284

## Problem

On Windows, the standard `main(int argc, char *argv[])` entry point receives arguments encoded in the system's local legacy ANSI code page (e.g., CP-1252), not UTF-8. 

When these arguments are passed to the new Rust parameter parser (`ccxr_parse_parameters`), Rust strictly expects UTF-8 strings and attempts to parse them using `to_string_lossy()`. Because non-ASCII ANSI characters (like the `£` symbol, which is `0xA3`) are invalid UTF-8 byte sequences, they get gracefully replaced with the Unicode Replacement Character (U+FFFD). When printed back to the console, this manifests as mangled, permanently mangling the file path and preventing CCExtractor from opening the file.

## Fix

Added a Windows-specific `#ifdef _WIN32` block at the very top of `main()` in `ccextractor.c` to intercept and sanitize the arguments. 

It uses the native Windows APIs `GetCommandLineW()` and `CommandLineToArgvW()` to fetch the raw UTF-16 Unicode command line, safely converts the wide strings to standard UTF-8 using `WideCharToMultiByte()`, and dynamically overrides the legacy `argv` array before it is passed to the rest of the application. 

This perfectly preserves all non-ASCII characters without changing the Rust API, breaking backwards compatibility for libraries, or changing the main entry point signature.

## Repro instructions

1. On a standard Windows installation without global UTF-8 beta features enabled, rename any video file to include the `£` symbol. Example: `£5 Million Restoration.ts`.
2. Run CCExtractor against it: `ccextractorwinfull.exe "£5 Million Restoration.ts"`.
3. **Before fix:** CCExtractor fails with `Error: Failed to open one of the input file(s): File does not exist.` and prints the mangled input file name as `ï¿½5 Million Restoration.ts`.
4. **After fix:** CCExtractor successfully parses the `£` symbol, natively locates the file, and proceeds to extract the captions.