### PR TITLE
[FIX] transcript: suppress spurious blank lines from write_cc_line_as_transcript2

### DIFF
--- a/src/lib_ccx/ccx_encoders_common.h
+++ b/src/lib_ccx/ccx_encoders_common.h
@@ -238,7 +238,7 @@ void write_cc_buffer_to_gui(struct eia608_screen *data, struct encoder_ctx *cont
 int write_cc_buffer_as_g608(struct eia608_screen *data, struct encoder_ctx *context);
 int write_cc_buffer_as_transcript2(struct eia608_screen *data, struct encoder_ctx *context);
 
-void write_cc_line_as_transcript2(struct eia608_screen *data, struct encoder_ctx *context, int line_number);
+int write_cc_line_as_transcript2(struct eia608_screen *data, struct encoder_ctx *context, int line_number);
 
 int write_cc_subtitle_as_srt(struct cc_subtitle *sub, struct encoder_ctx *context);
 int write_cc_subtitle_as_ssa(struct cc_subtitle *sub, struct encoder_ctx *context);

--- a/src/lib_ccx/ccx_encoders_transcript.c
+++ b/src/lib_ccx/ccx_encoders_transcript.c
@@ -236,7 +236,7 @@ int write_cc_subtitle_as_transcript(struct cc_subtitle *sub, struct encoder_ctx 
 }
 
 // TODO Convert CC line to TEXT format and remove this function
-void write_cc_line_as_transcript2(struct eia608_screen *data, struct encoder_ctx *context, int line_number)
+int write_cc_line_as_transcript2(struct eia608_screen *data, struct encoder_ctx *context, int line_number)
 {
 	int ret = 0;
 	int length = get_str_basic(context->subline, data->characters[line_number],
@@ -255,7 +255,7 @@ void write_cc_line_as_transcript2(struct eia608_screen *data, struct encoder_ctx
 			// is set for example by the write_char function, it possible that we don't have one in empty lines (unclear)
 			// For now, let's not consider this a bug as before and just return.
 			// fatal (EXIT_BUG_BUG, "Bug in timedtranscript (ts_start_of_current_line==-1). Please report.");
-			return;
+			return 0;
 		}
 
 		if (context->transcript_settings->showStartTime)
@@ -333,7 +333,9 @@ void write_cc_line_as_transcript2(struct eia608_screen *data, struct encoder_ctx
 		{
 			mprint("Warning:Loss of data\n");
 		}
+		return 1;
 	}
+	return 0;
 	// fprintf (wb->fh,encoded_crlf);
 }
 
@@ -356,8 +358,7 @@ int write_cc_buffer_as_transcript2(struct eia608_screen *data, struct encoder_ct
 				}
 			}
 
-			write_cc_line_as_transcript2(data, context, i);
-			wrote_something = 1;
+			wrote_something |= write_cc_line_as_transcript2(data, context, i);
 		}
 	}
 


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

Reason for this PR:

- [ ] This PR adds new functionality.
- [X] This PR fixes a bug that I have personally experienced or that a real user has reported and for which a sample exists.
- [ ] This PR is porting code from C to Rust.

Sanity check:
- [X] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [X] I have checked that another pull request for this purpose does not exist.
- [X] If the PR adds new functionality, I've added it to the changelog. If it's just a bug fix, I have NOT added it to the changelog.
- [X] I am NOT adding new C code unless it's to fix an existing, reproducible bug.

Repro instructions:

Run with `--autoprogram --out=ttxt --latin1` on any sample with a pop-on → roll-up mode transition. The output contains one or more spurious blank lines not present in the reference file. Confirmed on the sample platform via [RT41](https://sampleplatform.ccextractor.org/regression/test/41/view), RT84, RT11, RT29, RT30.

---
## Issue:
`write_cc_buffer_as_transcript2` emits spurious blank lines in `--out=ttxt output` on samples with pop-on → roll-up transitions.

## Root cause:
Introduced in PR #2105 - it refactored `write_cc_buffer_as_transcript2` to emit `encoded_end_frame` after each block, and changed the call to:
```
write_cc_line_as_transcript2(data, context, i);
wrote_something = 1;   // unconditional
```
Because `write_cc_line_as_transcript2` returned void, the caller couldn't know it wrote nothing (blank cursor row). `wrote_something` got set to 1 anyway, so a bare newline was emitted for every empty row.

## Fix:
Change `write_cc_line_as_transcript2` from void to int (returns 1 if content was written, 0 if not) and use `|=` in the caller:
`wrote_something |= write_cc_line_as_transcript2(data, context, i)`; `encoded_end_frame` is now only written when at least one line produced output.

## Testing: 
- [RT41](https://sampleplatform.ccextractor.org/regression/test/41/view) (`01509...ts`, `--out=ttxt --latin1`): two spurious blank lines removed. Output is byte-identical to accepted variant ref `9f139b8c...`