### PR TITLE
[FIX] Correct typo: hat was -> that was

### DIFF
--- a/docs/ccextractor.cnf.sample
+++ b/docs/ccextractor.cnf.sample
@@ -143,7 +143,7 @@ INPUT_SOURCE=0
 # By default its 1, ccextractor will process input files in
 # sequence as if they were all one large file i.e
 # split by a generic, non video-aware tool. If you
-# are processing video hat was split with a editing
+# are processing video that was split with a editing
 # tool, use 0 so ccextractor doesn't try to rebuild
 # the original timing.
 # This tag take 0 or 1 in input

--- a/src/lib_ccx/params.c
+++ b/src/lib_ccx/params.c
@@ -195,7 +195,7 @@ void print_usage(void)
 	mprint("       --videoedited: By default, ccextractor will process input files in\n");
 	mprint("                       sequence as if they were all one large file (i.e.\n");
 	mprint("                       split by a generic, non video-aware tool. If you\n");
-	mprint("                       are processing video hat was split with a editing\n");
+	mprint("                       are processing video that was split with a editing\n");
 	mprint("                       tool, use --ve so ccextractor doesn't try to rebuild\n");
 	mprint("                       the original timing.\n");
 	mprint("   -s --stream [secs]: Consider the file as a continuous stream that is\n");

--- a/src/rust/src/args.rs
+++ b/src/rust/src/args.rs
@@ -311,7 +311,7 @@ pub struct Args {
     /// By default, ccextractor will process input files in
     /// sequence as if they were all one large file (i.e.
     /// split by a generic, non video-aware tool. If you
-    /// are processing video hat was split with a editing
+    /// are processing video that was split with a editing
     /// tool, use --videoedited so ccextractor doesn't try to rebuild
     /// the original timing.
     #[arg(long, verbatim_doc_comment, help_heading=OPTIONS_AFFECTING_INPUT_FILES)]


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

Reason for this PR:

- [ ] This PR adds new functionality.
- [x] This PR fixes a bug that I have personally experienced or that a real user has reported and for which a sample exists.
- [ ] This PR is porting code from C to Rust.

Sanity check:
- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] If the PR adds new functionality, I've added it to the changelog. If it's just a bug fix, I have NOT added it to the changelog.
- [x] I am NOT adding new C code unless it's to fix an existing, reproducible bug.

Repro instructions:

1. Execute `ccextractor -h | grep -i " hat was"`
2. Observe that this string is printed to stdout: `are processing video hat was split with a editing`

---

This PR fixes three instances of the same typo.
