### PR TITLE
[FIX] Segfault on files carrying both teletext and DVB subtitles

### DIFF
--- a/src/lib_ccx/lib_ccx.c
+++ b/src/lib_ccx/lib_ccx.c
@@ -469,6 +469,11 @@ struct encoder_ctx *update_encoder_list_cinfo(struct lib_ccx_ctx *ctx, struct ca
 			return enc_ctx;
 	}
 
+	/* Nothing matched. list_for_each_entry() leaves the iterator pointing at the list
+	   head reinterpreted as an encoder_ctx, which is not a usable encoder, so clear it
+	   to let the code below tell "not found" apart from "found". */
+	enc_ctx = NULL;
+
 	const char *extension = get_file_extension(ccx_options.enc_cfg.write_format);
 	if (!extension && ccx_options.enc_cfg.write_format != CCX_OF_CURL)
 		return NULL;
@@ -487,7 +492,12 @@ struct encoder_ctx *update_encoder_list_cinfo(struct lib_ccx_ctx *ctx, struct ca
 				dvb_pid_count++;
 		}
 
-		if (dvb_pid_count >= 2)
+		/* Give the stream its own per-language encoder when there is more than one DVB
+		   PID, or when some other stream (teletext, 608/708) already owns an encoder and
+		   this DVB PID is an extra one alongside it. A recording whose only caption
+		   stream is a single DVB PID still reaches the standard path below, because the
+		   encoder list is empty on that first call, which keeps its filename unchanged. */
+		if (dvb_pid_count >= 2 || !list_empty(&ctx->enc_ctx_head))
 		{
 			struct encoder_cfg local_cfg = ccx_options.enc_cfg;
 			local_cfg.program_number = pn;
@@ -574,6 +584,11 @@ struct encoder_ctx *update_encoder_list_cinfo(struct lib_ccx_ctx *ctx, struct ca
 
 		list_add_tail(&(enc_ctx->list), &(ctx->enc_ctx_head));
 	}
+	/* No encoder was found or created. Report it rather than dereferencing the iterator
+	   left behind by the search loop; callers already skip a NULL encoder. */
+	if (!enc_ctx)
+		return NULL;
+
 	// DVB related
 	enc_ctx->prev = NULL;
 	if (cinfo && cinfo->codec == CCX_CODEC_DVB && cinfo->lang[0])


### PR DESCRIPTION
`ccextractor --out=srt sample.mpg` segfaults on any recording that carries both a teletext stream and a DVB subtitle stream. No special flags are needed and every output format is affected.

## Root cause

`update_encoder_list_cinfo()` declares `enc_ctx` uninitialised and then uses it as the `list_for_each_entry()` iterator. For a DVB stream carrying a language, the search loop `continue`s past every encoder whose `dvb_lang` does not match, so it can run to completion without returning. When the encoder list is non-empty, none of the creation branches below run either, and the function falls through to

```c
	// DVB related
	enc_ctx->prev = NULL;
```

with `enc_ctx` still holding the value the loop terminated on — the list head reinterpreted as an `encoder_ctx`. That bogus pointer is written to and then returned. `general_loop.c:1358` later does `dvb_enc->timing = dvb_dec->timing` on it and faults.

Under gdb the faulting address is exactly `&dvb_enc->timing`, and the instruction is a store:

```
=> 0x...<process_non_multiprogram_general_loop+10404>:	mov %rdx,0x50(%rax)
si_addr        = 0x7d2ff31dfea0
&dvb_enc->timing = 0x7d2ff31dfea0
```

The condition arises whenever a DVB PID is not the stream the main path selected — i.e. a DVB stream sitting alongside teletext.

## Why CI never caught it

Restricting to a single PID avoids it entirely, and the one affected sample in the regression suite (`85c7fc1ad7`, sample 19) is only ever run as `--datapid 5603 …`. Plain extraction on the same file crashes.

## Fix

Clear the iterator after the search loop so "not found" is distinguishable from "found", and give such a stream its own per-language encoder — which is what the multi-DVB path already does for extra DVB PIDs. The existing `dvb_pid_count >= 2` test is kept as an `OR`, so a recording whose only caption stream is a single DVB PID still reaches the standard path with an empty encoder list and keeps its plain output filename. A `NULL` guard before the tail keeps the fall-through honest.

Both streams are now extracted into separate, well-formed files rather than being merged into one file with two interleaved cue numberings.

## Verification

Scanned all 162 local media samples with a release build of master and of this branch:

| | master | this branch |
|---|---|---|
| `85c7fc1ad7…mpg` | SIGSEGV | `out.srt` + `out_eng.srt` |
| `f1422b8bfe…ts` | SIGSEGV | `out.srt` + `out_spa.srt` |

Each produced file has monotonic, unique cue indices and monotonic timestamps.

Regression checks:

- **45 samples byte-identical** to master (`--out=srt`, whole output directory compared).
- **Multi-language DVB unchanged** — `04e47919de59…ts` still yields `out_chi.srt` + `out_chs.srt`, byte-identical to master.
- **Filename compatibility preserved** — a recording whose only stream is DVB still produces plain `out.srt` on both master and this branch.
- **ASan**: the SEGV is gone. The remaining report is the pre-existing 32-byte-per-encoder leak in `init_encoder` (`ccx_encoders_common.c:818`) that master also has; this branch shows it twice simply because it now creates a second encoder.

## Not fixed here

A third sample, `5f6dfe831e35…wtv`, also segfaults on master but through an unrelated path — an unsigned underflow in `buffered_seek()` reaching `buffered_read()`. That is a separate bug and will get its own PR.