### PR TITLE
[FIX] scc: don't prefix special characters with a base char, and fix out-of-bounds control code at column 0

### DIFF
--- a/docs/CHANGES.TXT
+++ b/docs/CHANGES.TXT
@@ -1,5 +1,7 @@
 0.96.7 (unreleased)
 -------------------
+- Fix: Correctly encode EIA-608 special and extended characters (apostrophes, quotes, music notes, accented letters) in --out=scc and --out=ccd instead of writing raw internal bytes (#2098)
+- Fix: Crash in --out=ccd and corrupt control codes in --out=scc when a caption needs a mid-row style change in column 0 (out-of-bounds control code index)
 - Fix: Move C0 bounds check before match in CEA-708 Rust decoder to prevent process_p16 index-out-of-bounds panic on truncated ATSC1.0 TS blocks; improve C1 warn message with command code and lengths (#1407)
 - New: Allow output \0 terminated frames via --null-terminated
 - New: Added ASS/SSA \pos-based positioning for CEA-608 captions when layout is simple (1–2 rows) (#1726)

--- a/src/lib_ccx/ccx_encoders_scc.c
+++ b/src/lib_ccx/ccx_encoders_scc.c
@@ -96,8 +96,22 @@ static unsigned int calculate_caption_bytes(const struct eia608_screen *data)
 				prev_color = data->colors[row][col];
 			}
 
-			// Text character
-			char_count++;
+			// Text character. Special/extended chars are not written as one byte:
+			// a special char (0x80-0x8f) costs the 2-byte 608 code, and an extended
+			// char (0x90-0xcf) additionally carries a fallback base char before it.
+			// Counting them as 1 byte made the preroll start too late.
+			if (data->characters[row][col] >= 0x90)
+			{
+				char_count += 3;
+			}
+			else if (data->characters[row][col] >= 0x80)
+			{
+				char_count += 2;
+			}
+			else
+			{
+				char_count++;
+			}
 			prev_col = col;
 		}
 
@@ -610,12 +624,14 @@ void check_padding(const int fd, bool disassemble, unsigned int *bytes_written)
  *   special  0x80-0x8f: hi=0x11, lo=c-0x50
  *   extended 0x90-0xaf: hi=0x12, lo=c-0x70
  *   extended 0xb0-0xcf: hi=0x13, lo=c-0x90
- * (hi is the odd-channel value; caller adds 8 for field 2.)
+ * (hi is the channel-1 value; caller adds 8 for channel 2, i.e. CC2/CC4.)
  *
- * Returns the fallback base character transmitted immediately before the extended
- * code, which a decoder lacking extended-character support displays before the extended
- * code backspace-replaces it. When the char's UTF-8 form is a single ASCII byte we reuse it
- * (matches real streams/FFmpeg, e.g. apostrophe -> 0x27 -> "a7"); otherwise a space.
+ * Returns the fallback base character transmitted immediately before an EXTENDED
+ * code, which a decoder lacking extended-character support displays before the
+ * extended code backspace-replaces it. When the char's UTF-8 form is a single ASCII
+ * byte we reuse it (matches real streams/FFmpeg, e.g. apostrophe -> 0x27 -> "a7");
+ * otherwise a space. The return value is unused for special chars, which are
+ * stand-alone and are not preceded by a base character.
  */
 static unsigned char get_extended_scc_code(unsigned char c, unsigned char *hi, unsigned char *lo)
 {
@@ -631,6 +647,13 @@ static unsigned char get_extended_scc_code(unsigned char c, unsigned char *hi, u
 	}
 	else
 	{
+		// The decoder never produces codes above 0xcf (get_char_in_utf_8 maps
+		// 0x80-0xcf and nothing beyond), so clamp rather than emit a lo byte
+		// outside the valid 0x20-0x3f range.
+		if (c > 0xcf)
+		{
+			c = 0xcf;
+		}
 		*hi = 0x13;
 		*lo = c - 0x90;
 	}
@@ -660,22 +683,35 @@ void write_character(const int fd, const unsigned char channel, const unsigned c
 		return;
 	}
 
-	// SCC: special/extended chars (>= 0x80) are not valid single-byte characters. Emit a
-	// padded fallback base char followed by the two-byte extended code, which destructively
-	// backspace-replaces it (e.g. apostrophe -> "a7 80 92 29"). check_padding keeps the
-	// extended pair 2-byte aligned.
+	// SCC: special/extended chars (>= 0x80) are not valid single-byte characters, so emit
+	// the two-byte EIA-608 code they came from.
+	//
+	// EXTENDED chars (0x90-0xcf, hi 0x12/0x13) destructively backspace-replace the cell
+	// before them (ccx_decoders_608.c handle_extended() decrements cursor_column), so the
+	// stream must carry a fallback base char for them to overwrite -- apostrophe becomes
+	// "a7 80 92 29".
+	//
+	// SPECIAL chars (0x80-0x8f, hi 0x11) are stand-alone: handle_double() writes them
+	// without moving the cursor back. Emitting a base char for those would leave it on
+	// screen, inserting a spurious space before every one: a row starting with a music
+	// note came back one column further right on re-decode.
 	if (character >= 0x80)
 	{
 		unsigned char hi, lo;
 		unsigned char base = get_extended_scc_code(character, &hi, &lo);
 		if (!is_odd_channel(channel))
-			hi += 8; // field 2 (CC3/CC4) uses 0x19/0x1a/0x1b
+			hi += 8; // channel 2 (CC2/CC4) uses 0x19/0x1a/0x1b
 
-		if (*bytes_written % 2 == 0)
-			write_wrapped(fd, " ", 1);
-		fdprintf(fd, "%02x", odd_parity(base));
-		++*bytes_written;
+		if (character >= 0x90)
+		{
+			if (*bytes_written % 2 == 0)
+				write_wrapped(fd, " ", 1);
+			fdprintf(fd, "%02x", odd_parity(base));
+			++*bytes_written;
+		}
 
+		// The two-byte code has to start at an even offset so it lands inside a single
+		// SCC word; otherwise it straddles two frames and is read as two other codes.
 		check_padding(fd, disassemble, bytes_written);
 
 		if (*bytes_written % 2 == 0)
@@ -1054,9 +1090,16 @@ int write_cc_buffer_as_scenarist(const struct eia608_screen *data, struct encode
 					else
 					{
 						// Column - 1 because the preamble code is going to
-						// move the cursor to the right
-						position_code = get_preamble_code(row, column - 1);
-						tab_offset_code = get_tab_offset_code(column - 1);
+						// move the cursor to the right. At column 0 there is
+						// no cell to the left: column - 1 wraps to 255 in the
+						// unsigned char parameter and indexes control_codes[]
+						// far out of bounds (row 12 yielded code 186 against
+						// CONTROL_CODE_MAX 147, crashing --out=ccd). Keep the
+						// preamble at column 0 and let the mid-row code take
+						// the first cell, as the space branch above does.
+						const unsigned char pac_column = column > 0 ? column - 1 : 0;
+						position_code = get_preamble_code(row, pac_column);
+						tab_offset_code = get_tab_offset_code(pac_column);
 					}
 					font_code = get_font_code(data->fonts[row][column], data->colors[row][column]);
 				}


### PR DESCRIPTION
Follow-up to #2301. Two defects in the SCC/CCD writer, both found while deep-reviewing that PR.

## 1. Special characters gained a spurious leading space

#2301 emits a fallback base character before every internal code `>= 0x80`. That is right for **extended** characters (`0x90-0xcf`, hi `0x12`/`0x13`) — `handle_extended()` decrements `cursor_column`, so they destructively replace the cell before them and the stream has to carry something for them to overwrite.

It is wrong for **special** characters (`0x80-0x8f`, hi `0x11`). `handle_double()` writes those without moving the cursor back, so the base character stays on screen and every special character comes back one column further right.

```
reference    : ♪ (Wendy Talbot) DEAR JOHN,
master today :  ♪ (Wendy Talbot) DEAR JOHN,   <- spurious space
this PR      : ♪ (Wendy Talbot) DEAR JOHN,
```

Fix: only emit the base character for extended codes. `check_padding()` still runs in both cases so the two-byte code starts on an even offset and lands inside a single SCC word.

### Testing

Generated an SCC exercising all 80 codes in `0x80-0xcf`, re-encoded it and decoded it again:

| | wrong of 80 |
|---|---|
| before #2301 | 79 |
| master (with #2301) | 16 |
| this PR | 0 |

Real samples: `725a49f871` (15 music-note rows) and `c032183ef0` (3) now round-trip with no altered text. The apostrophe from #2098 is unchanged — still `a7 80 92 29`.

## 2. Out-of-bounds control code index when a style change starts at column 0

`get_preamble_code()` and `get_tab_offset_code()` take `unsigned char`. The `column - 1` used to place the preamble one cell to the left wraps to 255 at column 0, giving `255 / 4 = 63` and an index far past the end of `control_codes[]` — row 12 produces code **186** against `CONTROL_CODE_MAX` **147**.

In `--out=ccd` that entry's `assembly` pointer is handed to `strlen()` and segfaults. In `--out=scc` it silently emits whatever ints happen to follow the array.

This read predates #2301 — 2 of 20 local samples hit it both before and after — but #2301 shifted the binary layout so the garbage pointer now lands in unmapped memory. It went from quietly wrong to a hard crash:

```
pre-#2301 build : --out=ccd exit 0   (instrumented: 'BADCODE 186, max 147')
master today    : --out=ccd SIGSEGV
this PR         : --out=ccd exit 0
```

Fix: clamp the preamble column to 0, which is what the adjacent space branch already does.

## Regression scope

- Non-SCC output (`txt`, `sami`, `srt`, `ttxt`, `webvtt`, `g608`) byte-identical to master across 20 samples.
- Of those 20, SCC output changes on 12 that contain special characters and 1 that hit the out-of-bounds index; the other 7 are unchanged.
- Valgrind: no invalid reads. Only the pre-existing 32-byte `init_encoder` leak, which master has too.
- `clang-format` clean.