### PR TITLE
Fix SSA compliance issues #2310

### DIFF
--- a/src/lib_ccx/ccx_encoders_helpers.c
+++ b/src/lib_ccx/ccx_encoders_helpers.c
@@ -263,15 +263,24 @@ unsigned char *close_tag(struct encoder_ctx *ctx, unsigned char *buffer, char *t
 		switch (cur)
 		{
 			case 'F':
-				buffer += encode_line(ctx, buffer, (unsigned char *)"</font>");
+				if (ctx->write_format == CCX_OF_SSA)
+					buffer += encode_line(ctx, buffer, (unsigned char *)"{\\c}");
+				else
+					buffer += encode_line(ctx, buffer, (unsigned char *)"</font>");
 				(*pchanged_font)--;
 				break;
 			case 'U':
-				buffer += encode_line(ctx, buffer, (unsigned char *)"</u>");
+				if (ctx->write_format == CCX_OF_SSA)
+					buffer += encode_line(ctx, buffer, (unsigned char *)"{\\u0}");
+				else
+					buffer += encode_line(ctx, buffer, (unsigned char *)"</u>");
 				(*punderlined)--;
 				break;
 			case 'I':
-				buffer += encode_line(ctx, buffer, (unsigned char *)"</i>");
+				if (ctx->write_format == CCX_OF_SSA)
+					buffer += encode_line(ctx, buffer, (unsigned char *)"{\\i0}");
+				else
+					buffer += encode_line(ctx, buffer, (unsigned char *)"</i>");
 				(*pitalics)--;
 				break;
 		}
@@ -310,7 +319,21 @@ unsigned get_decoder_line_encoded(struct encoder_ctx *ctx, unsigned char *buffer
 
 			// Add new font tag
 			if (MAX_COLOR > its_color)
-				buffer += encode_line(ctx, buffer, (unsigned char *)color_text[its_color][1]);
+			{
+				if (ctx->write_format == CCX_OF_SSA)
+				{
+					const char *ssa_cols[] = {
+						"", "{\\c&H00FF00&}", "{\\c&HFF0000&}", "{\\c&HFFFF00&}", 
+						"{\\c&H0000FF&}", "{\\c&H00FFFF&}", "{\\c&HFF00FF&}", 
+						"{\\c&H", "", ""
+					};
+					buffer += encode_line(ctx, buffer, (unsigned char *)ssa_cols[its_color]);
+				}
+				else
+				{
+					buffer += encode_line(ctx, buffer, (unsigned char *)color_text[its_color][1]);
+				}
+			}
 			else
 			{
 				ccx_common_logging.log_ftn("WARNING:get_decoder_line_encoded:Invalid Color index Selected %d\n", its_color);
@@ -319,12 +342,43 @@ unsigned get_decoder_line_encoded(struct encoder_ctx *ctx, unsigned char *buffer
 
 			if (its_color == COL_USERDEFINED)
 			{
-				// The previous sentence doesn't copy the whole
-				// <font> tag, just up to the quote before the color
-				buffer += encode_line(ctx, buffer, (unsigned char *)usercolor_rgb);
-				buffer += encode_line(ctx, buffer, (unsigned char *)"\">");
+				if (ctx->write_format == CCX_OF_SSA)
+				{
+					if (strlen((char *)usercolor_rgb) == 7 && usercolor_rgb[0] == '#') {
+						char bgr[7];
+						bgr[0] = usercolor_rgb[5]; bgr[1] = usercolor_rgb[6];
+						bgr[2] = usercolor_rgb[3]; bgr[3] = usercolor_rgb[4];
+						bgr[4] = usercolor_rgb[1]; bgr[5] = usercolor_rgb[2];
+						bgr[6] = '\0';
+						buffer += encode_line(ctx, buffer, (unsigned char *)bgr);
+					}
+					buffer += encode_line(ctx, buffer, (unsigned char *)"&}");
+				}
+				else
+				{
+					buffer += encode_line(ctx, buffer, (unsigned char *)usercolor_rgb);
+					buffer += encode_line(ctx, buffer, (unsigned char *)"\">");
+				}
 			}
-			if (color_text[its_color][1][0]) // That means a <font> was added to the buffer
+			int added_font = 0;
+			if (ctx->write_format == CCX_OF_SSA) {
+				const char *ssa_cols[] = {
+					"", "{\\c&H00FF00&}", "{\\c&HFF0000&}", "{\\c&HFFFF00&}", 
+					"{\\c&H0000FF&}", "{\\c&H00FFFF&}", "{\\c&HFF00FF&}", 
+					"{\\c&H", "", ""
+				};
+				if (MAX_COLOR > its_color && ssa_cols[its_color][0])
+					added_font = 1;
+				else if (its_color == COL_USERDEFINED)
+					added_font = 1;
+			} else {
+				if (MAX_COLOR > its_color && color_text[its_color][1][0])
+					added_font = 1;
+				else if (its_color == COL_USERDEFINED)
+					added_font = 1;
+			}
+
+			if (added_font) // That means a <font> or {\c} was added to the buffer
 			{
 				strncat(tagstack, "F", sizeof(tagstack) - strlen(tagstack) - 1);
 				changed_font++;
@@ -335,7 +389,10 @@ unsigned get_decoder_line_encoded(struct encoder_ctx *ctx, unsigned char *buffer
 		int is_underlined = data->fonts[line_num][i] & FONT_UNDERLINED;
 		if (is_underlined && underlined == 0 && !ctx->no_type_setting) // Open underline
 		{
-			buffer += encode_line(ctx, buffer, (unsigned char *)"<u>");
+			if (ctx->write_format == CCX_OF_SSA)
+				buffer += encode_line(ctx, buffer, (unsigned char *)"{\\u1}");
+			else
+				buffer += encode_line(ctx, buffer, (unsigned char *)"<u>");
 			strncat(tagstack, "U", sizeof(tagstack) - strlen(tagstack) - 1);
 			underlined++;
 		}
@@ -347,7 +404,10 @@ unsigned get_decoder_line_encoded(struct encoder_ctx *ctx, unsigned char *buffer
 		int has_ita = data->fonts[line_num][i] & FONT_ITALICS;
 		if (has_ita && italics == 0 && !ctx->no_type_setting) // Open italics
 		{
-			buffer += encode_line(ctx, buffer, (unsigned char *)"<i>");
+			if (ctx->write_format == CCX_OF_SSA)
+				buffer += encode_line(ctx, buffer, (unsigned char *)"{\\i1}");
+			else
+				buffer += encode_line(ctx, buffer, (unsigned char *)"<i>");
 			strncat(tagstack, "I", sizeof(tagstack) - strlen(tagstack) - 1);
 			italics++;
 		}

--- a/src/lib_ccx/ccx_encoders_helpers.c
+++ b/src/lib_ccx/ccx_encoders_helpers.c
@@ -20,10 +20,9 @@ struct word_list capitalization_list = {
 };
 
 static const char *ssa_cols[] = {
-	"", "{\\c&H00FF00&}", "{\\c&HFF0000&}", "{\\c&HFFFF00&}", 
-	"{\\c&H0000FF&}", "{\\c&H00FFFF&}", "{\\c&HFF00FF&}", 
-	"{\\c&H", "", ""
-};
+    "", "{\\c&H00FF00&}", "{\\c&HFF0000&}", "{\\c&HFFFF00&}",
+    "{\\c&H0000FF&}", "{\\c&H00FFFF&}", "{\\c&HFF00FF&}",
+    "{\\c&H", "", ""};
 
 struct word_list profane = {
     .words = NULL,
@@ -345,11 +344,15 @@ unsigned get_decoder_line_encoded(struct encoder_ctx *ctx, unsigned char *buffer
 			{
 				if (ctx->write_format == CCX_OF_SSA)
 				{
-					if (strlen((char *)usercolor_rgb) == 7 && usercolor_rgb[0] == '#') {
+					if (strlen((char *)usercolor_rgb) == 7 && usercolor_rgb[0] == '#')
+					{
 						char bgr[7];
-						bgr[0] = usercolor_rgb[5]; bgr[1] = usercolor_rgb[6];
-						bgr[2] = usercolor_rgb[3]; bgr[3] = usercolor_rgb[4];
-						bgr[4] = usercolor_rgb[1]; bgr[5] = usercolor_rgb[2];
+						bgr[0] = usercolor_rgb[5];
+						bgr[1] = usercolor_rgb[6];
+						bgr[2] = usercolor_rgb[3];
+						bgr[3] = usercolor_rgb[4];
+						bgr[4] = usercolor_rgb[1];
+						bgr[5] = usercolor_rgb[2];
 						bgr[6] = '\0';
 						buffer += encode_line(ctx, buffer, (unsigned char *)bgr);
 					}
@@ -362,12 +365,15 @@ unsigned get_decoder_line_encoded(struct encoder_ctx *ctx, unsigned char *buffer
 				}
 			}
 			int added_font = 0;
-			if (ctx->write_format == CCX_OF_SSA) {
+			if (ctx->write_format == CCX_OF_SSA)
+			{
 				if (MAX_COLOR > its_color && ssa_cols[its_color][0])
 					added_font = 1;
 				else if (its_color == COL_USERDEFINED)
 					added_font = 1;
-			} else {
+			}
+			else
+			{
 				if (MAX_COLOR > its_color && color_text[its_color][1][0])
 					added_font = 1;
 				else if (its_color == COL_USERDEFINED)

--- a/src/lib_ccx/ccx_encoders_helpers.c
+++ b/src/lib_ccx/ccx_encoders_helpers.c
@@ -19,6 +19,12 @@ struct word_list capitalization_list = {
     .capacity = 0,
 };
 
+static const char *ssa_cols[] = {
+	"", "{\\c&H00FF00&}", "{\\c&HFF0000&}", "{\\c&HFFFF00&}", 
+	"{\\c&H0000FF&}", "{\\c&H00FFFF&}", "{\\c&HFF00FF&}", 
+	"{\\c&H", "", ""
+};
+
 struct word_list profane = {
     .words = NULL,
     .len = 0,
@@ -322,11 +328,6 @@ unsigned get_decoder_line_encoded(struct encoder_ctx *ctx, unsigned char *buffer
 			{
 				if (ctx->write_format == CCX_OF_SSA)
 				{
-					const char *ssa_cols[] = {
-						"", "{\\c&H00FF00&}", "{\\c&HFF0000&}", "{\\c&HFFFF00&}", 
-						"{\\c&H0000FF&}", "{\\c&H00FFFF&}", "{\\c&HFF00FF&}", 
-						"{\\c&H", "", ""
-					};
 					buffer += encode_line(ctx, buffer, (unsigned char *)ssa_cols[its_color]);
 				}
 				else
@@ -362,11 +363,6 @@ unsigned get_decoder_line_encoded(struct encoder_ctx *ctx, unsigned char *buffer
 			}
 			int added_font = 0;
 			if (ctx->write_format == CCX_OF_SSA) {
-				const char *ssa_cols[] = {
-					"", "{\\c&H00FF00&}", "{\\c&HFF0000&}", "{\\c&HFFFF00&}", 
-					"{\\c&H0000FF&}", "{\\c&H00FFFF&}", "{\\c&HFF00FF&}", 
-					"{\\c&H", "", ""
-				};
 				if (MAX_COLOR > its_color && ssa_cols[its_color][0])
 					added_font = 1;
 				else if (its_color == COL_USERDEFINED)

--- a/src/lib_ccx/ccx_encoders_ssa.c
+++ b/src/lib_ccx/ccx_encoders_ssa.c
@@ -20,20 +20,21 @@ static int ccx_strncasecmp(const char *s1, const char *s2, size_t n)
 	return 0;
 }
 
-typedef struct {
-    const char *from;
-    size_t from_len;
-    const char *to;
-    size_t to_len;
+typedef struct
+{
+	const char *from;
+	size_t from_len;
+	const char *to;
+	size_t to_len;
 } tag_map_t;
 
 static const tag_map_t html_to_ass[] = {
-    { "<i>",  3, "{\\i1}", 5 },
-    { "</i>", 4, "{\\i0}", 5 },
-    { "<u>",  3, "{\\u1}", 5 },
-    { "</u>", 4, "{\\u0}", 5 },
-    { "<b>",  3, "{\\b1}", 5 },
-    { "</b>", 4, "{\\b0}", 5 },
+    {"<i>", 3, "{\\i1}", 5},
+    {"</i>", 4, "{\\i0}", 5},
+    {"<u>", 3, "{\\u1}", 5},
+    {"</u>", 4, "{\\u0}", 5},
+    {"<b>", 3, "{\\b1}", 5},
+    {"</b>", 4, "{\\b0}", 5},
 };
 #define NUM_TAG_MAPS (sizeof(html_to_ass) / sizeof(html_to_ass[0]))
 

--- a/src/lib_ccx/ccx_encoders_ssa.c
+++ b/src/lib_ccx/ccx_encoders_ssa.c
@@ -37,7 +37,7 @@ int write_stringz_as_ssa(char *string, struct encoder_ctx *context, LLONG ms_sta
 	millis_to_time(ms_start, &h1, &m1, &s1, &ms1);
 	millis_to_time(ms_end - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
 
-	snprintf(timeline, sizeof(timeline), "Dialogue: 0,%02u:%02u:%02u.%01u,%02u:%02u:%02u.%02u,Default,,0000,0000,0000,,",
+	snprintf(timeline, sizeof(timeline), "Dialogue: 0,%u:%02u:%02u.%02u,%u:%02u:%02u.%02u,Default,,0000,0000,0000,,",
 		 h1, m1, s1, ms1 / 10, h2, m2, s2, ms2 / 10);
 	used = encode_line(context, context->buffer, (unsigned char *)timeline);
 	dbg_print(CCX_DMT_DECODER_608, "\n- - - ASS/SSA caption - - -\n");
@@ -45,7 +45,7 @@ int write_stringz_as_ssa(char *string, struct encoder_ctx *context, LLONG ms_sta
 
 	write_wrapped(context->out->fh, context->buffer, used);
 	int len = strlen(string);
-	unsigned char *unescaped = (unsigned char *)malloc(len + 1);
+	unsigned char *unescaped = (unsigned char *)malloc(len * 2 + 1);
 	if (!unescaped)
 		fatal(EXIT_NOT_ENOUGH_MEMORY, "In write_stringz_as_ssa() - not enough memory for unescaped buffer.\n");
 	unsigned char *el = (unsigned char *)malloc(len * 3 + 1); // Be generous
@@ -61,15 +61,83 @@ int write_stringz_as_ssa(char *string, struct encoder_ctx *context, LLONG ms_sta
 	{
 		if (string[pos_r] == '\\' && string[pos_r + 1] == 'n')
 		{
-			unescaped[pos_w] = 0;
+			unescaped[pos_w++] = 0;
 			pos_r += 2;
+			continue;
 		}
-		else
+
+		int matched = 0;
+		for (size_t i = 0; i < NUM_TAG_MAPS; i++)
 		{
-			unescaped[pos_w] = string[pos_r];
-			pos_r++;
+			const tag_map_t *m = &html_to_ass[i];
+#ifdef _MSC_VER
+			if (_strnicmp(string + pos_r, m->from, m->from_len) == 0)
+#else
+			if (strncasecmp(string + pos_r, m->from, m->from_len) == 0)
+#endif
+			{
+				memcpy(unescaped + pos_w, m->to, m->to_len);
+				pos_w += m->to_len;
+				pos_r += m->from_len;
+				matched = 1;
+				break;
+			}
 		}
-		pos_w++;
+		if (matched)
+			continue;
+
+#ifdef _MSC_VER
+		if (_strnicmp(string + pos_r, "<font color=\"#", 14) == 0)
+#else
+		if (strncasecmp(string + pos_r, "<font color=\"#", 14) == 0)
+#endif
+		{
+			if (pos_r + 21 < len && string[pos_r + 20] == '"' && string[pos_r + 21] == '>')
+			{
+				char r1 = string[pos_r + 14], r2 = string[pos_r + 15];
+				char g1 = string[pos_r + 16], g2 = string[pos_r + 17];
+				char b1 = string[pos_r + 18], b2 = string[pos_r + 19];
+				char ssa_col[14];
+				snprintf(ssa_col, sizeof(ssa_col), "{\\c&H%c%c%c%c%c%c&}", b1, b2, g1, g2, r1, r2);
+				memcpy(unescaped + pos_w, ssa_col, 13);
+				pos_w += 13;
+				pos_r += 22; // Skip up to and including '>'
+			}
+			else
+			{
+				while (pos_r < len && string[pos_r] != '>')
+					pos_r++;
+				if (pos_r < len)
+					pos_r++; // Skip '>'
+			}
+			continue;
+		}
+
+#ifdef _MSC_VER
+		if (_strnicmp(string + pos_r, "<font", 5) == 0)
+#else
+		if (strncasecmp(string + pos_r, "<font", 5) == 0)
+#endif
+		{
+			while (pos_r < len && string[pos_r] != '>')
+				pos_r++;
+			if (pos_r < len)
+				pos_r++;
+			continue;
+		}
+#ifdef _MSC_VER
+		if (_strnicmp(string + pos_r, "</font>", 7) == 0)
+#else
+		if (strncasecmp(string + pos_r, "</font>", 7) == 0)
+#endif
+		{
+			memcpy(unescaped + pos_w, "{\\c}", 4);
+			pos_w += 4;
+			pos_r += 7;
+			continue;
+		}
+
+		unescaped[pos_w++] = string[pos_r++];
 	}
 	unescaped[pos_w] = 0;
 	// Now read the unescaped string (now several string'z and write them)
@@ -134,7 +202,7 @@ int write_cc_bitmap_as_ssa(struct cc_subtitle *sub, struct encoder_ctx *context)
 			millis_to_time(sub->start_time, &h1, &m1, &s1, &ms1);
 			millis_to_time(sub->end_time - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
 
-			snprintf(timeline, sizeof(timeline), "Dialogue: 0,%02u:%02u:%02u.%01u,%02u:%02u:%02u.%02u,Default,,0000,0000,0000,,",
+			snprintf(timeline, sizeof(timeline), "Dialogue: 0,%u:%02u:%02u.%02u,%u:%02u:%02u.%02u,Default,,0000,0000,0000,,",
 				 h1, m1, s1, ms1 / 10, h2, m2, s2, ms2 / 10);
 			used = encode_line(context, context->buffer, (unsigned char *)timeline);
 			write_wrapped(context->out->fh, context->buffer, used);
@@ -220,7 +288,7 @@ int write_cc_buffer_as_ssa(struct eia608_screen *data, struct encoder_ctx *conte
 	millis_to_time(data->start_time, &h1, &m1, &s1, &ms1);
 	millis_to_time(data->end_time - 1, &h2, &m2, &s2, &ms2); // -1 To prevent overlapping with next line.
 	char timeline[128];
-	snprintf(timeline, sizeof(timeline), "Dialogue: 0,%02u:%02u:%02u.%01u,%02u:%02u:%02u.%02u,Default,,0000,0000,0000,,",
+	snprintf(timeline, sizeof(timeline), "Dialogue: 0,%u:%02u:%02u.%02u,%u:%02u:%02u.%02u,Default,,0000,0000,0000,,",
 		 h1, m1, s1, ms1 / 10, h2, m2, s2, ms2 / 10);
 	used = encode_line(context, context->buffer, (unsigned char *)timeline);
 

--- a/src/lib_ccx/ccx_encoders_ssa.c
+++ b/src/lib_ccx/ccx_encoders_ssa.c
@@ -4,9 +4,21 @@
 #include "utility.h"
 #include "ccx_encoders_helpers.h"
 #include "ocr.h"
-#ifndef _MSC_VER
-#include <strings.h>
-#endif
+#include <ctype.h>
+
+static int ccx_strncasecmp(const char *s1, const char *s2, size_t n)
+{
+	for (size_t i = 0; i < n; i++)
+	{
+		int c1 = tolower((unsigned char)s1[i]);
+		int c2 = tolower((unsigned char)s2[i]);
+		if (c1 != c2)
+			return c1 - c2;
+		if (c1 == 0)
+			return 0;
+	}
+	return 0;
+}
 
 static void ass_position_from_row_col(
     int row,
@@ -73,11 +85,7 @@ int write_stringz_as_ssa(char *string, struct encoder_ctx *context, LLONG ms_sta
 		for (size_t i = 0; i < NUM_TAG_MAPS; i++)
 		{
 			const tag_map_t *m = &html_to_ass[i];
-#ifdef _MSC_VER
-			if (_strnicmp(string + pos_r, m->from, m->from_len) == 0)
-#else
-			if (strncasecmp(string + pos_r, m->from, m->from_len) == 0)
-#endif
+			if (ccx_strncasecmp(string + pos_r, m->from, m->from_len) == 0)
 			{
 				memcpy(unescaped + pos_w, m->to, m->to_len);
 				pos_w += m->to_len;
@@ -89,11 +97,7 @@ int write_stringz_as_ssa(char *string, struct encoder_ctx *context, LLONG ms_sta
 		if (matched)
 			continue;
 
-#ifdef _MSC_VER
-		if (_strnicmp(string + pos_r, "<font color=\"#", 14) == 0)
-#else
-		if (strncasecmp(string + pos_r, "<font color=\"#", 14) == 0)
-#endif
+		if (ccx_strncasecmp(string + pos_r, "<font color=\"#", 14) == 0)
 		{
 			if (pos_r + 21 < len && string[pos_r + 20] == '"' && string[pos_r + 21] == '>')
 			{
@@ -116,11 +120,7 @@ int write_stringz_as_ssa(char *string, struct encoder_ctx *context, LLONG ms_sta
 			continue;
 		}
 
-#ifdef _MSC_VER
-		if (_strnicmp(string + pos_r, "<font", 5) == 0)
-#else
-		if (strncasecmp(string + pos_r, "<font", 5) == 0)
-#endif
+		if (ccx_strncasecmp(string + pos_r, "<font", 5) == 0)
 		{
 			while (pos_r < len && string[pos_r] != '>')
 				pos_r++;
@@ -128,11 +128,7 @@ int write_stringz_as_ssa(char *string, struct encoder_ctx *context, LLONG ms_sta
 				pos_r++;
 			continue;
 		}
-#ifdef _MSC_VER
-		if (_strnicmp(string + pos_r, "</font>", 7) == 0)
-#else
-		if (strncasecmp(string + pos_r, "</font>", 7) == 0)
-#endif
+		if (ccx_strncasecmp(string + pos_r, "</font>", 7) == 0)
 		{
 			memcpy(unescaped + pos_w, "{\\c}", 4);
 			pos_w += 4;

--- a/src/lib_ccx/ccx_encoders_ssa.c
+++ b/src/lib_ccx/ccx_encoders_ssa.c
@@ -20,6 +20,23 @@ static int ccx_strncasecmp(const char *s1, const char *s2, size_t n)
 	return 0;
 }
 
+typedef struct {
+    const char *from;
+    size_t from_len;
+    const char *to;
+    size_t to_len;
+} tag_map_t;
+
+static const tag_map_t html_to_ass[] = {
+    { "<i>",  3, "{\\i1}", 5 },
+    { "</i>", 4, "{\\i0}", 5 },
+    { "<u>",  3, "{\\u1}", 5 },
+    { "</u>", 4, "{\\u0}", 5 },
+    { "<b>",  3, "{\\b1}", 5 },
+    { "</b>", 4, "{\\b0}", 5 },
+};
+#define NUM_TAG_MAPS (sizeof(html_to_ass) / sizeof(html_to_ass[0]))
+
 static void ass_position_from_row_col(
     int row,
     int col,

--- a/src/lib_ccx/ccx_encoders_ssa.c
+++ b/src/lib_ccx/ccx_encoders_ssa.c
@@ -4,6 +4,9 @@
 #include "utility.h"
 #include "ccx_encoders_helpers.h"
 #include "ocr.h"
+#ifndef _MSC_VER
+#include <strings.h>
+#endif
 
 static void ass_position_from_row_col(
     int row,


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

Reason for this PR:

- [ ] This PR adds new functionality.
- [x] This PR fixes a bug that I have personally experienced or that a real user has reported and for which a sample exists.
- [ ] This PR is porting code from C to Rust.

Sanity check:
- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] If the PR adds new functionality, I've added it to the changelog. If it's just a bug fix, I have NOT added it to the changelog.
- [x] I am NOT adding new C code unless it's to fix an existing, reproducible bug.

Repro instructions:

1. Download the `DresdenTest.ts` sample provided in Issue #2310: [DresdenTest.ts](https://1drv.ms/v/c/8b5ee05414946e03/IQDLLzwLvNY3RJi8rYvDN7PyAVTV7dC2YotrGHTGfnRkFUM?e=4YsJPQ)
2. Run CCExtractor to generate Substation Alpha output:
   `ccextractor DresdenTest.ts -out=ass`
3. Inspect the resulting `.ass` file.
   - **Before this PR:** The file contains two-digit hours (`00:`), misaligned milliseconds (`.7` instead of `.07`), and raw HTML tags (`<i>`).
   - **After this PR:** The file contains compliant single-digit hours (`0:`), correctly padded milliseconds (`.07`), and ASS override tags (`{\i1}`).

---

### Description
This PR resolves several compliance issues with the Substation Alpha (SSA/ASS) output generated by CCExtractor, addressing the bugs reported in #2310.

**Fixes included:**
1. **Timestamp Formatting**
   - Changed the hour format from zero-padded two digits (`%02u`) to a single unpadded digit (`%u`) in all `Dialogue:` lines to comply with strict SSA parser expectations.
   - Fixed a critical padding bug where centiseconds/milliseconds were incorrectly formatted (missing leading zeros), which caused timestamp values to shift silently (e.g., `12.07s` rendering as `12.7s`).

2. **CEA-608 Override Tag Generation**
   - Modified `get_decoder_line_encoded()` so that when outputting SSA, it emits valid SSA override tags directly (e.g., `{\i1}`, `{\u1}`, `{\c&H00FF00&}`) instead of generating HTML tags (`<i>`, `<u>`, `<font...>`) that are technically invalid in SSA. 
   - Hoisted the SSA color mapping table (`ssa_cols`) to file-scope in `ccx_encoders_helpers.c` to ensure the emitted font colors stay safely synchronized with the tag-stack tracking logic.

3. **HTML-to-SSA Tag Translation (DVB/Teletext/708)**
   - Implemented a table-driven tag replacement inside `write_stringz_as_ssa()` for subtitle formats that generate generic HTML-tagged C-strings upstream. This gracefully translates `<i>`, `<u>`, `<b>`, and `<font color="#RRGGBB">` into their respective SSA equivalents (`{\i1}`, `{\u1}`, `{\b1}`, `{\c&HBBGGRR&}`) without breaking other format outputs that rely on the HTML representation.

Fixes #2310.