### PR TITLE
[FIX]: Fix libpng ARM source inclusion for non-Darwin AArch64 CMake builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,13 +67,16 @@ include_directories(${PROJECT_SOURCE_DIR}/thirdparty)
 include_directories(${PROJECT_SOURCE_DIR}/thirdparty/lib_hash)
 include_directories(${PROJECT_SOURCE_DIR}/thirdparty/libpng)
 
+# libpng NEON sources are needed on any arm64/aarch64 target, not just Darwin
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$")
+  include_directories(${PROJECT_SOURCE_DIR}/thirdparty/libpng/arm)
+  aux_source_directory(${PROJECT_SOURCE_DIR}/thirdparty/libpng/arm SOURCEFILE)
+endif()
+
 # Check if the operating system is macOS (Darwin)
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  if(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "arm64")
-    # ARM Macs
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$")
     include_directories("/opt/homebrew/include")
-    include_directories(${PROJECT_SOURCE_DIR}/thirdparty/libpng/arm)
-    aux_source_directory(${PROJECT_SOURCE_DIR}/thirdparty/libpng/arm SOURCEFILE)
   else()
     include_directories("/usr/local/include")
   endif()


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

Reason for this PR:

- [ ] This PR adds new functionality.
- [X] This PR fixes a bug that I have personally experienced or that a real user has reported and for which a sample exists.
- [ ] This PR is porting code from C to Rust.

Sanity check:
- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] If the PR adds new functionality, I've added it to the changelog. If it's just a bug fix, I have NOT added it to the changelog.
- [X] I am NOT adding new C code unless it's to fix an existing, reproducible bug.

Repro instructions:

- Reproduced the failure while building CCExtractor with CMake on Linux AArch64 (Ubuntu 24.04, GCC 13.3, CMake 3.28) using the pre-fix `CMakeLists.txt`.

---

## Issue

Building CCExtractor from source with CMake on Linux AArch64 (Ubuntu 24.04, GCC 13.3, CMake 3.28) fails at link time:

```text
/usr/bin/ld: pngrtran.c: undefined reference to `png_do_expand_palette_rgba8_neon'
/usr/bin/ld: pngrtran.c: undefined reference to `png_do_expand_palette_rgb8_neon'
/usr/bin/ld: pngrtran.c: undefined reference to `png_riffle_palette_neon'
/usr/bin/ld: pngrutil.c: undefined reference to `png_init_filter_functions_neon'
collect2: error: ld returned 1 exit status
```

The identical commit builds cleanly on Apple Silicon macOS.

## Root Cause

Bundled libpng (`thirdparty/libpng/pngpriv.h`) auto-enables ARM NEON code paths (`PNG_ARM_NEON_OPT=2`) whenever the compiler defines `__ARM_NEON`/ `__ARM_NEON__` — which GCC/clang do unconditionally on any aarch64 target, since NEON is mandatory in the AArch64 ISA. This causes `pngrtran.c` and `pngrutil.c` to reference NEON symbols regardless of OS.

However, `src/CMakeLists.txt` only compiled the NEON implementation sources (`thirdparty/libpng/arm/*.c`) under `Darwin` + `arm64`:

```cmake
if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
  if(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "arm64")
    include_directories(${PROJECT_SOURCE_DIR}/thirdparty/libpng/arm)
    aux_source_directory(${PROJECT_SOURCE_DIR}/thirdparty/libpng/arm SOURCEFILE)
  else()
    include_directories("/usr/local/include")
  endif()
endif()
```

On Linux AArch64 the symbols are referenced but never defined, producing the undefined-reference errors above.

## Fix

Split the OS-specific include-path logic from the architecture-specific source-selection logic, and gate the latter on the target processor (`CMAKE_SYSTEM_PROCESSOR`) rather than host + OS:

```cmake
# ARM libpng sources
if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$")
    include_directories(${PROJECT_SOURCE_DIR}/thirdparty/libpng/arm)
    aux_source_directory(${PROJECT_SOURCE_DIR}/thirdparty/libpng/arm SOURCEFILE)
endif()

# macOS include paths
if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
    if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$")
        include_directories("/opt/homebrew/include")
    else()
        include_directories("/usr/local/include")
    endif()
endif()
```

`CMAKE_SYSTEM_PROCESSOR` (target arch) is used instead of `CMAKE_HOST_SYSTEM_PROCESSOR` (build-machine arch), which is also the technically correct variable for this decision and fixes a latent cross-compilation bug in the original code (host arch and target arch only happened to match for native builds).

Behavior on macOS Intel, Apple Silicon, and Linux x86_64 is unchanged.

## Testing

- Reproduced the failure on Linux AArch64 (Ubuntu 24.04, GCC 13.3, CMake 3.28) with the original CMake configuration.
- Applied this patch and performed a clean rebuild
- Verified that the bundled libpng ARM NEON sources are now compiled into the build by confirming the generated object files (e.g. `filter_neon_intrinsics.c.o` and `palette_neon_intrinsics.c.o`), which were absent before the change.
- Confirmed the previous undefined NEON linker errors no longer occur.
- Verified the resulting binary by running, it executes successfully and prints the expected version information.