### PR TITLE
[FIX] Out-of-bounds read: unsigned underflow defeats the file buffer bounds checks

### DIFF
--- a/src/lib_ccx/file_buffer.h
+++ b/src/lib_ccx/file_buffer.h
@@ -61,7 +61,10 @@ static size_t inline buffered_read(struct ccx_demuxer *ctx, unsigned char *buffe
 	{
 		if (buffer != NULL)
 			memcpy(buffer, ctx->filebuffer + ctx->filebuffer_pos, bytes);
-		ctx->filebuffer_pos += bytes;
+		/* The guard above proved bytes fits in what is left of the buffer, and that
+		   remainder is an unsigned int, so narrowing here cannot lose data. Say so
+		   explicitly: MSVC warns C4267 on the implicit size_t -> unsigned int. */
+		ctx->filebuffer_pos += (unsigned int)bytes;
 		result = bytes;
 	}
 	else

--- a/src/lib_ccx/file_buffer.h
+++ b/src/lib_ccx/file_buffer.h
@@ -18,13 +18,27 @@
 size_t buffered_read_opt(struct ccx_demuxer *ctx, unsigned char *buffer, size_t bytes);
 
 /**
+ * Bytes still unread in the file buffer.
+ *
+ * bytesinbuffer and filebuffer_pos are both unsigned, so subtracting them without
+ * checking their order wraps around and turns a bounds check into a pass. Callers use
+ * this instead of doing the subtraction themselves.
+ */
+static inline size_t buffered_bytes_left(struct ccx_demuxer *ctx)
+{
+	if (ctx->filebuffer_pos >= ctx->bytesinbuffer)
+		return 0;
+	return (size_t)(ctx->bytesinbuffer - ctx->filebuffer_pos);
+}
+
+/**
  * Skip bytes from file buffer and if needed also seek file for number of bytes.
  *
  */
 static size_t inline buffered_skip(struct ccx_demuxer *ctx, unsigned int bytes)
 {
 	size_t result;
-	if (bytes <= ctx->bytesinbuffer - ctx->filebuffer_pos)
+	if (bytes <= buffered_bytes_left(ctx))
 	{
 		ctx->filebuffer_pos += bytes;
 		result = bytes;
@@ -43,7 +57,7 @@ static size_t inline buffered_skip(struct ccx_demuxer *ctx, unsigned int bytes)
 static size_t inline buffered_read(struct ccx_demuxer *ctx, unsigned char *buffer, size_t bytes)
 {
 	size_t result;
-	if (bytes <= ctx->bytesinbuffer - ctx->filebuffer_pos)
+	if (bytes <= buffered_bytes_left(ctx))
 	{
 		if (buffer != NULL)
 			memcpy(buffer, ctx->filebuffer + ctx->filebuffer_pos, bytes);
@@ -70,7 +84,7 @@ static size_t inline buffered_read(struct ccx_demuxer *ctx, unsigned char *buffe
 static size_t inline buffered_read_byte(struct ccx_demuxer *ctx, unsigned char *buffer)
 {
 	size_t result = 0;
-	if (ctx->bytesinbuffer - ctx->filebuffer_pos)
+	if (buffered_bytes_left(ctx))
 	{
 		if (buffer)
 		{

--- a/src/lib_ccx/file_functions.c
+++ b/src/lib_ccx/file_functions.c
@@ -230,16 +230,24 @@ void buffered_seek(struct ccx_demuxer *ctx, int offset)
 	position_sanity_check(ctx);
 	if (offset < 0)
 	{
-		ctx->filebuffer_pos += offset;
-		if (ctx->filebuffer_pos < 0)
+		/* filebuffer_pos and startbytes_pos are unsigned, so "filebuffer_pos += offset"
+		   wrapped around instead of going negative and neither guard below could ever
+		   fire. A backward seek past the start of the buffer left filebuffer_pos at
+		   roughly 2^32, which buffered_read() then trusted. Do the arithmetic signed. */
+		int64_t newpos = (int64_t)ctx->filebuffer_pos + offset;
+		if (newpos < 0)
 		{
 			// We got into the start buffer (hopefully)
-			if ((ctx->filebuffer_pos + ctx->startbytes_pos) < 0)
+			if ((int64_t)ctx->startbytes_pos + newpos < 0)
 			{
 				fatal(CCX_COMMON_EXIT_BUG_BUG, "PANIC: Attempt to seek before buffer start, this is a bug!");
 			}
-			ctx->startbytes_pos += ctx->filebuffer_pos;
+			ctx->startbytes_pos = (unsigned int)((int64_t)ctx->startbytes_pos + newpos);
 			ctx->filebuffer_pos = 0;
+		}
+		else
+		{
+			ctx->filebuffer_pos = (unsigned int)newpos;
 		}
 	}
 	else


### PR DESCRIPTION
A WTV recording makes ccextractor read ~2.3 GB past a 1 MB buffer and segfault. The buffer bounds check that should have stopped it is defeated by unsigned arithmetic.

## Root cause

`buffered_seek()` handles a negative offset like this:

```c
ctx->filebuffer_pos += offset;
if (ctx->filebuffer_pos < 0)
{
	if ((ctx->filebuffer_pos + ctx->startbytes_pos) < 0)
		fatal(CCX_COMMON_EXIT_BUG_BUG, "PANIC: Attempt to seek before buffer start, this is a bug!");
	...
}
```

`filebuffer_pos` and `startbytes_pos` are both `unsigned int`, so the addition wraps instead of going negative and **neither guard can ever be true**. The "seek before buffer start" path is dead code.

A backward seek past the start of the buffer therefore leaves `filebuffer_pos` at roughly 2^32. `buffered_read()` then evaluates

```c
if (bytes <= ctx->bytesinbuffer - ctx->filebuffer_pos)
```

which underflows for the same reason, so the bounds check passes and `memcpy()` reads from far outside the buffer.

## Observed

On `5f6dfe831e35…wtv` the WTV parser reaches `buffered_seek(ctx, -1969339576)` while `filebuffer_pos` is 1048576. Values captured at the fault:

```
bytes                          = 32
ctx->bytesinbuffer             = 1048576        (1 MB)
ctx->filebuffer_pos            = 2326676296     (wrapped)
bytesinbuffer - filebuffer_pos = 1969339576     (underflow -> check passes)

memcpy(dst, ctx->filebuffer + 2326676296, 32)   -> SIGSEGV
```

## Fix

Do the seek arithmetic in `int64_t` so both existing guards work as written, and route the buffer-space checks through a small `buffered_bytes_left()` helper that returns 0 when the position is past the end.

Three call sites shared the hazard, so all three are converted:

- `buffered_read()` — the crash above
- `buffered_skip()` — same comparison
- `buffered_read_byte()` — `if (ctx->bytesinbuffer - ctx->filebuffer_pos)` would be truthy on underflow and index `filebuffer[]` out of bounds

Input files are untrusted, so this is a bounds-check fix rather than only a crash fix.

## Verification

- The sample no longer performs an out-of-bounds read. The previously unreachable guard now fires and the file is rejected cleanly (`PANIC: Attempt to seek before buffer start`) instead of faulting.
- **No captions are lost**: master (before crashing) and this branch both write the same 8662-byte output with 100 cues.
- ASan on the fixed build reports no SEGV and no invalid access on that file.
- **55 media files swept** (ts, mpg, wtv, mp4, mkv, mxf): output byte-identical to master in every case, with no exit-code changes.

## What the remaining PANIC means

With this fix the sample no longer reads out of bounds; the guard that was previously dead now fires:

```
Error: PANIC: Attempt to seek before buffer start, this is a bug!
```

That message is accurate and should stay: reaching it means an invariant really was broken, and the invariant was broken by our own code rather than by the input.

Tracing the caller shows why. `get_data()` reads a 32-bit element length straight from the file and does `len -= 32` with no check that `len >= 32`, then passes `len + pad` to `skip_sized_buffer(uint32_t size)`, which calls `buffered_seek(ctx, size)` — and that parameter is an `int`. The observed size was 2325627720, which is above `INT_MAX`, so the conversion produced -1969339576 (`2325627720 - 2^32`). A forward skip silently became a 1.8 GB backward seek.

For the avoidance of doubt, the input is not meaningfully damaged: `ffprobe` reports a well-formed WTV with four streams and a 358 s duration matching the file size, and `ffmpeg` decodes the whole file to completion with exit 0 (a couple of localized glitches typical of a broadcast capture, nothing structural). The file is 0.34 GiB, so a 1.8 GiB backward seek could never have been legitimate.

Fixing that properly means validating the parsed length and not narrowing a `uint32_t` into an `int` seek. That is a WTV-parser change and belongs in its own PR; this one stops the out-of-bounds read for every caller of the buffer layer.

## Related

Found while investigating a different segfault; that one is fixed separately in #2319. This branch does not fix it, and #2319 does not fix this one — they are independent bugs in different subsystems.

