### PR TITLE
[FIX] Clear stale CEA-708 window rows in no-rollup mode

### DIFF
--- a/src/lib_ccx/ccx_decoders_708.c
+++ b/src/lib_ccx/ccx_decoders_708.c
@@ -771,7 +771,11 @@ void dtvcc_process_cr(dtvcc_ctx *dtvcc, dtvcc_service_decoder *decoder)
 			dtvcc_window_copy_to_screen(decoder, window);
 			dtvcc_screen_print(dtvcc, decoder);
 			if (dtvcc->no_rollup)
-				dtvcc_window_clear_row(window, window->pen_row);
+			{
+				for (int row = 0; row < CCX_DTVCC_MAX_ROWS; row++)
+					dtvcc_window_clear_row(window, row);
+				window->is_empty = 1;
+			}
 			else
 				dtvcc_window_rollup(decoder, window);
 		}

--- a/src/rust/src/decoder/service_decoder.rs
+++ b/src/rust/src/decoder/service_decoder.rs
@@ -163,7 +163,6 @@ impl dtvcc_service_decoder {
         };
 
         if is_true(window.is_defined) {
-            let pen_row = window.pen_row;
             window.update_time_hide(timing);
 
             if rollup_required {
@@ -171,7 +170,11 @@ impl dtvcc_service_decoder {
                 self.copy_to_screen(&self.windows[self.current_window as usize]);
                 self.screen_print(encoder, timing);
                 if no_rollup {
-                    self.windows[self.current_window as usize].clear_row(pen_row as usize);
+                    let window = &mut self.windows[self.current_window as usize];
+                    for row in 0..CCX_DTVCC_MAX_ROWS as usize {
+                        window.clear_row(row);
+                    }
+                    window.is_empty = 1;
                 } else {
                     self.windows[self.current_window as usize].rollup();
                 }
@@ -1918,6 +1921,72 @@ mod test {
                 decoder.windows[0].rows[0].add(0).read(),
                 dtvcc_symbol::new(0x41)
             );
+        }
+    }
+
+    #[test]
+    fn test_process_cr_no_rollup_clears_emitted_rows_and_preserves_pen_state() {
+        use std::ffi::CString;
+
+        let mut decoder = get_zero_allocated_obj::<dtvcc_service_decoder>();
+        decoder.current_window = 0;
+        decoder.tv = Box::into_raw(Box::new(dtvcc_tv_screen {
+            service_number: 1,
+            ..Default::default()
+        }));
+
+        let window = &mut decoder.windows[0];
+        window.is_defined = 1;
+        window.visible = 1;
+        window.row_count = 2;
+        window.col_count = 4;
+        window.pen_row = 1;
+        window.pen_column = 3;
+        window.memory_reserved = 1;
+        window.is_empty = 0;
+        window.attribs.print_direction = dtvcc_window_pd::DTVCC_WINDOW_PD_LEFT_RIGHT as i32;
+        window.pen_color_pattern = dtvcc_pen_color {
+            fg_color: 0x0f,
+            ..Default::default()
+        };
+        window.pen_attribs_pattern = dtvcc_pen_attribs {
+            italic: 1,
+            ..Default::default()
+        };
+
+        let layout = Layout::array::<dtvcc_symbol>(CCX_DTVCC_MAX_COLUMNS as usize).unwrap();
+        for row in 0..CCX_DTVCC_MAX_ROWS as usize {
+            window.rows[row] = unsafe { alloc_zeroed(layout) } as *mut dtvcc_symbol;
+        }
+        unsafe {
+            *window.rows[0] = dtvcc_symbol::new(0x41);
+            *window.rows[1] = dtvcc_symbol::new(0x42);
+        }
+
+        let output = tempfile::NamedTempFile::new().unwrap();
+        let filename = CString::new(output.path().to_str().unwrap()).unwrap();
+        let mut encoder = encoder_ctx::default();
+        encoder.dtvcc_writers[0].fd = -1;
+        encoder.dtvcc_writers[0].filename = filename.as_ptr() as *mut _;
+        let mut timing = ccx_common_timing_ctx::default();
+
+        decoder.process_cr(&mut encoder, &mut timing, true);
+
+        assert_eq!(decoder.windows[0].pen_row, 1);
+        assert_eq!(decoder.windows[0].pen_column, 0);
+        unsafe {
+            assert_eq!(*decoder.windows[0].rows[0], dtvcc_symbol::default());
+            assert_eq!(*decoder.windows[0].rows[1], dtvcc_symbol::default());
+        }
+        assert_eq!(decoder.windows[0].is_empty, 1);
+        assert_eq!(decoder.windows[0].pen_color_pattern.fg_color, 0x0f);
+        assert_eq!(decoder.windows[0].pen_attribs_pattern.italic, 1);
+
+        for row_ptr in decoder.windows[0].rows.iter() {
+            unsafe { crate::decoder::window::dealloc_row(*row_ptr) };
+        }
+        unsafe {
+            drop(Box::from_raw(decoder.tv));
         }
     }
 }


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

Reason for this PR:

- [ ] This PR adds new functionality.
- [x] This PR fixes a bug that I have personally experienced or that a real user has reported and for which a sample exists.
- [ ] This PR is porting code from C to Rust.

Sanity check:

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] This is a bug fix, so I have not added it to the changelog.
- [x] I am not adding new C code except to fix this existing, reproducible bug.

Repro instructions:

The input is a 35.1-second, video-only H.264 MPEG-TS sample. To avoid distributing the original broadcast pictures, every decoded frame was replaced with black before H.264 re-encoding. FFmpeg preserved the A53/CEA-708 caption side data in the new H.264 SEI messages. The sample contains Korean CEA-708 service 1 and no audio.

Sample URL: https://sampleplatform.ccextractor.org/sample/188

Sample properties:

```text
size:       344,792 bytes
duration:   35.101733 seconds
video:      H.264, 1280x720, 30000/1001 fps
frames:     1,049
other A/V:  no audio and no original broadcast imagery
captions:   CEA-708 service 1
SHA-256:    36d67699a84883d901d3eef089e6bbca5e72a603f55925a406e9513dccbebbfe
```

The Sample Platform identifies the uploaded caption stream as EIA-708 and reports the same SHA-256 as the locally verified redacted artifact.

Baseline commit:

```text
6077cf5c617e5db63b7068f2c06eae2fabe6e8c9
```

Build from the checked-out source:

```bash
docker build \
  --build-arg USE_LOCAL_SOURCE=1 \
  --build-arg BUILD_TYPE=minimal \
  -f docker/Dockerfile \
  -t ccextractor:local .
```

Run the same command against the baseline and this change:

```bash
docker run --rm \
  -v "$PWD:/data" -w /data \
  ccextractor:local \
  sample-redacted-black.ts \
  --input ts \
  --out srt \
  --service '1[EUC-KR]' \
  --utf8 \
  --no-rollup \
  --no-bom \
  --trim \
  --autodash \
  -o result.srt
```

For this service, CCExtractor writes `result.p1.svc01.srt`.

---

## Description

When a CEA-708 carriage return reaches a roll-up boundary, CCExtractor first emits the current window. With `--no-rollup`, it then clears only the current pen row. Text in previously emitted upper rows remains in the backing window and is emitted again with later cues.

This change clears every row in the active window after emission when `--no-rollup` is enabled, then marks the window empty. It deliberately preserves the current pen location, pen color, and pen attributes. Normal roll-up behavior is unchanged.

The C and Rust CEA-708 implementations are updated together. The Rust regression test exercises `process_cr(..., no_rollup = true)`, verifies that all emitted rows are cleared, verifies `is_empty`, and verifies that active pen styling is preserved.

## Before

The second cue repeats two lines already emitted by the first cue:

```srt
2
00:00:03,671 --> 00:00:06,339
<font color="#ffff00">내뿜으며 순식간에 폭발했고 그 </font>
<font color="#ffff00">충격으로 건물 파편들이 사방으로 쏟아져 </font>
<font color="#ffff00">같은 시각 근처를 지나던 차량에서도 </font>
```

Those stale lines recur in later cues. The baseline also emits a cue at `00:00:21,255 --> 00:00:27,327` containing only stale text.

## After

The second cue contains only its new text:

```srt
2
00:00:03,671 --> 00:00:06,339
<font color="#ffff00">같은 시각 근처를 지나던 차량에서도 </font>
```

The original two lines remain together in cue 1, where they are valid, but do not reappear. The stale-only cue disappears. The redacted sample produces 12 baseline cues and 11 fixed cues; all fixed lines at shared timestamps are the expected ordered suffix of the baseline lines.

## Cross-broadcaster validation

Representative 10-minute CEA-708 service-1 samples from five Korean broadcasters were compared with identical options:

| Broadcaster | Baseline | Fixed | Result |
|---|---:|---:|---|
| MBC | 67 cues | 67 cues | byte-identical, including 40 color spans |
| KBS1 | 148 cues | 148 cues | byte-identical |
| SBS | 29 cues | 28 cues | stale previous rows removed; one stale-only cue removed |
| KBS2 | 162 cues | 162 cues | byte-identical |
| EBS1 | 153 cues | 153 cues | byte-identical |

All five samples use three-row CEA-708 windows. SBS starts at row 0 and relies on CR to advance through the window. Once the pen reaches the final row, clearing only that row leaves rows 0 and 1 available for re-emission. The other four samples set the pen directly to the final row for each cue, so their upper rows are already empty.

An initial candidate used `clear_text()`. That fixed SBS but reset the active pen patterns and removed all 40 yellow color spans from MBC. The final implementation clears row contents and sets `is_empty = 1` without resetting active pen color or attributes. This restores byte-for-byte output parity for the four unaffected broadcasters.

## Tests

The focused regression was first confirmed to fail on the old one-row behavior. It was then strengthened after the rejected `clear_text()` candidate to require preservation of a non-default foreground color and italic state. The unit test drives the real `process_cr(..., no_rollup = true)` path and fixes the decoder-state contract; the redacted-sample A/B run below separately verifies the user-visible SRT output across consecutive emissions.

```text
cargo fmt --all -- --check                  passed
focused no-rollup regression               1 passed
cargo test --lib                           402 passed; 0 failed
official minimal Docker build              passed (C and Rust compiled)
redacted black-video sample A/B             passed; baseline 12 cues, fixed 11 cues
five-broadcaster 10-minute comparison      passed
RCWT command analyzer                      12 passed
git diff --check                           passed
```

The redacted-sample output comparison confirms that the first valid multi-line cue is preserved, later cues no longer repeat its stale upper rows, no fixed-only text or timestamp interval is introduced, and the stale-only baseline cue disappears.

`cargo clippy --lib -- -D warnings` reports four existing `unnecessary_cast` findings in `libccxr_exports/time.rs` and `libccxr_exports/util.rs`. The same four findings occur on the clean baseline; this change introduces no new clippy findings.

No public checks existed for the fork commit before this PR. The local results above are exact-artifact results; repository CI for this branch should run on the PR.

## Production validation

The fixed binary was also exercised by the production caption pipeline against seven archived days from the same five broadcasters. The normal transactional publication and verifier paths completed successfully:

```text
broadcaster-days verified                  35 (7 days × 5 broadcasters)
programme SRT artifacts verified           1,091
captioned programmes                       1,026
verified no-caption programmes             65
total cues                                 669,258
failed or unknown programme outcomes       0
```

All 35 publication manifests verified the expected binary path, version `0.96.5`, extraction policy, and current generation. This operational run supplements—but does not replace—the focused regression, reproducible sample, or repository CI.

## Scope

This PR does not change CEA-608, the `no_rollup = false` path, public APIs, or dependencies. It does not include the original broadcast video. The provided reproduction sample contains black video plus the caption packets and timing needed to reproduce the decoder bug.

# Checklist

- [x] I have tested these changes locally.
- [x] I have added a focused regression test.
- [x] I have updated both C and Rust CEA-708 implementations.
- [x] I have included exact reproduction instructions and before/after output.
- [x] I have compared representative CEA-708 output from five broadcasters.
- [x] I have removed the original broadcast imagery and audio from the shareable sample.
- [x] I have uploaded the redacted sample to the CCExtractor Sample Platform and linked it above.
