### PR TITLE
fix: correctly initialize frame type for tx3g and mov_text subtitles

### DIFF
--- a/src/lib_ccx/mp4.c
+++ b/src/lib_ccx/mp4.c
@@ -1121,11 +1121,11 @@ int processmp4(struct lib_ccx_ctx *ctx, struct ccx_s_mp4Cfg *cfg, char *file)
 					const LLONG timestamp = (LLONG)((sample->DTS + sample->CTS_Offset) * 1000) / timescale;
 #endif
 					set_current_pts(dec_ctx->timing, (sample->DTS + sample->CTS_Offset) * MPEG_CLOCK_FREQ / timescale);
-					// For caption-only tracks (c608/c708), set frame type to I-frame
+					// For subtitle and caption-only tracks, set frame type to I-frame
 					// so that set_fts() will set min_pts from the first sample.
 					// Without video frames, frame type would stay Unknown and
 					// min_pts would never be set, causing broken timestamps.
-					if (type == GF_ISOM_MEDIA_CLOSED_CAPTION || type == GF_ISOM_MEDIA_TEXT || type == GF_ISOM_MEDIA_SUBT)
+					if (type == GF_ISOM_MEDIA_TEXT || type == GF_ISOM_MEDIA_SUBT || type == GF_ISOM_MEDIA_CLOSED_CAPTION)
 						dec_ctx->timing->current_picture_coding_type = CCX_FRAME_TYPE_I_FRAME;
 					set_fts(dec_ctx->timing);
 

--- a/src/lib_ccx/mp4.c
+++ b/src/lib_ccx/mp4.c
@@ -1125,7 +1125,7 @@ int processmp4(struct lib_ccx_ctx *ctx, struct ccx_s_mp4Cfg *cfg, char *file)
 					// so that set_fts() will set min_pts from the first sample.
 					// Without video frames, frame type would stay Unknown and
 					// min_pts would never be set, causing broken timestamps.
-					if (type == GF_ISOM_MEDIA_CLOSED_CAPTION)
+					if (type == GF_ISOM_MEDIA_CLOSED_CAPTION || type == GF_ISOM_MEDIA_TEXT || type == GF_ISOM_MEDIA_SUBT)
 						dec_ctx->timing->current_picture_coding_type = CCX_FRAME_TYPE_I_FRAME;
 					set_fts(dec_ctx->timing);
 


### PR DESCRIPTION
This PR fixes MP4 subtitle timestamp initialization by ensuring subtitle-only tracks (including \mov_text\/\	x3g\) get an I-frame picture type so \set_fts()\ can set \min_pts\ from the first sample.