### PR TITLE
[FIX] --out report: probe both EIA-608 fields so CC3/CC4 are reported accurately (#2177)

### DIFF
--- a/src/rust/src/demuxer/stream_functions.rs
+++ b/src/rust/src/demuxer/stream_functions.rs
@@ -392,7 +392,7 @@ pub fn detect_myth(ctx: &mut CcxDemuxer) -> i32 {
         uc.copy_from_slice(&ctx.startbytes[..3]);
 
         for &byte in &ctx.startbytes[3..ctx.startbytes_avail as usize] {
-            if (uc == [b't', b'v', b'0']) || (uc == [b'T', b'V', b'0']) {
+            if (uc == *b"tv0") || (uc == *b"TV0") {
                 vbi_blocks += 1;
             }
 

--- a/src/rust/src/parser.rs
+++ b/src/rust/src/parser.rs
@@ -204,6 +204,9 @@ impl OptionsExt for Options {
                 self.messages_target = OutputTarget::Quiet;
                 self.print_file_reports = true;
                 self.demux_cfg.ts_allprogram = true;
+                // Probe both EIA-608 fields so CC3/CC4 presence is reported accurately (issue #2177).
+                // Runs before --output-field parsing, so an explicit field choice still overrides this.
+                self.extract = 12;
             }
             OutFormat::Raw => self.write_format = OutputFormat::Raw,
             OutFormat::Smptett => self.write_format = OutputFormat::SmpteTt,
@@ -1573,6 +1576,7 @@ impl OptionsExt for Options {
             && self.cc_to_stdout
             && self.extract != 0
             && self.extract == 12
+            && !self.print_file_reports
         {
             fatal!(
                 cause = ExitCause::IncompatibleParameters;
@@ -1918,6 +1922,15 @@ pub mod tests {
         assert_eq!(options.write_format, OutputFormat::Null);
         assert!(options.print_file_reports);
         assert!(options.demux_cfg.ts_allprogram);
+        // issue #2177: report mode probes both fields by default
+        assert_eq!(options.extract, 12);
+    }
+
+    #[test]
+    fn test_out_report_explicit_field_overrides_both() {
+        let (options, _) = parse_args(&["--out", "report", "--output-field", "1"]);
+        assert!(options.print_file_reports);
+        assert_eq!(options.extract, 1);
     }
 
     // =========================================================================


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

Reason for this PR:

- [ ] This PR adds new functionality.
- [X] This PR fixes a bug that I have personally experienced or that a real user has reported and for which a sample exists.
- [ ] This PR is porting code from C to Rust.

Sanity check:
- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] If the PR adds new functionality, I've added it to the changelog. If it's just a bug fix, I have NOT added it to the changelog.
- [X] I am NOT adding new C code unless it's to fix an existing, reproducible bug.

Repro instructions:

```sh
ffmpeg -i "https://weather.horse/samples/cc3.mkv" -c copy cc3.ts -y
ccextractor --out report cc3.ts
```

## Before / After

Sample `cc3.ts` (captions on field 2; this sample does **not** contain XDS):

Before:
```
EIA-608: Yes
CC1: No
CC2: No
CC3: No      <-- wrong, CC3 is present
CC4: No
```

After:
```
EIA-608: Yes
CC1: No
CC2: No
CC3: Yes     <-- correct
CC4: No
```

## Issue

Fixes #2177.

`--out report` reports `CC3` / `CC4` as **No** even when the stream carries captions on EIA-608 **field 2** (CC3/CC4 live on field 2). The report is therefore inaccurate for any field-2-only source.

## Root cause

The report path never asked the decoder to look at field 2.

`options->extract` defaults to `1` (field 1 only) — `src/lib_ccx/ccx_common_option.c:28`. The `--out report` arm never changed it, so the decoder's field gate (`src/lib_ccx/ccx_decoders_608.c:1185-1193`, which only processes field 2 when `extract == 2 || extract == 12`) skipped field 2 entirely. CC3/CC4 presence was never probed, so it was always reported as No.

## Fix

Set `extract = 12` (both fields) in the `OutFormat::Report` arm (`src/rust/src/parser.rs:202-209`).

As a side effect, report mode also correctly reports XDS on streams that carry XDS data, since XDS is transmitted on EIA-608 field 2. The `cc3.ts` sample above does not contain XDS, so that behavior is not demonstrated by this reproducer.

Two supporting details keep this scoped:

1. **Explicit `--output-field` still wins.** The Report arm runs during `set_output_format` (parser.rs:783); `--output-field` is parsed afterwards (parser.rs:988) and overwrites `extract`. Order of CLI flags is irrelevant because processing order in `parse_parameters` is fixed.
2. **The "both fields to stdout" guard is bypassed for report mode only.** Because report now carries `extract == 12`, `--out report --stdout` would otherwise trip the broadcast-mode guard (parser.rs:1575-1585). The guard now has `&& !self.print_file_reports`, so it is relaxed *only* for report mode. Report writes `write_format = Null` (no caption stream to stdout), so the guard is meaningless there; normal extraction is unaffected.

The change is 13 lines, Rust-only, entirely inside the report arm + that one guard. It does not alter `extract` for any non-report invocation.

This PR also includes an unrelated Rust Clippy cleanup (`byte_char_slices`) in `stream_functions.rs`.

## Testing

Built from this branch (binary reports Git commit `0d968cde`). All behaviours verified against `cc3.ts`:

| Command | Result |
|---|---|
| `--out report` | CC3 **Yes**, exit 10 (normal report exit), no files |
| `--out report --output-field 1` | CC3 **No** (explicit override wins) |
| `--out report --output-field both` | CC3 **Yes** |
| `--out report --stdout` | report printed, no fatal, no files |
| `--out report --output-field both --stdout` | report printed, no fatal |
| `--output-field both --stdout` (normal) | still rejected: *"You can't extract both fields to stdout…"* (exit 4) |
| `--output-field 1 --out report` vs `--out report --output-field 1` | identical (CC3 No) — flag order irrelevant |
| normal extraction, `--output-field 1`, `--output-field 2`, `--output-field both` | unchanged (exit 0, expected output files) |

Regression scope verified: the only new `extract` write is inside the report arm, and the stdout-guard edit is a no-op when `print_file_reports == false`, so non-report behaviour cannot change. The C-side `extract == 12` encoder branches (`ccx_encoders_common.c:583/605/643/920`) are inert in report mode because `generates_file = 0` for `CCX_OF_NULL` (verified: `--out report -o out.srt` creates no files) and `encode_sub` has no `CCX_OF_NULL` case.

Unit tests: `src/rust` — `parser::` module 204/204 pass, including:
- `test_out_report_enables_file_reports` (now asserts `extract == 12`)
- `test_out_report_explicit_field_overrides_both`