### PR TITLE
[FIX] NUL-terminate mode/info strings in add_cc_sub_text

### DIFF
--- a/src/lib_ccx/ccx_common_common.c
+++ b/src/lib_ccx/ccx_common_common.c
@@ -69,9 +69,15 @@ int add_cc_sub_text(struct cc_subtitle *sub, char *str, LLONG start_time,
 	sub->start_time = start_time;
 	sub->end_time = end_time;
 	if (info)
-		strncpy(sub->info, info, 4);
+	{
+		strncpy(sub->info, info, sizeof(sub->info) - 1);
+		sub->info[sizeof(sub->info) - 1] = '\0';
+	}
 	if (mode)
-		strncpy(sub->mode, mode, 4);
+	{
+		strncpy(sub->mode, mode, sizeof(sub->mode) - 1);
+		sub->mode[sizeof(sub->mode) - 1] = '\0';
+	}
 	sub->got_output = 1;
 	sub->next = NULL;
 

--- a/src/rust/lib_ccxr/src/encoder/txt_helpers.rs
+++ b/src/rust/lib_ccxr/src/encoder/txt_helpers.rs
@@ -42,21 +42,19 @@ fn change_utf8_encoding(dest: &mut [u8], src: &[u8], len: i32, out_enc: Encoding
 
     while src_idx < max {
         let c = src[src_idx];
-        let c_len: usize;
-
-        if c < 0x80 {
-            c_len = 1;
+        let c_len: usize = if c < 0x80 {
+            1
         } else if (c & 0x20) == 0 {
-            c_len = 2;
+            2
         } else if (c & 0x10) == 0 {
-            c_len = 3;
+            3
         } else if (c & 0x08) == 0 {
-            c_len = 4;
+            4
         } else if (c & 0x04) == 0 {
-            c_len = 5;
+            5
         } else {
-            c_len = 1;
-        }
+            1
+        };
 
         match out_enc {
             Encoding::UTF8 => {

--- a/src/rust/lib_ccxr/src/encoder/txt_helpers.rs
+++ b/src/rust/lib_ccxr/src/encoder/txt_helpers.rs
@@ -42,19 +42,21 @@ fn change_utf8_encoding(dest: &mut [u8], src: &[u8], len: i32, out_enc: Encoding
 
     while src_idx < max {
         let c = src[src_idx];
-        let c_len: usize = if c < 0x80 {
-            1
+        let c_len: usize;
+
+        if c < 0x80 {
+            c_len = 1;
         } else if (c & 0x20) == 0 {
-            2
+            c_len = 2;
         } else if (c & 0x10) == 0 {
-            3
+            c_len = 3;
         } else if (c & 0x08) == 0 {
-            4
+            c_len = 4;
         } else if (c & 0x04) == 0 {
-            5
+            c_len = 5;
         } else {
-            1
-        };
+            c_len = 1;
+        }
 
         match out_enc {
             Encoding::UTF8 => {


### PR DESCRIPTION
Fixes #2330

**In raising this pull request, I confirm the following (please check boxes):**

Reason for this PR:

- [x] This PR adds new functionality.
- [x] This PR fixes a bug that I have personally experienced or that a real user has reported and for which a sample exists. (Reported in #2330; this is a source-level C string bug, not a video-sample extraction failure.)
- [ ] This PR is porting code from C to Rust.

Sanity check:

- [x] I have read and understood the [contributors guide](https://github.com/CCExtractor/ccextractor/blob/master/.github/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] If the PR adds new functionality, I've added it to the changelog. If it's just a bug fix, I have NOT added it to the changelog.
- [x] I am NOT adding new C code unless it's to fix an existing, reproducible bug.

Repro instructions:

This is a C string bug in `add_cc_sub_text()`, not a single-file caption extraction failure. No video sample is attached because the defect is in how `mode` / `info` are copied.

1. `struct cc_subtitle` has `char mode[5]` and `char info[4]`.
2. Callers pass 4-character modes: `"ISDB"` (`ccx_decoders_isdb.c`) and `"BURN"` (`hardsubx_decoder.c`).
3. Old code used `strncpy(..., 4)`. When the source is exactly 4 characters, `strncpy` does not write `'\0'`.
4. Transcript output then uses `strcmp(sub->mode, "TLT")` and `"%s"` on `sub->mode` (`ccx_encoders_transcript.c`), which requires a terminator.
5. `"TLT"` (3 characters) was already terminated by `strncpy`. The first subtitle can also look fine if the struct was `calloc`'d (the extra byte is already 0). Later nodes use `malloc` and can leave `mode[4]` as garbage.

How to confirm from source: search for `add_cc_sub_text(..., "ISDB"` / `"BURN"` and the old `strncpy(..., 4)` on master vs this branch.

---

## Summary

`add_cc_sub_text()` now copies `info` and `mode` with `sizeof(field) - 1` and always writes a terminating `'\0'`.

That keeps 4-character labels such as `ISDB` and `BURN` valid C strings, so later `strcmp` / `"%s"` in transcript output cannot read past the array.

No changelog update: this is a bug fix only. No new feature code.
