### PR TITLE
[FIX] networking: print int length with %d in NETWORKING_DEBUG output

### DIFF
--- a/src/lib_ccx/networking.c
+++ b/src/lib_ccx/networking.c
@@ -177,7 +177,7 @@ int net_send_cc(const unsigned char *data, int len, void *private_data, struct c
 	assert(srv_sd > 0);
 
 #if DEBUG_OUT
-	fprintf(stderr, "[C] Sending %u bytes\n", len);
+	fprintf(stderr, "[C] Sending %d bytes\n", len);
 #endif
 
 	if (write_block(srv_sd, BIN_DATA, data, len) <= 0)


### PR DESCRIPTION
Follow-up to #2307, picking up the one bit its sibling PR got right.

`net_send_cc()` takes `int len`, but its debug line printed it with `%u`:

```c
fprintf(stderr, "[C] Sending %u bytes\n", len);   // len is int
```

#2307 fixed the other two specifiers in these blocks (`%u` → `%zu` where `len` is `size_t`) but missed this one. #2175 by @Varadraj75 had it right — that PR was closed after five months without a rebase, so this ports the remaining fix.

## Scope

These blocks only compile under `-DNETWORKING_DEBUG=ON`, so no shipped build was affected. `gcc` doesn't diagnose `%u` against `int` (same width), which is why it survived the sweep on #2307 — I found it by auditing every specifier in the enabled blocks rather than trusting the compiler.

## Verification

Enabling the debug blocks and compiling with `-Wall -Wextra -Wformat=2`, both with and without `-DDISABLE_RUST`:

- before: `[C] Sending %u bytes` with an `int`
- after: **zero** format diagnostics in either configuration

The two remaining `-Wpointer-sign` warnings on `write_block()` are pre-existing, in live code, and unrelated to the debug output — left alone deliberately.

`clang-format` clean. One line, one file.

Credit: @Varadraj75 reported #2174 and caught this specifier in #2175.