### PR TITLE
[FIX] file_functions: check the seek that can fail instead of one that cannot

### DIFF
--- a/src/lib_ccx/file_functions.c
+++ b/src/lib_ccx/file_functions.c
@@ -371,9 +371,18 @@ size_t buffered_read_opt(struct ccx_demuxer *ctx, unsigned char *buffer, size_t 
 						{
 							LLONG op, np;
 							op = LSEEK(ctx->infd, 0, SEEK_CUR); // Get current pos
-							if (op + bytes < 0)		    // Would mean moving beyond start of file: Not supported
-								return 0;
+							/* The guard here used to be "op + bytes < 0", meant to catch a
+							   seek before the start of the file. It could not fire: bytes is
+							   unsigned, so the sum was computed unsigned and never went
+							   negative, and every caller passes a forward distance anyway.
+							   What can actually fail is LSEEK itself, and the arithmetic
+							   below then subtracted one error value from another and
+							   reported the result as a byte count. */
+							if (op < 0)
+								return copied;
 							np = LSEEK(ctx->infd, bytes, SEEK_CUR); // Pos after moving
+							if (np < 0)
+								return copied;
 							i = (int)(np - op);
 						}
 						// if both above lseek returned -1 (error); i would be 0 here and


### PR DESCRIPTION
Follow-up to #2325, which flagged this line and deliberately left it alone.

## The guard could not fire

```c
LLONG op, np;
op = LSEEK(ctx->infd, 0, SEEK_CUR);   // Get current pos
if (op + bytes < 0)                   // Would mean moving beyond start of file: Not supported
	return 0;
np = LSEEK(ctx->infd, bytes, SEEK_CUR);
i = (int)(np - op);
```

`bytes` is a `size_t`, so `op + bytes` is evaluated unsigned and never goes negative — the same family as the underflow #2322 fixed. And it could not matter anyway: every caller reaches here with a forward distance, so a seek from a valid position cannot land before the start of the file.

## What can actually fail

`LSEEK` returns −1 on error. Neither result was checked, so `np - op` was computed from two error values and reported as a byte count.

Today that lands on `(-1) - (-1) == 0`, the `do/while` condition then ends the loop, and the function returns `copied` — so the observable behaviour is correct **by arithmetic accident**. Nothing tells the next reader that, and the guard sitting above it implies the failure is already handled.

```c
if (op < 0)
	return copied;
np = LSEEK(ctx->infd, bytes, SEEK_CUR);
if (np < 0)
	return copied;
i = (int)(np - op);
```

`copied` rather than `0`: it is what the normal path returns a few lines down, and bytes already handed to the caller should not be forgotten because a later seek failed.

## Testing

A/B against a binary built from current master (`3af3fc22`):

| | result |
|---|---|
| 59 samples, `--autoprogram --out=srt --latin1` (99 output files) | byte-identical, exit codes match |
| 36 invocations targeting this branch — `--startat/--endat`, `--no-bufferinput`, `--dru` | 30 identical, 6 produced no output on either side, **0 differences** |

Builds with no compiler messages; `clang-format` clean.

Worth stating how that second row was nearly misread: comparing the two runs with `cmp` alone reported "6 differences", because `cmp` fails the same way whether the contents differ or the file is absent — and with those options neither side writes one. The counts above separate *identical*, *both produced nothing*, *one-sided*, and *content differs*, because only the last is evidence of anything.