### PR TITLE
Fix clippy needless_late_init in txt_helpers

### DIFF
--- a/src/rust/lib_ccxr/src/encoder/txt_helpers.rs
+++ b/src/rust/lib_ccxr/src/encoder/txt_helpers.rs
@@ -42,21 +42,21 @@ fn change_utf8_encoding(dest: &mut [u8], src: &[u8], len: i32, out_enc: Encoding
 
     while src_idx < max {
         let c = src[src_idx];
-        let c_len: usize;
-
-        if c < 0x80 {
-            c_len = 1;
+        // Leading-byte width. A byte that matches none of the UTF-8 lead
+        // patterns is consumed one at a time so the loop always advances.
+        let c_len: usize = if c < 0x80 {
+            1
         } else if (c & 0x20) == 0 {
-            c_len = 2;
+            2
         } else if (c & 0x10) == 0 {
-            c_len = 3;
+            3
         } else if (c & 0x08) == 0 {
-            c_len = 4;
+            4
         } else if (c & 0x04) == 0 {
-            c_len = 5;
+            5
         } else {
-            c_len = 1;
-        }
+            1
+        };
 
         match out_enc {
             Encoding::UTF8 => {


### PR DESCRIPTION
## Why

`cargo clippy -- -D warnings` fails on master:

```
error: unneeded late initialization
  --> src/encoder/txt_helpers.rs:45:9
error: could not compile `lib_ccxr` (lib) due to 1 previous error
```

So `format_rust (./src/rust/lib_ccxr)` is red on every open PR regardless of what it changes — #2327, #2329 and #2331 all fail on this line and not on their own code.

The side effect is worse than the red tick: authors have been fixing it *inside* unrelated PRs to get CI green. #2331 carried this exact fix alongside a C string change until it was asked to drop it, at which point its CI went red for a reason that had nothing to do with the PR. That is the wrong shape — a lint fix on shared code should land once, on its own.

## What

Assign `c_len` from an `if`-expression rather than declaring it and assigning in every branch. Semantically identical; clippy stops objecting.

The added comment records why the final `else` yields 1: a byte matching no UTF-8 lead pattern is consumed singly so the loop always advances. That is the one branch whose value is not obvious from the pattern above it.

## Testing

- `cargo clippy -- -D warnings` clean on **both** crates (`lib_ccxr` and `src/rust`); master fails the first
- `cargo fmt --check` clean
- 45 `lib_ccxr` tests pass
- Builds with no compiler messages
- A/B against a master build (`982586e8`): 59 samples × `--out=ttxt` and `--out=srt`, **112 outputs byte-identical, 0 differences, 0 exit-code changes** (6 produced no output on either side)

Once this lands, #2327/#2329/#2331-style PRs go green on their own merits, and the next PR touching Rust does not have to carry someone else's lint fix.