### PR TITLE
[FIX] WTV: resynchronise instead of trusting an implausible element length

### DIFF
--- a/src/lib_ccx/wtv_functions.c
+++ b/src/lib_ccx/wtv_functions.c
@@ -132,6 +132,58 @@ void skip_sized_buffer(struct ccx_demuxer *ctx, struct wtv_chunked_buffer *cb, u
 	ctx->past = cb->filepos;
 }
 
+// Largest element we are willing to believe. Real WTV elements are a few KB; a
+// length beyond this means we are no longer looking at an element header.
+#define WTV_MAX_ELEMENT_LEN (16 * 1024 * 1024)
+// How far to hunt for the next element header before giving up.
+#define WTV_RESYNC_LIMIT (4 * 1024 * 1024)
+
+// The bulk of the GUIDs that start a timeline element share these 15 trailing
+// bytes and differ only in the first (data, sync, index, stream1, stream2...),
+// which makes them a dependable anchor when re-synchronising.
+static const uint8_t wtv_guid_tail[15] = {
+    0xC3, 0xD2, 0xC2, 0x7E, 0x9A, 0xDA, 0x11, 0x8B, 0xF7, 0x00, 0x07, 0xE9, 0x5E, 0xAD, 0x8D};
+
+static int wtv_len_plausible(uint32_t raw_len)
+{
+	return raw_len >= 32 && raw_len <= WTV_MAX_ELEMENT_LEN;
+}
+
+static int wtv_is_anchor(const uint8_t *hdr)
+{
+	uint32_t raw_len;
+	if (memcmp(hdr + 1, wtv_guid_tail, sizeof(wtv_guid_tail)) != 0)
+		return 0;
+	memcpy(&raw_len, hdr + 16, 4);
+	return wtv_len_plausible(raw_len);
+}
+
+// Walk forward until a plausible element header shows up, keeping a rolling
+// 32-byte window so the caller ends up positioned exactly as it would after a
+// normal header read. Returns 1 when re-synchronised.
+static int wtv_resync(struct ccx_demuxer *ctx, struct wtv_chunked_buffer *cb, uint8_t *hdr)
+{
+	uint64_t scanned = 0;
+
+	while (scanned < WTV_RESYNC_LIMIT)
+	{
+		memmove(hdr, hdr + 8, 24);
+		get_sized_buffer(ctx, cb, 8);
+		if (cb->buffer == NULL)
+			return 0;
+		memcpy(hdr + 24, cb->buffer, 8);
+		scanned += 8;
+		if (wtv_is_anchor(hdr))
+		{
+			mprint("\nWTV: lost element alignment, resynchronised after %llu bytes.\n",
+			       (unsigned long long)scanned);
+			return 1;
+		}
+	}
+	mprint("\nWTV: lost element alignment and could not resynchronise.\n");
+	return 0;
+}
+
 // get_sized_buffer will alloc and set a buffer in the passed wtv_chunked_buffer struct
 // it will handle any meta data chunks that need to be skipped in the file
 // Will print error messages and return a null buffer on error.
@@ -364,23 +416,36 @@ LLONG get_data(struct lib_ccx_ctx *ctx, struct wtv_chunked_buffer *cb, struct de
 		uint32_t stream_id;
 
 		// Read the 32 bytes containing the GUID and length and stream_id info
+		uint8_t hdr[32];
+		uint32_t raw_len;
+
 		get_sized_buffer(ctx->demux_ctx, cb, 32);
 		if (cb->buffer == NULL)
 			return CCX_EOF;
+		memcpy(hdr, cb->buffer, 32);
 
-		memcpy(&guid, cb->buffer, 16); // Read the GUID
+		// A length we cannot believe means we are no longer aligned to an element
+		// boundary -- reading on would hand a bogus size to the seek/skip helpers.
+		// Hunt for the next header instead of trusting it. The end-of-file marker is
+		// exempt: it legitimately carries a zero length and is handled further down.
+		memcpy(&raw_len, hdr + 16, 4);
+		if (memcmp(hdr, WTV_EOF, 16) != 0 && !wtv_len_plausible(raw_len) &&
+		    !wtv_resync(ctx->demux_ctx, cb, hdr))
+			return CCX_EOF;
+
+		memcpy(&guid, hdr, 16); // Read the GUID
 
 		for (x = 0; x < 16; x++)
 			dbg_print(CCX_DMT_PARSE, "%02X ", guid[x]);
 		dbg_print(CCX_DMT_PARSE, "\n");
 
-		memcpy(&len, cb->buffer + 16, 4); // Read the length
+		memcpy(&len, hdr + 16, 4); // Read the length
 		len -= 32;
 		dbg_print(CCX_DMT_PARSE, "len %X\n", len);
 		pad = len % 8 == 0 ? 0 : 8 - (len % 8); // Calculate the padding to add to the length
 		// to get to the next GUID
 		dbg_print(CCX_DMT_PARSE, "pad %X\n", pad);
-		memcpy(&stream_id, cb->buffer + 20, 4);
+		memcpy(&stream_id, hdr + 20, 4);
 		stream_id = stream_id & 0x7f; // Read and calculate the stream_id
 		dbg_print(CCX_DMT_PARSE, "stream_id: 0x%X\n", stream_id);
 


### PR DESCRIPTION
A WTV recording crashes ccextractor, and the same defect silently costs a third of its captions.

## What happens

`get_data()` reads a 32-byte element header and believes whatever 32-bit length it finds there. On `5f6dfe831e35…wtv` the parser walks **182,902 elements correctly**, then meets 8800 bytes it cannot interpret. The "length" it reads at that point is `0x8A9E4344` (2,325,627,716).

That value flows to `skip_sized_buffer(uint32_t size)`, which passes it to `buffered_seek(ctx, int offset)`. `2325627720 - 2^32 = -1969339576`, so a forward skip becomes a 1.8 GB backward seek, and the read that follows walks off the buffer.

## Why the parser gets there

Independently of ccextractor, the file's own structure shows the gap. Walking the element chain from the last good header:

```
236970600  WTV_DATA  rawlen 8224   -> next expected 236978824
236978824  <8800 bytes that are not an element header>
236987624  WTV_DATA  rawlen 8224   <- parsing is fine again from here
```

ffmpeg reads a packet at 236982768, inside that region, and decodes the whole file to completion, so the recording is sound — it is our element walk that cannot cross this.

## Fix

Reject a length that cannot describe an element (smaller than the 32-byte header, or implausibly large) and hunt forward for the next header rather than trusting it.

Most GUIDs that open a timeline element share the same 15 trailing bytes and differ only in the first (data, sync, index, stream1, stream2…), which makes them a dependable anchor. The scan keeps a rolling 32-byte window, so when it re-anchors the caller is positioned exactly as it would be after a normal header read, and the existing code path continues unchanged.

## Measured over all 45 local WTV samples

| | master | this branch |
|---|---|---|
| captions gained | — | **1 sample, +51 cues** (100 → 151) |
| captions lost | — | **none** |
| crashes | 1 | **0** |
| resyncs used | — | 1 in the whole corpus |

On the affected recording, coverage goes from **228 s to 356 s of a 358 s file**. The resync fires after exactly 8800 bytes, matching the gap measured independently from the file structure — the two numbers were derived separately and agree.

The single resync across 45 files is the point worth noting: this is not a parser that now guesses its way through recordings, it is a guard that fires once, where the old code crashed.

## Behaviour change worth flagging

Two samples (the same content, present twice locally) produced **no captions before and no captions after**, but now exit 10 ("no captions were found") instead of 0, because a failed resync ends the parse rather than running off the end. Exit 10 is the accurate code for a file with no captions, but it is a change, and one of those files is regression test rt7 — that test already fails today ("No output generated but there should be"), so it stays failing, just with a different reason.

## Related

Found while investigating a segfault. #2322 hardens the buffer layer so a bogus size can no longer read out of bounds; this PR stops the bogus size being produced in the first place. They are independent and either is useful alone.