### PR TITLE
[FIX] file_functions: three integer conversions in the read path (truncated seek, unsigned underflow, signed/unsigned compare)

### DIFF
--- a/src/lib_ccx/file_functions.c
+++ b/src/lib_ccx/file_functions.c
@@ -11,7 +11,10 @@ int iResult = 0;
 
 LLONG get_file_size(int in)
 {
-	int ret = 0;
+	/* LSEEK returns a 64-bit offset. Storing it in an int truncated the result, so a
+	   successful seek back to a position at or beyond 2 GB could land on a negative
+	   value and be reported as a failure. */
+	LLONG ret = 0;
 	LLONG current = LSEEK(in, 0, SEEK_CUR);
 	LLONG length = LSEEK(in, 0, SEEK_END);
 	if (current < 0 || length < 0)
@@ -344,7 +347,7 @@ size_t buffered_read_opt(struct ccx_demuxer *ctx, unsigned char *buffer, size_t 
 				// for the data to come up
 				sleepandchecktimeout(seconds);
 			}
-			size_t ready = ctx->bytesinbuffer - ctx->filebuffer_pos;
+			size_t ready = buffered_bytes_left(ctx);
 			if (ready == 0) // We really need to read more
 			{
 				if (!ccx_options.buffer_input)
@@ -417,7 +420,16 @@ size_t buffered_read_opt(struct ccx_demuxer *ctx, unsigned char *buffer, size_t 
 				{
 					/* If live stream, don't try to switch - acknowledge eof here as it won't
 					   cause a loop end */
-					if (ccx_options.live_stream || ((struct lib_ccx_ctx *)ctx->parent)->inputsize <= origin_buffer_size || !(ccx_options.binary_concat && switch_to_next_file(ctx->parent, copied)))
+					/* inputsize is a signed 64-bit size while origin_buffer_size is unsigned,
+					   so the comparison used to convert inputsize to unsigned. A negative
+					   inputsize -- what get_filesize() reports when the size could not be
+					   determined -- turned into a huge value, and the test silently read as
+					   "the input is enormous". Say what is meant instead. An unknown size
+					   still does not count as fitting in one read, so behaviour is unchanged. */
+					LLONG parent_inputsize = ((struct lib_ccx_ctx *)ctx->parent)->inputsize;
+					int input_fits_in_one_read = parent_inputsize >= 0 &&
+								     (uint64_t)parent_inputsize <= (uint64_t)origin_buffer_size;
+					if (ccx_options.live_stream || input_fits_in_one_read || !(ccx_options.binary_concat && switch_to_next_file(ctx->parent, copied)))
 						eof = 1;
 				}
 				ctx->filebuffer_pos = keep;


### PR DESCRIPTION
Follow-up to #2322. While reading the MSVC narrowing warnings on that PR I checked each one in `file_functions.c`; most are benign, three are not. All three are the same family as #2322 — an integer conversion that quietly turns a check into something other than what it reads as.

## 1. `get_file_size()` truncates a 64-bit offset

```c
int ret = 0;                                 // LSEEK returns LLONG
...
ret = LSEEK(in, current, SEEK_SET);
if (ret < 0) return -1;
```

A successful seek back to a position at or beyond 2 GB truncates to a negative `int`, so the function reports failure for a seek that worked, and the caller sees the file size as `-1`.

`ccx_demuxer_get_file_size()` (`ccx_demuxer.c:236`) is the same routine written correctly with `LLONG ret` — this copy had drifted.

**Latent, not observable today:** the only caller, `get_total_file_size()`, opens each file fresh, so `current` is always 0. Fixed because the next caller has no way to know that.

## 2. Same unsigned underflow #2322 fixed, one layer down

```c
size_t ready = ctx->bytesinbuffer - ctx->filebuffer_pos;
```

Both operands are `unsigned int`. This is exactly the subtraction that made the `file_buffer.h` bounds checks pass when they should have failed. #2322 added `buffered_bytes_left()` for it; this site was missed.

## 3. End-of-input test compares signed against unsigned

```c
((struct lib_ccx_ctx *)ctx->parent)->inputsize <= origin_buffer_size
```

`inputsize` is `LLONG`, `origin_buffer_size` is `size_t`, so the usual arithmetic conversions make the comparison unsigned. `get_filesize()` returns **−1 when the size cannot be determined** (`ccx_demuxer.c:246`), and that −1 becomes `SIZE_MAX` — the test silently reads as "the input is enormous".

Now spelled out:

```c
LLONG parent_inputsize = ((struct lib_ccx_ctx *)ctx->parent)->inputsize;
int input_fits_in_one_read = parent_inputsize >= 0 &&
			     (uint64_t)parent_inputsize <= (uint64_t)origin_buffer_size;
```

**Behaviour is unchanged.** For `inputsize >= 0` the unsigned comparison is identical to before. For `inputsize < 0` both the old and new forms yield false, so an unknown size still does not count as fitting in one read. The hoisted expression is a pure field read and comparison, so the short-circuit order is preserved and `switch_to_next_file()` — the one clause with side effects — is still called exactly when it was.

## Testing

This file sits on every input path, so the changes were A/B'd against a binary built from current master (`128175ea`):

| path | result |
|---|---|
| 99 output files across the sample library, `--out=srt --latin1` | byte-identical, exit codes match |
| `--bufferinput` (10 samples) | byte-identical |
| multi-file input (binary concat / `switch_to_next_file`) | byte-identical |
| stdin (`-stdin`, where `inputsize` can be negative) | byte-identical |

Builds clean with no compiler messages; `clang-format` reports no changes.

## Noted, not changed

`buffered_read_opt()` has a vacuous guard at what is now line 374:

```c
if (op + bytes < 0)   // Would mean moving beyond start of file: Not supported
	return 0;
```

`op` is `LLONG` and `bytes` is `size_t`, so the sum is unsigned and can never be negative — and every caller passes a non-negative `bytes` anyway, so it could not fire even with correct types. It is dead rather than wrong, and removing it is a separate judgement call about whether the intended check should exist at all. Flagging it here rather than widening this PR.